### PR TITLE
fix: implement FillByNodeID to support fill action with refs (fixes #114)

### DIFF
--- a/internal/bridge/actions.go
+++ b/internal/bridge/actions.go
@@ -61,7 +61,10 @@ func (b *Bridge) InitActionRegistry() {
 			if req.Selector != "" {
 				return map[string]any{"filled": req.Text}, chromedp.Run(ctx, chromedp.SetValue(req.Selector, req.Text, chromedp.ByQuery))
 			}
-			return map[string]any{"filled": req.Text}, nil
+			if req.NodeID > 0 {
+				return map[string]any{"filled": req.Text}, FillByNodeID(ctx, req.NodeID, req.Text)
+			}
+			return nil, fmt.Errorf("need selector or ref")
 		},
 		ActionPress: func(ctx context.Context, req ActionRequest) (map[string]any, error) {
 			if req.Key == "" {

--- a/internal/bridge/cdp.go
+++ b/internal/bridge/cdp.go
@@ -167,6 +167,36 @@ func HoverByNodeID(ctx context.Context, nodeID int64) error {
 	)
 }
 
+func FillByNodeID(ctx context.Context, nodeID int64, value string) error {
+	return chromedp.Run(ctx,
+		chromedp.ActionFunc(func(ctx context.Context) error {
+			return chromedp.FromContext(ctx).Target.Execute(ctx, "DOM.focus", map[string]any{"backendNodeId": nodeID}, nil)
+		}),
+		chromedp.ActionFunc(func(ctx context.Context) error {
+			var result json.RawMessage
+			if err := chromedp.FromContext(ctx).Target.Execute(ctx, "DOM.resolveNode", map[string]any{
+				"backendNodeId": nodeID,
+			}, &result); err != nil {
+				return err
+			}
+			var resolved struct {
+				Object struct {
+					ObjectID string `json:"objectId"`
+				} `json:"object"`
+			}
+			if err := json.Unmarshal(result, &resolved); err != nil {
+				return err
+			}
+			js := `function(v) { this.value = v; this.dispatchEvent(new Event('input', {bubbles: true})); this.dispatchEvent(new Event('change', {bubbles: true})); }`
+			return chromedp.FromContext(ctx).Target.Execute(ctx, "Runtime.callFunctionOn", map[string]any{
+				"functionDeclaration": js,
+				"objectId":            resolved.Object.ObjectID,
+				"arguments":           []map[string]any{{"value": value}},
+			}, nil)
+		}),
+	)
+}
+
 func SelectByNodeID(ctx context.Context, nodeID int64, value string) error {
 	return chromedp.Run(ctx,
 		chromedp.ActionFunc(func(ctx context.Context) error {

--- a/tests/integration/actions_test.go
+++ b/tests/integration/actions_test.go
@@ -357,3 +357,53 @@ func TestAction_NoTab(t *testing.T) {
 		t.Error("expected error for nonexistent tab")
 	}
 }
+
+func TestAction_Fill_ActuallySetsValue(t *testing.T) {
+	navigate(t, "https://httpbin.org/forms/post")
+	defer closeCurrentTab(t)
+
+	_, snapBody := httpGet(t, "/snapshot?filter=interactive&format=text&tabId="+currentTabID)
+	ref := findRef(string(snapBody), "textbox")
+	if ref == "" {
+		ref = findRef(string(snapBody), "input")
+	}
+	if ref == "" {
+		t.Skip("no input ref found")
+	}
+
+	testValue := "test_fill_" + randomString(8)
+	code, _ := httpPost(t, "/action", map[string]any{
+		"tabId": currentTabID,
+		"kind":  "fill",
+		"ref":   ref,
+		"text":  testValue,
+	})
+	if code != 200 {
+		t.Fatalf("fill failed with %d", code)
+	}
+
+	_, snapBody2 := httpGet(t, "/snapshot?tabId="+currentTabID)
+	snapStr := string(snapBody2)
+
+	if !strings.Contains(snapStr, testValue) {
+		t.Errorf("fill did not set value - snapshot does not contain %q (issue #114: fill with ref no-ops)", testValue)
+		t.Logf("snapshot: %s", snapStr[:min(500, len(snapStr))])
+	}
+}
+
+// randomString generates a deterministic test value for unique snapshot verification
+func randomString(n int) string {
+	chars := "abcdefghijklmnopqrstuvwxyz0123456789"
+	result := ""
+	for i := 0; i < n; i++ {
+		result += string(chars[i%len(chars)])
+	}
+	return result
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}


### PR DESCRIPTION
## Problem

`fill` action was silently no-oping when using refs (e.g. e35).

When passing a ref like `e35`, the ActionFill handler would resolve it to a NodeID but fall through to an else branch that returned success without doing anything.

## Solution

Implement FillByNodeID following the same pattern as SelectByNodeID:
1. Focus the element
2. Resolve backend node via DOM.resolveNode
3. Use Runtime.callFunctionOn to set value and dispatch input/change events

Update ActionFill handler to check NodeID branch and return error if neither selector nor ref provided.

## Changes

- internal/bridge/cdp.go: Add FillByNodeID function
- internal/bridge/actions.go: Update ActionFill handler
- tests/integration/actions_test.go: Add TestAction_Fill_ActuallySetsValue integration test

## Testing

- Unit tests: all passing ✅
- Build: successful ✅
- Integration test: verifies fill with ref actually sets value ✅

Fixes #114