### PR TITLE
Add SafePath validation to upload handler

### DIFF
--- a/internal/handlers/upload.go
+++ b/internal/handlers/upload.go
@@ -54,12 +54,18 @@ func (h *Handlers) HandleUpload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Validate local paths exist.
-	for _, p := range req.Paths {
-		if _, err := os.Stat(p); err != nil {
-			web.Error(w, 400, fmt.Errorf("file not found: %s", p))
+	// Validate local paths stay within the allowed StateDir.
+	for i, p := range req.Paths {
+		safe, err := web.SafePath(h.Config.StateDir, p)
+		if err != nil {
+			web.Error(w, 400, fmt.Errorf("invalid path: %w", err))
 			return
 		}
+		if _, err := os.Stat(safe); err != nil {
+			web.Error(w, 400, fmt.Errorf("file not found: %s", safe))
+			return
+		}
+		req.Paths[i] = safe
 	}
 
 	// Decode base64 files to temp dir.

--- a/internal/handlers/upload_test.go
+++ b/internal/handlers/upload_test.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"bytes"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -41,6 +42,33 @@ func TestHandleUpload_NonexistentPath(t *testing.T) {
 	h.HandleUpload(w, req)
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("expected 400 for nonexistent path, got %d", w.Code)
+	}
+}
+
+func TestHandleUpload_PathTraversal(t *testing.T) {
+	tmpDir := t.TempDir()
+	h := New(&mockBridge{}, &config.RuntimeConfig{StateDir: tmpDir}, nil, nil, nil)
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{"dotdot traversal", "../etc/passwd"},
+		{"absolute outside", "/etc/passwd"},
+		{"hidden traversal", "uploads/../../etc/passwd"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := fmt.Sprintf(`{"selector": "input[type=file]", "paths": [%q]}`, tt.path)
+			req := httptest.NewRequest("POST", "/upload", bytes.NewReader([]byte(body)))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			h.HandleUpload(w, req)
+			if w.Code != http.StatusBadRequest {
+				t.Errorf("expected 400 for traversal path %q, got %d", tt.path, w.Code)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Description
Adds `web.SafePath()` validation to the `/upload` endpoint to prevent arbitrary local file access via path traversal. This follows the same pattern already used in `download.go`, `pdf.go`, and `snapshot.go`.

## Related Issue
Closes #124

## Changes Made
- Updated `HandleUpload` in `internal/handlers/upload.go` to validate local file paths against `h.Config.StateDir` using `web.SafePath()` before passing them to CDP
- Added `TestHandleUpload_PathTraversal` with 3 sub-tests covering dotdot traversal, absolute paths outside StateDir, and hidden traversal

## Files Changed
- `internal/handlers/upload.go` — Added SafePath validation (consistent with download.go, pdf.go, snapshot.go pattern)
- `internal/handlers/upload_test.go` — Added path traversal test with 3 sub-cases

## Testing
- [x] All existing tests pass (no regressions)
- [x] New `TestHandleUpload_PathTraversal` passes (dotdot, absolute, hidden)
- [x] Build succeeds
- [x] gofmt clean

## Checklist
- [x] Code follows project style guidelines
- [x] Matches existing SafePath usage pattern (HTTP 400, `invalid path` error)
- [x] Self-review completed
- [x] No breaking changes