### PR TITLE
feat: add Docker images to goreleaser + GHCR publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      packages: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -24,6 +25,14 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: '1.26'
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: goreleaser/goreleaser-action@v6
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,6 +29,38 @@ changelog:
       - '^ci:'
       - '^chore:'
 
+dockers:
+  - image_templates:
+      - "ghcr.io/pinchtab/pinchtab:{{ .Version }}-amd64"
+    use: buildx
+    dockerfile: Dockerfile.goreleaser
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.source=https://github.com/pinchtab/pinchtab"
+    goos: linux
+    goarch: amd64
+  - image_templates:
+      - "ghcr.io/pinchtab/pinchtab:{{ .Version }}-arm64"
+    use: buildx
+    dockerfile: Dockerfile.goreleaser
+    build_flag_templates:
+      - "--platform=linux/arm64"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.source=https://github.com/pinchtab/pinchtab"
+    goos: linux
+    goarch: arm64
+
+docker_manifests:
+  - name_template: "ghcr.io/pinchtab/pinchtab:{{ .Version }}"
+    image_templates:
+      - "ghcr.io/pinchtab/pinchtab:{{ .Version }}-amd64"
+      - "ghcr.io/pinchtab/pinchtab:{{ .Version }}-arm64"
+  - name_template: "ghcr.io/pinchtab/pinchtab:latest"
+    image_templates:
+      - "ghcr.io/pinchtab/pinchtab:{{ .Version }}-amd64"
+      - "ghcr.io/pinchtab/pinchtab:{{ .Version }}-arm64"
+
 release:
   github:
     owner: pinchtab

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,0 +1,35 @@
+FROM alpine:latest
+
+LABEL org.opencontainers.image.source="https://github.com/pinchtab/pinchtab"
+LABEL org.opencontainers.image.description="Browser control for AI agents"
+
+RUN apk add --no-cache \
+    chromium \
+    nss \
+    freetype \
+    harfbuzz \
+    ca-certificates \
+    ttf-freefont \
+    dumb-init
+
+RUN adduser -D -g '' pinchtab && \
+    mkdir -p /data && \
+    chown pinchtab:pinchtab /data
+
+COPY pinchtab /usr/local/bin/pinchtab
+
+USER pinchtab
+WORKDIR /data
+
+ENV BRIDGE_BIND=0.0.0.0 \
+    BRIDGE_PORT=9867 \
+    BRIDGE_HEADLESS=true \
+    BRIDGE_STATE_DIR=/data \
+    BRIDGE_PROFILE=/data/chrome-profile \
+    CHROME_BINARY=/usr/bin/chromium-browser \
+    CHROME_FLAGS="--no-sandbox --disable-gpu"
+
+EXPOSE 9867
+
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+CMD ["pinchtab"]


### PR DESCRIPTION
Next release will ship Docker images alongside binaries.

## What's new

- **`.goreleaser.yml`**: multi-arch Docker builds (amd64 + arm64) → `ghcr.io/pinchtab/pinchtab`
- **`Dockerfile.goreleaser`**: slim runtime image (copies pre-built binary, no build stage)
- **Docker manifests**: `:version` + `:latest` tags
- **Release workflow**: GHCR login + `packages:write` permission

## Release output

| Asset | Registry |
|---|---|
| 6 binaries + checksums | GitHub Releases |
| `pinchtab/pinchtab:version` | DockerHub (existing) |
| `ghcr.io/pinchtab/pinchtab:version` | GHCR (new) |
| `ghcr.io/pinchtab/pinchtab:latest` | GHCR (new) |