### PR TITLE
Fix OpenClaw plugin package/manifest ID mismatch warning

### DIFF
--- a/plugin/README.md
+++ b/plugin/README.md
@@ -5,7 +5,7 @@ Browser control for AI agents via [Pinchtab](https://pinchtab.com). Single-tool 
 ## Install
 
 ```bash
-openclaw plugins install @pinchtab/openclaw-plugin
+openclaw plugins install @pinchtab/pinchtab
 openclaw gateway restart
 ```
 

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@pinchtab/openclaw-plugin",
+  "name": "@pinchtab/pinchtab",
   "version": "0.1.0",
   "description": "OpenClaw plugin for Pinchtab browser control",
   "type": "module",


### PR DESCRIPTION
## Description
This PR fixes the OpenClaw plugin ID mismatch warning by aligning the npm package name with the plugin manifest ID.

## Related Issue
Closes #150

## Changes Made
- Updated `plugin/package.json` name from `@pinchtab/openclaw-plugin` to `@pinchtab/pinchtab`
- Updated install command in `plugin/README.md` to match the new package name

## Testing
- [x] `go build ./cmd/pinchtab`
- [x] `golangci-lint run ./...`
- [x] `go test ./... -count=1`
- [x] `gofmt -l .` (no changes)

## Notes
This keeps `openclaw.plugin.json` id as `pinchtab`, so plugin config keys remain intuitive (`plugins.entries.pinchtab`) while removing the startup warning.
