### PR TITLE
fix(ci): add feat/ to branch naming regex pattern

### DIFF
--- a/.github/workflows/branch-naming.yml
+++ b/.github/workflows/branch-naming.yml
@@ -21,7 +21,7 @@ jobs:
           fi
 
           # Enforce prefix/description pattern
-          PATTERN="^(feature|fix|hotfix|docs|chore|refactor|test)/[a-z0-9][a-z0-9-]*$"
+          PATTERN="^(feature|feat|fix|hotfix|docs|chore|refactor|test)/[a-z0-9][a-z0-9-]*$"
           if [[ ! "$BRANCH" =~ $PATTERN ]]; then
             echo "❌ Branch name '$BRANCH' doesn't match convention."
             echo ""


### PR DESCRIPTION
PR #20 updated the help text but missed the actual PATTERN regex. This fixes it.