### PR TITLE
Dashboard: add headless option to profile Launch modal

### DIFF
--- a/internal/dashboard/dashboard/dashboard.html
+++ b/internal/dashboard/dashboard/dashboard.html
@@ -76,6 +76,10 @@
     <input id="launch-profile-path" type="hidden" />
     <label style="color:#888;font-size:12px;display:block;margin-bottom:4px">Port</label>
     <input id="launch-port" placeholder="e.g. 9868" />
+    <label style="color:#ccc;font-size:12px;display:flex;align-items:center;gap:8px;margin:10px 0 12px">
+      <input id="launch-headless" type="checkbox" />
+      Launch headless (recommended for Docker/VPS)
+    </label>
     <label style="color:#888;font-size:12px;display:block;margin-bottom:4px">Direct launch command (backup)</label>
     <textarea id="launch-command" class="launch-command" readonly></textarea>
     <div class="btn-row" style="justify-content:flex-start;margin-top:-2px;margin-bottom:8px">


### PR DESCRIPTION
## Summary
- add a headless checkbox to the profile Launch modal
- use the selected value for both the generated backup command and `/instances/launch` API call
- persist the last headless preference in localStorage

## Why
In Docker/VPS setups (no X server / no DISPLAY), the Launch button currently always sends `headless=false`, so instance startup fails immediately. This change keeps the existing desktop workflow available while making headless launches possible from the dashboard UI.

## Repro
1. Run `pinchtab dashboard` in Docker or a headless VPS
2. Create a profile in the dashboard
3. Click `Launch` (current UI hardcodes `headless=false`)
4. Instance exits before ready with an X server / `$DISPLAY` error
