### PR TITLE
feat: add install.sh for one-liner setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,58 @@ curl -X POST localhost:9867/action -d '{"kind":"click","ref":"e5"}'
 - **Stealth mode** — bypasses bot detection on major sites
 - **Persistent sessions** — log in once, stays logged in across restarts
 
+## Installation
+
+### One-liner (macOS/Linux)
+
+```bash
+curl -fsSL https://pinchtab.com/install.sh | bash
+```
+
+Then:
+```bash
+pinchtab                              # Start the server
+# In another terminal:
+pinchtab nav https://httpbin.org      # Navigate
+pinchtab snap                         # Get snapshot
+```
+
+**Requirements:**
+- Node.js 18+ (for npm install)
+- macOS or Linux
+
+**Troubleshooting:**
+
+**Command not found / PATH issue:**
+```bash
+# npm -g may be in an unusual location
+npm config get prefix  # Find where global packages go
+export PATH="$(npm config get prefix)/bin:$PATH"
+```
+
+**Permission denied (EACCES):**
+```bash
+# Option 1: Use nvm (recommended, fresh Node install)
+curl https://github.com/nvm-sh/nvm/raw/master/install.sh | bash
+nvm install node
+npm install -g pinchtab
+
+# Option 2: User prefix (no sudo)
+npm install -g --prefix ~/.local pinchtab
+export PATH="$HOME/.local/bin:$PATH"  # Add to ~/.bashrc or ~/.zshrc
+
+# Option 3: Change npm prefix globally
+mkdir ~/.npm-global && npm config set prefix '~/.npm-global'
+export PATH=~/.npm-global/bin:$PATH  # Add to ~/.bashrc or ~/.zshrc
+```
+
+### npm (manual)
+
+```bash
+npm install -g pinchtab
+pinchtab --version
+```
+
 ## Quick Start
 
 ### Docker (easiest)


### PR DESCRIPTION
Simple installer script for easy Pinchtab setup:

```bash
curl -fsSL https://pinchtab.com/install.sh | bash
```

**Features:**
- Detects OS (macOS/Linux)  
- Checks Node.js 18+ availability
- Installs via npm globally
- Verifies installation + shows version
- Displays next steps and links
- Clean, colorized output
- Minimal dependencies (bash + node/npm)

**Pattern:**
Follows OpenClaw installer approach for consistency and familiarity. When deployed to pinchtab.com, this enables frictionless onboarding.

**Next step:**
Once merged, add to website:
```
/static/install.sh → https://pinchtab.com/install.sh
```