### PR TITLE
Add CHROME_EXTENSION_PATHS support for loading Chrome extensions

### DIFF
--- a/cmd/pinchtab/cmd_dashboard.go
+++ b/cmd/pinchtab/cmd_dashboard.go
@@ -150,7 +150,7 @@ func runDashboard(cfg *config.RuntimeConfig) {
 			}
 
 			headlessDefault := os.Getenv("PINCHTAB_HEADED") == ""
-			inst, err := orch.Launch(profileToLaunch, defaultPort, headlessDefault)
+			inst, err := orch.Launch(profileToLaunch, defaultPort, headlessDefault, nil)
 			if err != nil {
 				slog.Warn("auto-launch failed", "profile", profileToLaunch, "err", err)
 				return

--- a/internal/api/types/types.go
+++ b/internal/api/types/types.go
@@ -132,8 +132,9 @@ type InstanceMetrics struct {
 
 // LaunchInstanceRequest is the request body for launching an instance.
 type LaunchInstanceRequest struct {
-	ProfileID string `json:"profileId,omitempty"` // profile ID (prof_XXXXXXXX)
-	Name      string `json:"name,omitempty"`      // profile name
-	Mode      string `json:"mode,omitempty"`      // "headed" or empty for headless
-	Port      string `json:"port,omitempty"`      // port number as string
+	ProfileID      string   `json:"profileId,omitempty"`      // profile ID (prof_XXXXXXXX)
+	Name           string   `json:"name,omitempty"`           // profile name
+	Mode           string   `json:"mode,omitempty"`           // "headed" or empty for headless
+	Port           string   `json:"port,omitempty"`           // port number as string
+	ExtensionPaths []string `json:"extensionPaths,omitempty"` // Chrome extension paths to load
 }

--- a/internal/bridge/api.go
+++ b/internal/bridge/api.go
@@ -62,7 +62,7 @@ type ProfileService interface {
 // OrchestratorService abstracts instance orchestration operations.
 type OrchestratorService interface {
 	RegisterHandlers(mux *http.ServeMux)
-	Launch(name, port string, headless bool) (*Instance, error)
+	Launch(name, port string, headless bool, extensionPaths []string) (*Instance, error)
 	Stop(id string) error
 	StopProfile(name string) error
 	List() []Instance

--- a/internal/bridge/init.go
+++ b/internal/bridge/init.go
@@ -145,9 +145,20 @@ func setupAllocator(cfg *config.RuntimeConfig) (context.Context, context.CancelF
 		chromedp.Flag("no-default-browser-check", ""),
 	)
 
+	// Extension loading
+	if len(cfg.ExtensionPaths) > 0 {
+		joined := strings.Join(cfg.ExtensionPaths, ",")
+		opts = append(opts, chromedp.Flag("disable-extensions", false))
+		opts = append(opts, chromedp.Flag("enable-automation", false))
+		opts = append(opts, chromedp.Flag("load-extension", joined))
+		opts = append(opts, chromedp.Flag("disable-extensions-except", joined))
+	}
+
 	// Extra flags
 	if cfg.ChromeExtraFlags != "" {
-		opts = append(opts, chromedp.Flag("", cfg.ChromeExtraFlags))
+		for _, f := range strings.Fields(cfg.ChromeExtraFlags) {
+			opts = append(opts, chromedp.Flag(strings.TrimLeft(f, "-"), ""))
+		}
 	}
 
 	// Timezone
@@ -432,7 +443,6 @@ func buildChromeArgs(cfg *config.RuntimeConfig, port int) []string {
 		"--disable-client-side-phishing-detection",
 		"--disable-default-apps",
 		"--disable-dev-shm-usage",
-		"--disable-extensions",
 		"--disable-hang-monitor",
 		"--disable-ipc-flooding-protection",
 		"--disable-popup-blocking",
@@ -449,6 +459,16 @@ func buildChromeArgs(cfg *config.RuntimeConfig, port int) []string {
 		// Stealth
 		"--disable-automation",
 		"--disable-blink-features=AutomationControlled",
+	}
+
+	if len(cfg.ExtensionPaths) > 0 {
+		joined := strings.Join(cfg.ExtensionPaths, ",")
+		args = append(args,
+			"--load-extension="+joined,
+			"--disable-extensions-except="+joined,
+		)
+	} else {
+		args = append(args, "--disable-extensions")
 	}
 
 	if cfg.Headless {
@@ -470,7 +490,7 @@ func buildChromeArgs(cfg *config.RuntimeConfig, port int) []string {
 	}
 
 	if cfg.ChromeExtraFlags != "" {
-		args = append(args, cfg.ChromeExtraFlags)
+		args = append(args, strings.Fields(cfg.ChromeExtraFlags)...)
 	}
 
 	return args

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,6 +29,7 @@ type RuntimeConfig struct {
 	MaxTabs           int
 	ChromeBinary      string
 	ChromeExtraFlags  string
+	ExtensionPaths    []string
 	UserAgent         string
 	NoAnimations      bool
 	StealthLevel      string
@@ -55,6 +56,25 @@ func envIntOr(key string, fallback int) int {
 		return fallback
 	}
 	return n
+}
+
+// splitCommaPaths splits a comma-separated string into non-empty trimmed paths.
+func splitCommaPaths(s string) []string {
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 func envBoolOr(key string, fallback bool) bool {
@@ -160,6 +180,7 @@ func Load() *RuntimeConfig {
 		MaxTabs:           envIntOr("BRIDGE_MAX_TABS", 20),
 		ChromeBinary:      envOr("CHROME_BIN", os.Getenv("CHROME_BINARY")),
 		ChromeExtraFlags:  os.Getenv("CHROME_FLAGS"),
+		ExtensionPaths:    splitCommaPaths(os.Getenv("CHROME_EXTENSION_PATHS")),
 		UserAgent:         os.Getenv("BRIDGE_USER_AGENT"),
 		NoAnimations:      os.Getenv("BRIDGE_NO_ANIMATIONS") == "true",
 		StealthLevel:      envOr("BRIDGE_STEALTH", "light"),
@@ -293,6 +314,7 @@ func HandleConfigCommand(cfg *RuntimeConfig) {
 		fmt.Printf("  Headless:   %v\n", cfg.Headless)
 		fmt.Printf("  Max Tabs:   %d\n", cfg.MaxTabs)
 		fmt.Printf("  No Restore: %v\n", cfg.NoRestore)
+		fmt.Printf("  Extensions: %v\n", cfg.ExtensionPaths)
 		fmt.Printf("  Timeouts:   action=%v navigate=%v\n", cfg.ActionTimeout, cfg.NavigateTimeout)
 
 	default:

--- a/internal/orchestrator/handlers_instances.go
+++ b/internal/orchestrator/handlers_instances.go
@@ -38,10 +38,11 @@ func (o *Orchestrator) handleGetInstance(w http.ResponseWriter, r *http.Request)
 
 func (o *Orchestrator) handleLaunchByName(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		ProfileId string `json:"profileId,omitempty"`
-		Name      string `json:"name,omitempty"`
-		Mode      string `json:"mode"`
-		Port      string `json:"port,omitempty"`
+		ProfileId      string   `json:"profileId,omitempty"`
+		Name           string   `json:"name,omitempty"`
+		Mode           string   `json:"mode"`
+		Port           string   `json:"port,omitempty"`
+		ExtensionPaths []string `json:"extensionPaths,omitempty"`
 	}
 
 	if r.ContentLength > 0 {
@@ -78,7 +79,7 @@ func (o *Orchestrator) handleLaunchByName(w http.ResponseWriter, r *http.Request
 		name = fmt.Sprintf("instance-%d", time.Now().UnixNano())
 	}
 
-	inst, err := o.Launch(name, req.Port, headless)
+	inst, err := o.Launch(name, req.Port, headless, req.ExtensionPaths)
 	if err != nil {
 		statusCode := classifyLaunchError(err)
 		web.Error(w, statusCode, err)
@@ -122,7 +123,7 @@ func (o *Orchestrator) handleStartByInstanceID(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	started, err := o.Launch(profileName, port, headless)
+	started, err := o.Launch(profileName, port, headless, nil)
 	if err != nil {
 		statusCode := classifyLaunchError(err)
 		web.Error(w, statusCode, err)
@@ -144,9 +145,10 @@ func (o *Orchestrator) handleLogsByID(w http.ResponseWriter, r *http.Request) {
 
 func (o *Orchestrator) handleStartInstance(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		ProfileID string `json:"profileId,omitempty"`
-		Mode      string `json:"mode,omitempty"`
-		Port      string `json:"port,omitempty"`
+		ProfileID      string   `json:"profileId,omitempty"`
+		Mode           string   `json:"mode,omitempty"`
+		Port           string   `json:"port,omitempty"`
+		ExtensionPaths []string `json:"extensionPaths,omitempty"`
 	}
 
 	if r.ContentLength > 0 {
@@ -171,7 +173,7 @@ func (o *Orchestrator) handleStartInstance(w http.ResponseWriter, r *http.Reques
 
 	headless := req.Mode != "headed"
 
-	inst, err := o.Launch(profileName, req.Port, headless)
+	inst, err := o.Launch(profileName, req.Port, headless, req.ExtensionPaths)
 	if err != nil {
 		statusCode := classifyLaunchError(err)
 		web.Error(w, statusCode, err)

--- a/internal/orchestrator/handlers_profiles.go
+++ b/internal/orchestrator/handlers_profiles.go
@@ -35,7 +35,7 @@ func (o *Orchestrator) handleStartByID(w http.ResponseWriter, r *http.Request) {
 	}
 	_ = json.NewDecoder(r.Body).Decode(&req)
 
-	inst, err := o.Launch(name, req.Port, req.Headless)
+	inst, err := o.Launch(name, req.Port, req.Headless, nil)
 	if err != nil {
 		statusCode := classifyLaunchError(err)
 		web.Error(w, statusCode, err)

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -146,7 +146,7 @@ func installStableBinary(src, dst string) error {
 	return err
 }
 
-func (o *Orchestrator) Launch(name, port string, headless bool) (*bridge.Instance, error) {
+func (o *Orchestrator) Launch(name, port string, headless bool, extensionPaths []string) (*bridge.Instance, error) {
 	// Validate profile name to prevent path traversal attacks
 	if err := profiles.ValidateProfileName(name); err != nil {
 		return nil, err
@@ -207,14 +207,18 @@ func (o *Orchestrator) Launch(name, port string, headless bool) (*bridge.Instanc
 		headlessStr = "false"
 	}
 
-	env := mergeEnvWithOverrides(os.Environ(), map[string]string{
+	envOverrides := map[string]string{
 		"BRIDGE_PORT":       port,
 		"BRIDGE_PROFILE":    profilePath,
 		"BRIDGE_STATE_DIR":  instanceStateDir,
 		"BRIDGE_HEADLESS":   headlessStr,
 		"BRIDGE_NO_RESTORE": "true",
 		"BRIDGE_ONLY":       "1",
-	})
+	}
+	if len(extensionPaths) > 0 {
+		envOverrides["CHROME_EXTENSION_PATHS"] = strings.Join(extensionPaths, ",")
+	}
+	env := mergeEnvWithOverrides(os.Environ(), envOverrides)
 
 	logBuf := newRingBuffer(64 * 1024)
 	slog.Info("starting instance process", "id", instanceID, "profile", name, "port", port)

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -14,7 +14,7 @@ func TestOrchestrator_Launch_Lifecycle(t *testing.T) {
 	runner := &mockRunner{portAvail: true}
 	o := NewOrchestratorWithRunner(t.TempDir(), runner)
 
-	inst, err := o.Launch("profile1", "9001", true)
+	inst, err := o.Launch("profile1", "9001", true, nil)
 	if err != nil {
 		t.Fatalf("First launch failed: %v", err)
 	}
@@ -22,13 +22,13 @@ func TestOrchestrator_Launch_Lifecycle(t *testing.T) {
 		t.Errorf("expected status starting, got %s", inst.Status)
 	}
 
-	_, err = o.Launch("profile1", "9002", true)
+	_, err = o.Launch("profile1", "9002", true, nil)
 	if err == nil {
 		t.Error("expected error when launching duplicate profile")
 	}
 
 	runner.portAvail = false
-	_, err = o.Launch("profile2", "9001", true)
+	_, err = o.Launch("profile2", "9001", true, nil)
 	if err == nil {
 		t.Error("expected error when launching on occupied port")
 	}
@@ -43,7 +43,7 @@ func TestOrchestrator_ListAndStop(t *testing.T) {
 	runner := &mockRunner{portAvail: true}
 	o := NewOrchestratorWithRunner(t.TempDir(), runner)
 
-	inst, _ := o.Launch("p1", "9001", true)
+	inst, _ := o.Launch("p1", "9001", true, nil)
 
 	if len(o.List()) != 1 {
 		t.Fatalf("expected 1 instance, got %d", len(o.List()))
@@ -122,7 +122,7 @@ func TestOrchestrator_Launch_RejectsPathTraversal(t *testing.T) {
 
 	for _, tt := range badNames {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := o.Launch(tt.input, "9999", true)
+			_, err := o.Launch(tt.input, "9999", true, nil)
 			if err == nil {
 				t.Errorf("Launch(%q) should have returned error", tt.input)
 				return
@@ -155,7 +155,7 @@ func TestOrchestrator_Launch_AcceptsValidNames(t *testing.T) {
 	for i, name := range validNames {
 		t.Run(name, func(t *testing.T) {
 			port := 9100 + i
-			inst, err := o.Launch(name, string(rune('0'+port%10))+string(rune('0'+(port/10)%10))+string(rune('0'+(port/100)%10))+string(rune('0'+(port/1000)%10)), true)
+			inst, err := o.Launch(name, string(rune('0'+port%10))+string(rune('0'+(port/10)%10))+string(rune('0'+(port/100)%10))+string(rune('0'+(port/1000)%10)), true, nil)
 			if err != nil {
 				t.Errorf("Launch(%q) unexpected error: %v", name, err)
 				return

--- a/internal/orchestrator/process_test.go
+++ b/internal/orchestrator/process_test.go
@@ -36,7 +36,7 @@ func TestLaunch_Mocked(t *testing.T) {
 	runner := &mockRunner{portAvail: true}
 	o := NewOrchestratorWithRunner(t.TempDir(), runner)
 
-	inst, err := o.Launch("test-prof", "9999", true)
+	inst, err := o.Launch("test-prof", "9999", true, nil)
 	if err != nil {
 		t.Fatalf("Launch failed: %v", err)
 	}
@@ -53,7 +53,7 @@ func TestLaunch_PortConflict(t *testing.T) {
 	runner := &mockRunner{portAvail: false}
 	o := NewOrchestratorWithRunner(t.TempDir(), runner)
 
-	_, err := o.Launch("test-prof", "9999", true)
+	_, err := o.Launch("test-prof", "9999", true, nil)
 	if err == nil {
 		t.Fatal("expected error for unavailable port")
 	}


### PR DESCRIPTION
## What Changed?

Added `CHROME_EXTENSION_PATHS` environment variable and `extensionPaths` API field to allow launching Chrome with unpacked extensions loaded.

When `ExtensionPaths` is set on `RuntimeConfig`:
- Omits `--disable-extensions` (chromedp path: `Flag("disable-extensions", false)`; direct-launch path: conditional)
- Adds `--load-extension=<paths>` and `--disable-extensions-except=<paths>`
- Overrides `--enable-automation` (chromedp default) which suppresses `--load-extension`
- Passes `CHROME_EXTENSION_PATHS` env var to child instance processes

Also fixes `CHROME_FLAGS` parsing â€” was passed as a single string argument, now split on `strings.Fields()` in both launch paths.

**Files changed (10):**
- `internal/config/config.go` â€” `ExtensionPaths []string` field, `splitCommaPaths()` helper, env var reading, `config show` output
- `internal/bridge/init.go` â€” Extension flags in `setupAllocator()` and `buildChromeArgs()`
- `internal/bridge/api.go` â€” `extensionPaths` param on `OrchestratorService.Launch`
- `internal/orchestrator/orchestrator.go` â€” Pass `CHROME_EXTENSION_PATHS` env to child processes
- `internal/orchestrator/handlers_instances.go` â€” Parse `extensionPaths` from API requests
- `internal/orchestrator/handlers_profiles.go` â€” Pass `nil` for extensions
- `internal/api/types/types.go` â€” `ExtensionPaths` on `LaunchInstanceRequest`
- `cmd/pinchtab/cmd_dashboard.go` â€” Pass `nil` for extensions
- `internal/orchestrator/orchestrator_test.go` â€” Updated `Launch()` call sites
- `internal/orchestrator/process_test.go` â€” Updated `Launch()` call sites

## Why?

Enables using PinchTab for end-to-end testing of Chrome extensions. Without this, `--disable-extensions` is hardcoded in both launch paths, making it impossible to load extensions.

Use case: launching multiple Chrome instances with an extension loaded to test multi-device sync workflows â€” scripting setup/navigation via PinchTab's API while interacting with the extension UI.

**Important:** Branded Chrome 137+ removed `--load-extension` entirely. This feature requires **Chrome for Testing** or **Chromium**. Set `CHROME_BIN` to point to a CfT binary.

## Testing

- [x] Unit/integration tests added or updated
- [x] Manual testing completed (describe below)

**Unit tests:** All existing tests pass (`go test ./internal/...`). Updated 8 `Launch()` call sites in `orchestrator_test.go` and `process_test.go` to include the new `extensionPaths` parameter.

**Manual testing:**
```bash
# Build
go build -o pinchtab.exe ./cmd/pinchtab

# Launch with extension (Chrome for Testing required)
CHROME_BIN="/path/to/chrome-for-testing/chrome.exe" \
CHROME_EXTENSION_PATHS="/path/to/my-extension" \
BRIDGE_HEADLESS=false \
./pinchtab.exe

# Create instance via API
curl -X POST http://localhost:9867/instances/launch \
  -H 'Content-Type: application/json' \
  -d '{"name":"test","mode":"headed"}'
```

Verified:
- Extension loads and appears in Chrome toolbar
- Extension service worker responds to `chrome.runtime.sendMessage()`
- Extension tracks tabs opened via PinchTab API
- Extension popup navigable at `chrome-extension://<id>/popup.html`
- `chrome.storage.local` readable/writable from extension context
- Default behavior (no extensions) unchanged â€” `--disable-extensions` still applied when `ExtensionPaths` is empty
- Branded Chrome 145 silently ignores `--load-extension` â€” confirming Chrome 137+ removal. CfT works correctly.

## Checklist

**Automated (CI enforces):**
- [x] gofmt + golangci-lint passes
- [x] All tests pass
- [x] Build succeeds

**Manual:**
- [x] Error handling explicit (wrapped with `%w`)
- [x] No regressions in stealth/performance/persistence
- [ ] README/CHANGELOG updated (if user-facing)
- [ ] npm install works (if npm changes) - N/A

## Impact

- **No breaking changes** â€” default behavior is identical when `CHROME_EXTENSION_PATHS` is unset
- **Compatibility note:** `--enable-automation` is removed when extensions are configured. This flag is already countered by PinchTab's `--disable-automation` stealth flag, so no functional regression expected
- **`CHROME_FLAGS` fix** is a minor behavior change: flags like `CHROME_FLAGS="--flag1 --flag2"` now correctly produce two separate arguments instead of one concatenated string