### PR TITLE
security: suppress CodeQL SSRF false positive in health.go

### DIFF
--- a/internal/orchestrator/health.go
+++ b/internal/orchestrator/health.go
@@ -36,6 +36,10 @@ func (o *Orchestrator) monitor(inst *InstanceInternal) {
 		time.Sleep(instanceHealthPollInterval)
 
 		for _, baseURL := range instanceBaseURLs(inst.Port) {
+			// Suppress CodeQL alert: baseURL comes from trusted orchestrator configuration
+			// (port-based child instance list), not user input. This is intentional design:
+			// agents request the orchestrator to probe known child instances.
+			// lgtm[go/request-forgery]
 			req, reqErr := http.NewRequest(http.MethodGet, baseURL+"/health", nil)
 			if reqErr != nil {
 				lastProbe = fmt.Sprintf("%s -> %s", baseURL, reqErr.Error())


### PR DESCRIPTION
The CodeQL alert is a false positive.

The baseURL comes from trusted orchestrator configuration (port-based child instance list), not user input. This is intentional Pinchtab design: agents request the orchestrator to probe known child instances.

The URL is not user-controlled in the SSRF sense — it's from configuration.

Add lgtm suppression comment to resolve the alert.