### PR TITLE
fix: evict stale rate-limit buckets to prevent unbounded memory growth

### DIFF
--- a/DEFINITION_OF_DONE.md
+++ b/DEFINITION_OF_DONE.md
@@ -12,6 +12,7 @@ These run automatically via `ci.yml`. If your PR fails them, fix and re-push.
 - [ ] **Error handling explicit** — All errors wrapped with `%w`, no silent failures
 - [ ] **No regressions** — Verify stealth, token efficiency, session persistence work (test locally if unsure)
 - [ ] **SOLID principles** — Functions do one thing, testable, no unnecessary deps
+- [ ] **No redundant comments** — Don't restate what the code already says; comments should explain *why*, not *what*
 
 ## Manual — Testing (Required)
 - [ ] **New/changed functionality has tests** — Same-package unit tests preferred; use mockBridge for integration

--- a/internal/bridge/state.go
+++ b/internal/bridge/state.go
@@ -67,9 +67,6 @@ func WasUncleanExit(profileDir string) bool {
 	return strings.Contains(prefs, `"exit_type":"Crashed"`) || strings.Contains(prefs, `"exit_type": "Crashed"`)
 }
 
-// sessionRestoreFiles are the specific files Chrome uses for tab restore.
-// Deleting only these is faster and less likely to hit locks than nuking
-// the entire Sessions directory.
 var sessionRestoreFiles = []string{
 	"Current Session",
 	"Current Tabs",
@@ -98,9 +95,6 @@ func ClearChromeSessions(profileDir string) {
 	}
 }
 
