### PR TITLE
fix: ClickElement bounds check and SelectByNodeID value setting (rebased)

### DIFF
--- a/internal/bridge/cdp.go
+++ b/internal/bridge/cdp.go
@@ -2,6 +2,7 @@ package bridge
 
 import (
 	"context"
+	"encoding/json"
 	"time"
 
 	"github.com/chromedp/cdproto/network"
@@ -112,7 +113,26 @@ func SelectByNodeID(ctx context.Context, nodeID int64, value string) error {
 			return chromedp.FromContext(ctx).Target.Execute(ctx, "DOM.focus", map[string]any{"backendNodeId": nodeID}, nil)
 		}),
 		chromedp.ActionFunc(func(ctx context.Context) error {
-			return nil
+			var result json.RawMessage
+			if err := chromedp.FromContext(ctx).Target.Execute(ctx, "DOM.resolveNode", map[string]any{
+				"backendNodeId": nodeID,
+			}, &result); err != nil {
+				return err
+			}
+			var resolved struct {
+				Object struct {
+					ObjectID string `json:"objectId"`
+				} `json:"object"`
+			}
+			if err := json.Unmarshal(result, &resolved); err != nil {
+				return err
+			}
+			js := `function(v) { this.value = v; this.dispatchEvent(new Event('input', {bubbles: true})); this.dispatchEvent(new Event('change', {bubbles: true})); }`
+			return chromedp.FromContext(ctx).Target.Execute(ctx, "Runtime.callFunctionOn", map[string]any{
+				"functionDeclaration": js,
+				"objectId":            resolved.Object.ObjectID,
+				"arguments":           []map[string]any{{"value": value}},
+			}, nil)
 		}),
 	)
 }

--- a/internal/bridge/cdp_test.go
+++ b/internal/bridge/cdp_test.go
@@ -37,3 +37,13 @@ func TestNavigatePage_ContextCancelled(t *testing.T) {
 		t.Error("expected error for cancelled context")
 	}
 }
+
+func TestSelectByNodeID_UsesValue(t *testing.T) {
+	ctx, _ := chromedp.NewContext(context.Background())
+	// Without a real browser this will error, but it must NOT silently succeed
+	// (the old implementation was a no-op that always returned nil).
+	err := SelectByNodeID(ctx, 1, "option-value")
+	if err == nil {
+		t.Error("expected error without browser connection, got nil (possible no-op)")
+	}
+}

--- a/internal/human/human.go
+++ b/internal/human/human.go
@@ -143,7 +143,7 @@ func ClickElement(ctx context.Context, nodeID cdp.NodeID) error {
 		return err
 	}
 
-	if len(box.Content) < 4 {
+	if len(box.Content) < 8 {
 		return fmt.Errorf("invalid box model")
 	}
 

--- a/internal/human/human_test.go
+++ b/internal/human/human_test.go
@@ -77,3 +77,15 @@ func TestTypeWithConfig(t *testing.T) {
 		t.Errorf("expected at least 10 actions, got %d", len(actions1))
 	}
 }
+
+func TestClickElement_RequiresMinContentLength(t *testing.T) {
+	// ClickElement accesses box.Content[0], [1], [2], and [5]
+	// CDP BoxModel Content has 8 float64 values (4 x/y pairs)
+	// The guard must check len(box.Content) < 8
+	// Without a browser, GetBoxModel will fail
+	ctx, _ := chromedp.NewContext(context.Background())
+	err := ClickElement(ctx, 0)
+	if err == nil {
+		t.Error("expected error without browser connection")
+	}
+}


### PR DESCRIPTION
**Rebased version of PR #67**

Resolved merge conflicts with latest main:
- internal/bridge/cdp.go (imports)
- internal/bridge/cdp_test.go (test functions)

All tests passing ✅

## Changes
- ClickElement bounds check: `< 4` → `< 8`
- SelectByNodeID: no-op → actual DOM implementation

Ready to merge!