### PR TITLE
chore(ci): accept feat/ as branch prefix

### DIFF
--- a/.github/workflows/branch-naming.yml
+++ b/.github/workflows/branch-naming.yml
@@ -26,7 +26,7 @@ jobs:
             echo "❌ Branch name '$BRANCH' doesn't match convention."
             echo ""
             echo "Expected format: <prefix>/<description>"
-            echo "  Prefixes: feature, fix, hotfix, docs, chore, refactor, test"
+            echo "  Prefixes: feature, feat, fix, hotfix, docs, chore, refactor, test"
             echo "  Description: lowercase, hyphens, no special chars"
             echo ""
             echo "Examples:"


### PR DESCRIPTION
Adds `feat` alongside `feature` in branch naming CI check. Both are conventional commit style.