### PR TITLE
fix(bridge): add direct-launch fallback for Chrome 145 DevTools port regression

### DIFF
--- a/internal/bridge/init.go
+++ b/internal/bridge/init.go
@@ -324,7 +324,8 @@ func startChromeWithRemoteAllocator(parentCtx context.Context, cfg *config.Runti
 	args := buildChromeArgs(cfg, debugPort)
 	slog.Debug("launching chrome directly", "binary", chromeBinary, "port", debugPort, "args", args)
 
-	cmd := exec.Command(chromeBinary, args...) //nolint:gosec // binary path comes from user config or known system locations
+	// #nosec G204 -- chromeBinary from CHROME_BIN env var, user config, or findChromeBinary() known system paths
+	cmd := exec.Command(chromeBinary, args...)
 	if err := cmd.Start(); err != nil {
 		return nil, nil, fmt.Errorf("failed to start chrome directly: %w", err)
 	}


### PR DESCRIPTION
## Summary

Fixes #106 — Chrome 145 stopped printing `DevTools listening on ws://...` to stderr, causing `chromedp.ExecAllocator` to hang indefinitely on startup.

**Root cause**: Chrome 145 silently removed the stderr announcement of its debugging port. `chromedp.ExecAllocator` relies on parsing this message; without it the allocator blocks forever.

**Fix approach** — two-layer, backwards compatible:

1. **Fixed debug port** — `setupAllocator` now overrides `--remote-debugging-port=0` (from `DefaultExecAllocatorOptions`) with a free port from the configured `InstancePortStart`/`InstancePortEnd` range. Knowing the port in advance is what makes the fallback possible without restarting Chrome.

2. **Direct-launch fallback** — `startChrome` wraps the initial connection check in a 20-second startup timeout. If the timeout fires (Chrome started but never announced its DevTools URL via stderr), the ExecAllocator is cleaned up and `startChromeWithRemoteAllocator` takes over:
   - Launches Chrome directly via `os/exec` with the pre-allocated fixed port
   - Polls `http://127.0.0.1:PORT/json/version` (250 ms intervals, 30 s limit)
   - Connects via `chromedp.NewRemoteAllocator`
   - Manages the child process lifecycle — the returned cancel func kills Chrome on shutdown

**Backwards compatible**: ExecAllocator is still tried first. The fallback only activates on timeout, so Chrome versions prior to 145 are completely unaffected.

## New functions

| Function | Purpose |
|---|---|
| `findFreePort(start, end int)` | Allocates a free TCP port from the configured range |
| `waitForChromeDevTools(port, timeout)` | Polls `/json/version` until Chrome's DevTools endpoint is ready |
| `buildChromeArgs(cfg, port)` | Builds Chrome CLI flags for the direct-launch path |
| `startChromeWithRemoteAllocator(...)` | Full direct-launch + RemoteAllocator connection path |
| `isStartupTimeout(err)` | Classifies an error as a Chrome startup timeout |

## Verification

Tested on Windows 11 with Chrome 145 (the affected version):
- Without fix: `pinchtab` hangs on startup, never reaches `chrome initialized successfully`
- With fix: falls back after 20 s, connects via RemoteAllocator, reaches `chrome initialized via direct-launch fallback`

`go vet ./...` — clean  
`gofmt` — clean  
All existing unit tests pass (`go test ./internal/... ./cmd/...`)

> **Note**: `internal/web/TestSafePath/traversal_absolute` fails in the base branch and is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)