### PR TITLE
fix: Ensure Build & Vet check completes for docs-only PRs

### DIFF
--- a/.github/workflows/go-verify.yml
+++ b/.github/workflows/go-verify.yml
@@ -48,26 +48,30 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     steps:
-      - name: Skip if no Go changes
-        if: needs.changes.outputs.go != 'true'
+      - name: Check for Go changes
+        id: check
         run: |
-          echo "⏭️ No Go files changed, skipping build"
-          echo "This is expected for docs/workflow-only changes"
+          if [ "${{ needs.changes.outputs.go }}" = "true" ]; then
+            echo "Go files detected"
+            echo "has_go_changes=true" >> $GITHUB_OUTPUT
+          else
+            echo "⏭️ No Go files changed - docs/workflow-only changes detected"
+            echo "has_go_changes=false" >> $GITHUB_OUTPUT
+          fi
 
       - uses: actions/checkout@v4
-        if: needs.changes.outputs.go == 'true'
 
       - uses: actions/setup-go@v5
-        if: needs.changes.outputs.go == 'true'
+        if: steps.check.outputs.has_go_changes == 'true'
         with:
           go-version: '1.26'
 
       - name: Download deps
-        if: needs.changes.outputs.go == 'true'
+        if: steps.check.outputs.has_go_changes == 'true'
         run: go mod download
 
       - name: Format check
-        if: needs.changes.outputs.go == 'true'
+        if: steps.check.outputs.has_go_changes == 'true'
         run: |
           unformatted=$(gofmt -l .)
           if [ -n "$unformatted" ]; then
@@ -77,19 +81,19 @@ jobs:
           fi
 
       - name: Vet
-        if: needs.changes.outputs.go == 'true'
+        if: steps.check.outputs.has_go_changes == 'true'
         run: go vet ./...
 
       - name: Build
-        if: needs.changes.outputs.go == 'true'
+        if: steps.check.outputs.has_go_changes == 'true'
         run: go build -o pinchtab ./cmd/pinchtab
 
       - name: Test with coverage
-        if: needs.changes.outputs.go == 'true'
+        if: steps.check.outputs.has_go_changes == 'true'
         run: go test ./... -v -count=1 -coverprofile=coverage.out -covermode=atomic
 
       - name: Coverage summary
-        if: needs.changes.outputs.go == 'true'
+        if: steps.check.outputs.has_go_changes == 'true'
         run: |
           coverage=$(go tool cover -func=coverage.out | tail -1)
           echo "### Coverage" >> $GITHUB_STEP_SUMMARY
@@ -102,20 +106,25 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     steps:
-      - name: Skip if no Go changes
-        if: needs.changes.outputs.go != 'true'
-        run: echo "⏭️ No Go files changed, skipping lint"
+      - name: Check for Go changes
+        id: check
+        run: |
+          if [ "${{ needs.changes.outputs.go }}" = "true" ]; then
+            echo "has_go_changes=true" >> $GITHUB_OUTPUT
+          else
+            echo "⏭️ No Go files changed, skipping lint"
+            echo "has_go_changes=false" >> $GITHUB_OUTPUT
+          fi
 
       - uses: actions/checkout@v4
-        if: needs.changes.outputs.go == 'true'
 
       - uses: actions/setup-go@v5
-        if: needs.changes.outputs.go == 'true'
+        if: steps.check.outputs.has_go_changes == 'true'
         with:
           go-version: '1.26'
 
       - name: golangci-lint
-        if: needs.changes.outputs.go == 'true'
+        if: steps.check.outputs.has_go_changes == 'true'
         uses: golangci/golangci-lint-action@v7
         with:
           version: v2.9.0
@@ -125,28 +134,33 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     steps:
-      - name: Skip if no Go changes
-        if: needs.changes.outputs.go != 'true'
-        run: echo "⏭️ No Go files changed, skipping security scan"
+      - name: Check for Go changes
+        id: check
+        run: |
+          if [ "${{ needs.changes.outputs.go }}" = "true" ]; then
+            echo "has_go_changes=true" >> $GITHUB_OUTPUT
+          else
+            echo "⏭️ No Go files changed, skipping security scan"
+            echo "has_go_changes=false" >> $GITHUB_OUTPUT
+          fi
 
       - uses: actions/checkout@v4
-        if: needs.changes.outputs.go == 'true'
 
       - uses: actions/setup-go@v5
-        if: needs.changes.outputs.go == 'true'
+        if: steps.check.outputs.has_go_changes == 'true'
         with:
           go-version: '1.26'
 
       - name: Install gosec
-        if: needs.changes.outputs.go == 'true'
+        if: steps.check.outputs.has_go_changes == 'true'
         run: go install github.com/securego/gosec/v2/cmd/gosec@latest
 
       - name: Run gosec
-        if: needs.changes.outputs.go == 'true'
+        if: steps.check.outputs.has_go_changes == 'true'
         run: gosec -exclude=G301,G302,G304,G306,G404,G107,G115,G703,G704,G705,G706 -fmt=json -out=gosec-results.json ./... || true
 
       - name: Check critical findings
-        if: needs.changes.outputs.go == 'true'
+        if: steps.check.outputs.has_go_changes == 'true'
         run: |
           # Fail on G112 (Slowloris), G204 (command injection)
           ISSUES=$(cat gosec-results.json | jq '[.Issues[] | select(.rule_id == "G112" or .rule_id == "G204")] | length')


### PR DESCRIPTION
Fixes the issue where 'Build & Vet' job is skipped for docs-only changes, blocking PR merges.

The job now always completes in GitHub's status check rollup, even when no Go files are changed.