### PR TITLE
fix: allow dependabot branches in naming convention

### DIFF
--- a/.github/workflows/branch-naming.yml
+++ b/.github/workflows/branch-naming.yml
@@ -23,6 +23,12 @@ jobs:
             exit 0
           fi
 
+          # Allow dependabot branches
+          if [[ "$BRANCH" =~ ^dependabot/ ]]; then
+            echo "✅ Dependabot branch: $BRANCH"
+            exit 0
+          fi
+
           # Enforce prefix/description pattern
           PATTERN="^(feature|feat|fix|hotfix|docs|chore|refactor|test)/[a-z0-9][a-z0-9-]*$"
           if [[ ! "$BRANCH" =~ $PATTERN ]]; then


### PR DESCRIPTION
## Summary

This PR updates the branch naming workflow to allow dependabot branches, preventing CI failures on automated dependency update PRs.

## Problem

Dependabot PRs (like #53) fail the branch naming check because branches like `dependabot/npm_and_yarn/npm/multi-8314c7e849` don't match the required pattern.

## Solution

Added an exception for branches starting with `dependabot/` in the branch naming workflow.

## Changes

- Updated `.github/workflows/branch-naming.yml` to allow dependabot branches
- Maintains existing naming convention for human-created branches

## Testing

- ✅ Dependabot branches will now pass the check
- ✅ Existing branch naming rules remain unchanged for other branches

This fix ensures automated dependency updates can proceed without manual intervention.