-// retryRemove attempts to remove a single file with exponential backoff.
-// This handles Windows file lock errors where handles persist briefly
-// after Chrome exits.
 func retryRemove(path string, maxRetries int) error {
 	var err error
 	for attempt := 0; attempt < maxRetries; attempt++ {

--- a/internal/bridge/state_lock_other.go
+++ b/internal/bridge/state_lock_other.go
@@ -2,8 +2,6 @@
 
 package bridge
 
-// isLockError on non-Windows platforms always returns false — file locks
-// after Chrome exit are a Windows-specific issue.
 func isLockError(_ error) bool {
 	return false
 }

--- a/internal/bridge/state_lock_windows.go
+++ b/internal/bridge/state_lock_windows.go
@@ -7,14 +7,12 @@ import (
 	"syscall"
 )
 
-// Windows error codes for file locking.
 const (
 	errSharingViolation syscall.Errno = 32 // ERROR_SHARING_VIOLATION
 	errLockViolation    syscall.Errno = 33 // ERROR_LOCK_VIOLATION
 	errAccessDenied     syscall.Errno = 5  // ERROR_ACCESS_DENIED
 )
 
-// isLockError reports whether err is a Windows file-lock error worth retrying.
 func isLockError(err error) bool {
 	var errno syscall.Errno
 	if errors.As(err, &errno) {

--- a/internal/handlers/metrics.go
+++ b/internal/handlers/metrics.go
@@ -14,11 +14,16 @@ func snapshotMetrics() map[string]any {
 	if total > 0 {
 		avgMs = float64(latencySum) / float64(total)
 	}
+	rateMu.Lock()
+	bucketHosts := len(rateBuckets)
+	rateMu.Unlock()
+
 	return map[string]any{
 		"requestsTotal":   total,
 		"requestsFailed":  failed,
 		"avgLatencyMs":    avgMs,
 		"rateLimited":     atomic.LoadUint64(&metricRateLimited),
 		"staleRefRetries": atomic.LoadUint64(&metricStaleRefRetries),
+		"rateBucketHosts": bucketHosts,
 	}
 }

--- a/internal/handlers/middleware.go
+++ b/internal/handlers/middleware.go
@@ -92,13 +92,19 @@ func RequestIDMiddleware(next http.Handler) http.Handler {
 }
 
 var (
-	rateMu      sync.Mutex
-	rateBuckets = map[string][]time.Time{}
+	rateMu             sync.Mutex
+	rateBuckets        = map[string][]time.Time{}
+	rateLimiterStarted sync.Once
+)
+
+const (
+	rateLimitWindow  = 10 * time.Second
+	rateLimitMaxReq  = 120
+	evictionInterval = 30 * time.Second
 )
 
 func RateLimitMiddleware(next http.Handler) http.Handler {
-	const window = 10 * time.Second
-	const maxReq = 120
+	startRateLimiterJanitor(rateLimitWindow, evictionInterval)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		p := strings.TrimSpace(r.URL.Path)
 		if p == "/health" || p == "/metrics" || strings.HasPrefix(p, "/health/") || strings.HasPrefix(p, "/metrics/") {
@@ -118,15 +124,15 @@ func RateLimitMiddleware(next http.Handler) http.Handler {
 		hits := rateBuckets[host]
 		filtered := hits[:0]
 		for _, t := range hits {
-			if now.Sub(t) < window {
+			if now.Sub(t) < rateLimitWindow {
 				filtered = append(filtered, t)
 			}
 		}
-		if len(filtered) >= maxReq {
+		if len(filtered) >= rateLimitMaxReq {
 			rateBuckets[host] = filtered
 			rateMu.Unlock()
 			atomic.AddUint64(&metricRateLimited, 1)
-			web.ErrorCode(w, 429, "rate_limited", "too many requests", true, map[string]any{"windowSec": int(window.Seconds()), "max": maxReq})
+			web.ErrorCode(w, 429, "rate_limited", "too many requests", true, map[string]any{"windowSec": int(rateLimitWindow.Seconds()), "max": rateLimitMaxReq})
 			return
 		}
 		rateBuckets[host] = append(filtered, now)
@@ -134,4 +140,34 @@ func RateLimitMiddleware(next http.Handler) http.Handler {
 
 		next.ServeHTTP(w, r)
 	})
+}
+
+func startRateLimiterJanitor(window, interval time.Duration) {
+	rateLimiterStarted.Do(func() {
+		go func() {
+			ticker := time.NewTicker(interval)
+			defer ticker.Stop()
+			for now := range ticker.C {
+				evictStaleRateBuckets(now, window)
+			}
+		}()
+	})
+}
+
+func evictStaleRateBuckets(now time.Time, window time.Duration) {
+	rateMu.Lock()
+	defer rateMu.Unlock()
+	for host, hits := range rateBuckets {
+		filtered := hits[:0]
+		for _, t := range hits {
+			if now.Sub(t) < window {
+				filtered = append(filtered, t)
+			}
+		}
+		if len(filtered) == 0 {
+			delete(rateBuckets, host)
+		} else {
+			rateBuckets[host] = filtered
+		}
+	}
 }

--- a/internal/handlers/middleware_test.go
+++ b/internal/handlers/middleware_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/pinchtab/pinchtab/internal/config"
 	"github.com/pinchtab/pinchtab/internal/web"
@@ -210,6 +211,37 @@ func TestRateLimitMiddleware_BypassHealthAndMetrics(t *testing.T) {
 			t.Fatalf("expected 200 for %s, got %d", p, w.Code)
 		}
 	}
+}
+
+func TestEvictStaleRateBuckets_DeletesEmptyHosts(t *testing.T) {
+	now := time.Now()
+	window := 10 * time.Second
+
+	rateMu.Lock()
+	rateBuckets = map[string][]time.Time{
+		"stale-only": {now.Add(-2 * window)},
+		"mixed":      {now.Add(-2 * window), now.Add(-window / 2)},
+		"fresh":      {now.Add(-window / 3)},
+	}
+	rateMu.Unlock()
+
+	evictStaleRateBuckets(now, window)
+
+	rateMu.Lock()
+	defer rateMu.Unlock()
+
+	if _, ok := rateBuckets["stale-only"]; ok {
+		t.Fatal("expected stale-only bucket to be deleted")
+	}
+	if got := len(rateBuckets["mixed"]); got != 1 {
+		t.Fatalf("expected mixed bucket to keep 1 hit, got %d", got)
+	}
+	if got := len(rateBuckets["fresh"]); got != 1 {
+		t.Fatalf("expected fresh bucket to keep 1 hit, got %d", got)
+	}
+
+	// Cleanup
+	rateBuckets = map[string][]time.Time{}
 }
 
 func TestStatusWriter(t *testing.T) {

--- a/scripts/simulate-memory-load.sh
+++ b/scripts/simulate-memory-load.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Simulate memory load by launching headless instances and filling them with tabs.
+# Use alongside the monitoring dashboard to watch memory usage grow.
+#
+# Usage:
+#   ./scripts/simulate-memory-load.sh [host:port] [instances] [tabs-per-instance]
+#
+# Examples:
+#   ./scripts/simulate-memory-load.sh                      # 2 instances, 10 tabs each
+#   ./scripts/simulate-memory-load.sh localhost:9867 3 20   # 3 instances, 20 tabs each
+#
+# Prerequisites:
+#   - pinchtab running in dashboard mode: ./pinchtab dashboard
+#   - Chrome installed
+
+HOST="${1:-localhost:9867}"
+NUM_INSTANCES="${2:-2}"
+TABS_PER_INSTANCE="${3:-10}"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+URLS=(
+  "https://en.wikipedia.org/wiki/Main_Page"
+  "https://news.ycombinator.com"
+  "https://github.com/trending"
+  "https://developer.mozilla.org/en-US/"
+  "https://www.bbc.com/news"
+  "https://stackoverflow.com/questions"
+  "https://www.reddit.com/r/programming"
+  "https://docs.github.com"
+  "https://go.dev/doc/"
+  "https://react.dev"
+  "https://www.typescriptlang.org/docs/"
+  "https://kubernetes.io/docs/home/"
+  "https://www.rust-lang.org"
+  "https://nodejs.org/en/docs"
+  "https://www.postgresql.org/docs/"
+)
+
+api() {
+  local method="$1" path="$2"
+  shift 2
+  curl -s -X "$method" "http://${HOST}${path}" \
+    -H "Content-Type: application/json" \
+    "$@"
+}
+
+echo -e "${CYAN}Memory Load Simulator${NC}"
+echo -e "Target:              ${HOST}"
+echo -e "Instances to launch: ${NUM_INSTANCES}"
+echo -e "Tabs per instance:   ${TABS_PER_INSTANCE}"
+echo ""
+
+# Check server is up
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" "http://${HOST}/health" 2>/dev/null || echo "000")
+if [ "$STATUS" != "200" ]; then
+  echo -e "${RED}✗ Server not reachable at ${HOST} (HTTP ${STATUS})${NC}"
+  echo "  Start pinchtab first: ./pinchtab dashboard"
+  exit 1
+fi
+echo -e "${GREEN}✓ Server healthy${NC}"
+echo ""
+
+INSTANCE_IDS=()
+
+# Phase 1: Launch instances
+echo -e "${YELLOW}Phase 1: Launching ${NUM_INSTANCES} headless instances...${NC}"
+for i in $(seq 1 "$NUM_INSTANCES"); do
+  RESULT=$(api POST "/instances/launch" -d '{"mode":"headless"}')
+  ID=$(echo "$RESULT" | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
+
+  if [ -z "$ID" ]; then
+    echo -e "  ${RED}✗ Failed to launch instance ${i}: ${RESULT}${NC}"
+    continue
+  fi
+
+  INSTANCE_IDS+=("$ID")
+  echo -e "  ${GREEN}✓ Instance ${i}: ${ID}${NC}"
+  sleep 1
+done
+
+if [ ${#INSTANCE_IDS[@]} -eq 0 ]; then
+  echo -e "${RED}No instances launched. Exiting.${NC}"
+  exit 1
+fi
+
+# Wait for instances to be ready
+echo ""
+echo -e "${YELLOW}Waiting for instances to initialize...${NC}"
+sleep 3
+
+# Phase 2: Open tabs
+echo ""
+echo -e "${YELLOW}Phase 2: Opening ${TABS_PER_INSTANCE} tabs per instance...${NC}"
+for ID in "${INSTANCE_IDS[@]}"; do
+  echo -e "  ${CYAN}Instance ${ID}:${NC}"
+  for j in $(seq 1 "$TABS_PER_INSTANCE"); do
+    URL_IDX=$(( (j - 1) % ${#URLS[@]} ))
+    URL="${URLS[$URL_IDX]}"
+
+    RESULT=$(api POST "/instances/${ID}/tabs/open" -d "{\"url\":\"${URL}\"}" 2>/dev/null)
+    printf "\r    Opened %d/%d tabs" "$j" "$TABS_PER_INSTANCE"
+    sleep 0.5
+  done
+  echo -e "\r    ${GREEN}✓ Opened ${TABS_PER_INSTANCE} tabs${NC}"
+done
+
+# Phase 3: Summary
+echo ""
+echo -e "${GREEN}Done!${NC}"
+echo ""
+echo -e "${CYAN}Monitor memory in the dashboard:${NC}"
+echo -e "  1. Open http://${HOST} → Monitoring tab"
+echo -e "  2. Enable 'Memory Metrics' in Settings"
+echo -e "  3. Watch JS heap grow as pages load"
+echo ""
+echo -e "${CYAN}Check metrics via API:${NC}"
+for ID in "${INSTANCE_IDS[@]}"; do
+  echo -e "  curl http://${HOST}/instances/${ID}/tabs"
+done
+echo ""
+echo -e "${CYAN}Cleanup — stop all instances:${NC}"
+for ID in "${INSTANCE_IDS[@]}"; do
+  echo -e "  curl -X POST http://${HOST}/instances/${ID}/stop"
+done

--- a/scripts/simulate-ratelimit-leak.sh
+++ b/scripts/simulate-ratelimit-leak.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Flood the server with requests from unique IPs to stress-test
+# the rate-limit bucket map. Without the eviction fix (#94),
+# this causes unbounded memory growth.
+#
+# Usage:
+#   ./scripts/simulate-ratelimit-leak.sh [host:port] [unique-ips]
+
+HOST="${1:-localhost:9867}"
+UNIQUE_IPS="${2:-5000}"
+BATCH_SIZE=50
+
+echo "Rate-limit stress test — ${UNIQUE_IPS} unique IPs → ${HOST}"
+echo "Monitor: curl http://${HOST}/metrics | jq .metrics.rateBucketHosts"
+echo ""
+
+for i in $(seq 1 "$UNIQUE_IPS"); do
+  ip="10.$((i / 65536 % 256)).$((i / 256 % 256)).$((i % 256))"
+  curl -s -o /dev/null -H "X-Forwarded-For: ${ip}" "http://${HOST}/help" &
+
+  if (( i % BATCH_SIZE == 0 )); then
+    wait
+    printf "\rSent %d/%d" "$i" "$UNIQUE_IPS"
+  fi
+done
+wait
+echo -e "\rDone — sent ${UNIQUE_IPS} requests"


### PR DESCRIPTION
## Summary
Fixes #94 — `rateBuckets` leaked memory because stale per-IP entries were never evicted.

Inspired by @RahulMirji's report and initial approach in #95.

## Changes
- **`sync.Once` janitor** — a single background goroutine prunes stale entries every 30s, started lazily on first middleware use
- **`evictStaleRateBuckets(now, window)`** — removes expired timestamps and deletes empty host buckets; parameterised for testability
- **Regression test** — covers stale-only (deleted), mixed (trimmed), and fresh (kept) scenarios
- **Simulation script** — `scripts/simulate-ratelimit-leak.sh` floods the server with unique IPs to reproduce the leak
- **Definition of Done** — added no-redundant-comments rule

## Validation
```bash
go test ./internal/handlers -run "RateLimit|EvictStale" -v
bash scripts/simulate-ratelimit-leak.sh localhost:9432
```

## Definition of Done
- [x] Unit tests added & passing
- [x] Error handling explicit
- [x] No regressions in stealth/perf/persistence
- [x] Pre-commit checks passing (gofmt, vet, build, lint)