### PR TITLE
Add auth to bridge mode and screencast WebSocket handler

### DIFF
--- a/cmd/pinchtab/cmd_bridge.go
+++ b/cmd/pinchtab/cmd_bridge.go
@@ -43,7 +43,7 @@ func runBridgeServer(cfg *config.RuntimeConfig) {
 	// HTTP server
 	server := &http.Server{
 		Addr:              listenAddr,
-		Handler:           recoveryMiddleware(loggingMiddleware(mux)),
+		Handler:           recoveryMiddleware(loggingMiddleware(handlers.AuthMiddleware(cfg, mux))),
 		ReadHeaderTimeout: 10 * time.Second,
 		ReadTimeout:       30 * time.Second,
 		WriteTimeout:      60 * time.Second,

--- a/internal/handlers/screencast.go
+++ b/internal/handlers/screencast.go
@@ -2,10 +2,12 @@ package handlers
 
 import (
 	"context"
+	"crypto/subtle"
 	"encoding/base64"
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -19,6 +21,22 @@ import (
 // HandleScreencast upgrades to WebSocket and streams screencast frames for a tab.
 // Query params: tabId (required), quality (1-100, default 40), maxWidth (default 800), fps (1-30, default 5)
 func (h *Handlers) HandleScreencast(w http.ResponseWriter, r *http.Request) {
+	// WebSocket auth: check query param token or Authorization header.
+	// WebSocket clients typically can't set custom headers during the
+	// upgrade handshake, so we accept the token as a query parameter.
+	if h.Config.Token != "" {
+		qToken := r.URL.Query().Get("token")
+		authHeader := r.Header.Get("Authorization")
+		provided := strings.TrimPrefix(authHeader, "Bearer ")
+		if provided == "" {
+			provided = qToken
+		}
+		if provided == "" || subtle.ConstantTimeCompare([]byte(provided), []byte(h.Config.Token)) != 1 {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+	}
+
 	tabID := r.URL.Query().Get("tabId")
 	if tabID == "" {
 		targets, err := h.Bridge.ListTargets()

--- a/internal/handlers/screencast_test.go
+++ b/internal/handlers/screencast_test.go
@@ -1,0 +1,65 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/pinchtab/pinchtab/internal/config"
+)
+
+func TestHandleScreencast_AuthRejectsNoToken(t *testing.T) {
+	cfg := &config.RuntimeConfig{Token: "secret-token-123"}
+	h := New(&mockBridge{}, cfg, nil, nil, nil)
+
+	req := httptest.NewRequest("GET", "/screencast", nil)
+	w := httptest.NewRecorder()
+	h.HandleScreencast(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 Unauthorized without token, got %d", w.Code)
+	}
+}
+
+func TestHandleScreencast_AuthRejectsWrongToken(t *testing.T) {
+	cfg := &config.RuntimeConfig{Token: "secret-token-123"}
+	h := New(&mockBridge{}, cfg, nil, nil, nil)
+
+	req := httptest.NewRequest("GET", "/screencast?token=wrong-token", nil)
+	w := httptest.NewRecorder()
+	h.HandleScreencast(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 Unauthorized with wrong token, got %d", w.Code)
+	}
+}
+
+func TestHandleScreencast_AuthRejectsWrongHeader(t *testing.T) {
+	cfg := &config.RuntimeConfig{Token: "secret-token-123"}
+	h := New(&mockBridge{}, cfg, nil, nil, nil)
+
+	req := httptest.NewRequest("GET", "/screencast", nil)
+	req.Header.Set("Authorization", "Bearer wrong-token")
+	w := httptest.NewRecorder()
+	h.HandleScreencast(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 Unauthorized with wrong Bearer header, got %d", w.Code)
+	}
+}
+
+func TestHandleScreencast_NoTokenConfigSkipsAuth(t *testing.T) {
+	cfg := &config.RuntimeConfig{} // No token configured
+	h := New(&mockBridge{failTab: true}, cfg, nil, nil, nil)
+
+	// With no token configured, auth is skipped. The handler will then
+	// fail at TabContext (failTab=true) and return 404 — proving auth
+	// didn't block the request.
+	req := httptest.NewRequest("GET", "/screencast", nil)
+	w := httptest.NewRecorder()
+	h.HandleScreencast(w, req)
+
+	if w.Code == http.StatusUnauthorized {
+		t.Errorf("should not get 401 when no token is configured, got %d", w.Code)
+	}
+}


### PR DESCRIPTION
Hey @luigi-agosti 

This fixes the missing authentication on the `/screencast` WebSocket endpoint (and all other endpoints) when running in bridge mode.

## What was happening

Bridge mode in `cmd_bridge.go` was only wrapping handlers with `loggingMiddleware` + `recoveryMiddleware` — it never applied `AuthMiddleware`. This meant every endpoint was wide open with no token check, including the screencast which streams live browser frames.

## What this PR does

**1. Wires `AuthMiddleware` into bridge mode** (`cmd_bridge.go` line 46)

The dashboard mode already had this (`cmd_dashboard.go` line 114), so this just brings bridge mode in line.

**2. Adds handler-level auth to the screencast WebSocket handler** (`screencast.go`)

WebSocket clients can't send custom `Authorization` headers during the upgrade handshake — that's a browser limitation. So the screencast handler now also accepts the token via `?token=<token>` query parameter, in addition to the standard `Bearer` header. Uses `crypto/subtle.ConstantTimeCompare` for timing-safe comparison, matching how `AuthMiddleware` already works.

When no token is configured (`Config.Token == ""`), auth is skipped entirely — same behavior as `AuthMiddleware`.

**3. Added 4 tests** (`screencast_test.go`)

- No token provided → 401
- Wrong query param token → 401
- Wrong Bearer header → 401
- No token configured → auth skipped (passes through)

## Testing

- All existing tests pass, no regressions
- All 4 new screencast auth tests pass
- Build clean, gofmt clean
