### PR TITLE
Fix silent error swallowing in animations.go

### DIFF
--- a/internal/bridge/animations.go
+++ b/internal/bridge/animations.go
@@ -20,8 +20,8 @@ const DisableAnimationsCSS = `
 
 // InjectNoAnimations adds a persistent script (via CDP) that disables CSS
 // animations on every document load. Used when BRIDGE_NO_ANIMATIONS=true.
-func (b *Bridge) InjectNoAnimations(ctx context.Context) {
-	_ = chromedp.Run(ctx,
+func (b *Bridge) InjectNoAnimations(ctx context.Context) error {
+	return chromedp.Run(ctx,
 		chromedp.ActionFunc(func(ctx context.Context) error {
 			_, err := page.AddScriptToEvaluateOnNewDocument(DisableAnimationsCSS).Do(ctx)
 			return err
@@ -37,8 +37,8 @@ func (b *Bridge) InjectNoAnimations(ctx context.Context) {
 
 // DisableAnimationsOnce runs the animation-disabling CSS on the current page
 // (one-shot, for per-request ?noAnimations=true).
-func DisableAnimationsOnce(ctx context.Context) {
-	_ = chromedp.Run(ctx,
+func DisableAnimationsOnce(ctx context.Context) error {
+	return chromedp.Run(ctx,
 		chromedp.Evaluate(DisableAnimationsCSS, nil),
 		chromedp.ActionFunc(func(ctx context.Context) error {
 			return emulation.SetEmulatedMedia().

--- a/internal/bridge/animations_test.go
+++ b/internal/bridge/animations_test.go
@@ -1,6 +1,7 @@
 package bridge
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -24,5 +25,24 @@ func TestInjectNoAnimations(t *testing.T) {
 	b := &Bridge{Config: cfg}
 	if b.Config.NoAnimations != true {
 		t.Error("Expected NoAnimations to be true")
+	}
+}
+
+func TestDisableAnimationsOnceReturnsErrorWhenContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := DisableAnimationsOnce(ctx); err == nil {
+		t.Fatal("expected error for canceled context")
+	}
+}
+
+func TestInjectNoAnimationsReturnsErrorWhenContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	b := &Bridge{}
+	if err := b.InjectNoAnimations(ctx); err == nil {
+		t.Fatal("expected error for canceled context")
 	}
 }

--- a/internal/bridge/bridge.go
+++ b/internal/bridge/bridge.go
@@ -84,7 +84,9 @@ func (b *Bridge) tabSetup(ctx context.Context) {
 	}
 	b.injectStealth(ctx)
 	if b.Config.NoAnimations {
-		b.InjectNoAnimations(ctx)
+		if err := b.InjectNoAnimations(ctx); err != nil {
+			slog.Warn("no-animations injection failed", "err", err)
+		}
 	}
 }
 

--- a/internal/handlers/screenshot.go
+++ b/internal/handlers/screenshot.go
@@ -42,7 +42,10 @@ func (h *Handlers) HandleScreenshot(w http.ResponseWriter, r *http.Request) {
 	go web.CancelOnClientDone(r.Context(), tCancel)
 
 	if reqNoAnim && !h.Config.NoAnimations {
-		bridge.DisableAnimationsOnce(tCtx)
+		if err := bridge.DisableAnimationsOnce(tCtx); err != nil {
+			web.Error(w, 500, fmt.Errorf("disable animations: %w", err))
+			return
+		}
 	}
 
 	var buf []byte

--- a/internal/handlers/snapshot.go
+++ b/internal/handlers/snapshot.go
@@ -97,7 +97,10 @@ func (h *Handlers) HandleSnapshot(w http.ResponseWriter, r *http.Request) {
 	go web.CancelOnClientDone(r.Context(), tCancel)
 
 	if reqNoAnim && !h.Config.NoAnimations {
-		bridge.DisableAnimationsOnce(tCtx)
+		if err := bridge.DisableAnimationsOnce(tCtx); err != nil {
+			web.Error(w, 500, fmt.Errorf("disable animations: %w", err))
+			return
+		}
 	}
 
 	var rawResult json.RawMessage


### PR DESCRIPTION
## Description
This PR addresses Issue #141 by fixing the silent error swallowing when injecting or disabling animations via CDP.

## Changes Made
- Changed `InjectNoAnimations` and `DisableAnimationsOnce` in `internal/bridge/animations.go` to return an `error`.
- Updated `internal/bridge/bridge.go` to explicitly log a warning if animation injection fails during initialization (non-fatal start path).
- Updated `internal/handlers/screenshot.go` and `internal/handlers/snapshot.go` to return an HTTP `500` error if disabling animations for a specific request (`?noAnimations=true`) fails.
- Added regression coverage in `internal/bridge/animations_test.go` confirming error propagation on context cancellation.

## Testing
- [x] Tested locally via `go test ./... -count=1`
- [x] Passed all lint checks via `golangci-lint run ./...`
- [x] Formatted cleanly
