### PR TITLE
fix: upload body limit and WaitForTitle/NavigatePage context handling

### DIFF
--- a/internal/bridge/cdp_test.go
+++ b/internal/bridge/cdp_test.go
@@ -1,0 +1,39 @@
+package bridge
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/chromedp/chromedp"
+)
+
+func TestWaitForTitle_ContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	_, err := WaitForTitle(ctx, 5*time.Second)
+	if err == nil {
+		t.Error("expected error for cancelled context")
+	}
+}
+
+func TestWaitForTitle_NoTimeout(t *testing.T) {
+	ctx, _ := chromedp.NewContext(context.Background())
+
+	// With timeout <= 0, should return immediately
+	title, _ := WaitForTitle(ctx, 0)
+	if title != "" {
+		t.Errorf("expected empty title without browser, got %q", title)
+	}
+}
+
+func TestNavigatePage_ContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := NavigatePage(ctx, "https://example.com")
+	if err == nil {
+		t.Error("expected error for cancelled context")
+	}
+}

--- a/internal/handlers/handler_upload_test.go
+++ b/internal/handlers/handler_upload_test.go
@@ -66,3 +66,16 @@ func TestHandleTabUpload_NoTab(t *testing.T) {
 		t.Errorf("expected 404, got %d", w.Code)
 	}
 }
+
+func TestHandleUpload_BodyTooLarge(t *testing.T) {
+	h := New(&mockBridge{}, &config.RuntimeConfig{}, nil, nil, nil)
+	// Create a body larger than 10MB
+	bigBody := make([]byte, 11<<20) // 11MB
+	req := httptest.NewRequest("POST", "/upload", bytes.NewReader(bigBody))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.HandleUpload(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for oversized body, got %d", w.Code)
+	}
+}

--- a/internal/handlers/navigation.go
+++ b/internal/handlers/navigation.go
@@ -161,7 +161,7 @@ func (h *Handlers) HandleNavigate(w http.ResponseWriter, r *http.Request) {
 
 		var url string
 		_ = chromedp.Run(tCtx, chromedp.Location(&url))
-		title := bridge.WaitForTitle(tCtx, titleWait)
+		title, _ := bridge.WaitForTitle(tCtx, titleWait)
 
 		web.JSON(w, 200, map[string]any{"tabId": hashTabID, "url": url, "title": title})
 		return
@@ -198,7 +198,7 @@ func (h *Handlers) HandleNavigate(w http.ResponseWriter, r *http.Request) {
 
 	var url string
 	_ = chromedp.Run(tCtx, chromedp.Location(&url))
-	title := bridge.WaitForTitle(tCtx, titleWait)
+	title, _ := bridge.WaitForTitle(tCtx, titleWait)
 
 	web.JSON(w, 200, map[string]any{"tabId": resolvedTabID, "url": url, "title": title})
 }

--- a/internal/handlers/upload.go
+++ b/internal/handlers/upload.go
@@ -37,6 +37,8 @@ type uploadRequest struct {
 func (h *Handlers) HandleUpload(w http.ResponseWriter, r *http.Request) {
 	tabID := r.URL.Query().Get("tabId")
 
+	r.Body = http.MaxBytesReader(w, r.Body, 10<<20) // 10MB limit
+
 	var req uploadRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		web.Error(w, 400, fmt.Errorf("invalid JSON body: %w", err))


### PR DESCRIPTION
## Summary
- Add `http.MaxBytesReader` (10MB) to upload handler — it was the only POST handler without a body size limit, allowing unbounded memory allocation
- Change `WaitForTitle` return type from `string` to `(string, error)` and use `select` on `ctx.Done()` instead of a `time.Sleep` loop that swallowed all errors and ignored context cancellation
- Remove hardcoded 30s `time.After` from `NavigatePage` so the caller's context controls the timeout entirely

## Test plan
- [ ] `TestHandleUpload_BodyTooLarge` — verifies 400 for 11MB body
- [ ] `TestWaitForTitle_ContextCancelled` — verifies error on cancelled context
- [ ] `TestWaitForTitle_NoTimeout` — verifies immediate return with timeout <= 0
- [ ] `TestNavigatePage_ContextCancelled` — verifies error on cancelled context
- [ ] Updated `navigation.go` call sites to `title, _ := bridge.WaitForTitle(...)` (preserves existing behavior)
- [ ] All existing tests pass: `go test ./internal/bridge/... ./internal/handlers/... -count=1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)