### PR TITLE
fix: correct Getting Started docs link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Read more in the [Core Concepts](https://pinchtab.com/docs/core-concepts) guide.
 
 Full docs at **[pinchtab.com/docs](https://pinchtab.com/docs)**
 
-- **[Getting Started](https://pinchtab.com/docs/getting-started)** — Install and run
+- **[Getting Started](https://pinchtab.com/docs/get-started)** — Install and run
 - **[Core Concepts](https://pinchtab.com/docs/core-concepts)** — Instances, profiles, tabs
 - **[Headless vs Headed](https://pinchtab.com/docs/headless-vs-headed)** — Choose the right mode
 - **[API Reference](https://pinchtab.com/docs/api-reference)** — HTTP endpoints

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -1,3 +1,4 @@
+// Package handlers provides HTTP request handlers for the bridge server.
 package handlers
 
 import (


### PR DESCRIPTION
Fixed the link in README.md to point to the correct documentation file.

**Changes:**
- README.md: `/docs/getting-started` → `/docs/get-started`
- Added minor package documentation comment to handlers.go

The `getting-started` filename was incorrect; the actual file is `get-started.md`.