### PR TITLE
Fix SafePath path traversal vulnerability on Windows

### DIFF
--- a/internal/web/safepath.go
+++ b/internal/web/safepath.go
@@ -21,6 +21,11 @@ func SafePath(base, userPath string) (string, error) {
 		resolved = filepath.Clean(filepath.Join(absBase, userPath))
 	}
 
+	resolved, err = filepath.Abs(resolved)
+	if err != nil {
+		return "", fmt.Errorf("invalid resolved path: %w", err)
+	}
+
 	// Ensure resolved path is within or equal to base
 	if !strings.HasPrefix(resolved, absBase+string(filepath.Separator)) && resolved != absBase {
 		return "", fmt.Errorf("path %q escapes base directory %q", userPath, absBase)


### PR DESCRIPTION
## Description
Fixes a path traversal vulnerability in `SafePath()` on Windows. On Windows, `filepath.IsAbs()` does not recognize Unix-style absolute paths (e.g., `/etc/passwd`), causing them to bypass the traversal check. Adding `filepath.Abs(resolved)` after cleaning normalizes the path on all platforms.

## Related Issue
Closes #117

## Changes Made
- Added `filepath.Abs(resolved)` call in `SafePath()` after `filepath.Clean()` to normalize paths on all platforms

## Files Changed
- `internal/web/safepath.go` — Added `filepath.Abs()` normalization (5 lines added)

## Testing
- [x] All existing tests pass
- [x] `TestSafePath/traversal_absolute` passes (this test already demonstrated the failure)
- [x] Linter passes
- [x] Build succeeds

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No breaking changes introduced