### PR TITLE
fix: only save tabs accessed during the session

### DIFF
--- a/internal/bridge/bridge.go
+++ b/internal/bridge/bridge.go
@@ -12,8 +12,9 @@ import (
 )
 
 type TabEntry struct {
-	Ctx    context.Context
-	Cancel context.CancelFunc
+	Ctx      context.Context
+	Cancel   context.CancelFunc
+	Accessed bool
 }
 
 type RefCache struct {

--- a/internal/bridge/state.go
+++ b/internal/bridge/state.go
@@ -82,6 +82,7 @@ func (b *Bridge) SaveState() {
 		return
 	}
 
+	accessed := b.AccessedTabIDs()
 	tabs := make([]TabState, 0, len(targets))
 	seen := make(map[string]bool, len(targets))
 	for _, t := range targets {
@@ -89,6 +90,9 @@ func (b *Bridge) SaveState() {
 			continue
 		}
 		if seen[t.URL] {
+			continue
+		}
+		if !accessed[string(t.TargetID)] {
 			continue
 		}
 		seen[t.URL] = true


### PR DESCRIPTION
Follow-up to #10. Tabs that were restored but never used during a session are no longer re-saved.

**How it works:**
- `TabManager` tracks an `accessed` map, marked when `TabContext()` resolves a tab or `CreateTab()` creates one
- `SaveState` checks `AccessedTabIDs()` and skips tabs that were never touched
- Combined with dedup + transient filtering, sessions.json only contains tabs you actually used

**Effect:** Stale tabs from old sessions naturally expire after one restart cycle if not revisited.