### PR TITLE
security: gate unsafe endpoints behind opt-in env vars

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -85,6 +85,10 @@ jobs:
           PINCHTAB_TEST_PORT: "19867"
           PINCHTAB_TEST_RETRY: "true"
           PINCHTAB_ALLOW_EVALUATE: "true"
+          PINCHTAB_ALLOW_MACRO: "true"
+          PINCHTAB_ALLOW_DOWNLOAD: "true"
+          PINCHTAB_ALLOW_UPLOAD: "true"
+          PINCHTAB_ALLOW_SCREENCAST: "true"
 
       - name: 📋 Add summary
         if: always()
@@ -149,6 +153,10 @@ jobs:
           PINCHTAB_TEST_PORT: "19868"
           PINCHTAB_TEST_RETRY: "true"
           PINCHTAB_ALLOW_EVALUATE: "true"
+          PINCHTAB_ALLOW_MACRO: "true"
+          PINCHTAB_ALLOW_DOWNLOAD: "true"
+          PINCHTAB_ALLOW_UPLOAD: "true"
+          PINCHTAB_ALLOW_SCREENCAST: "true"
 
       - name: 📋 Add summary
         if: always()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,10 @@ type RuntimeConfig struct {
 	CdpURL            string
 	Token             string
 	AllowEvaluate     bool
+	AllowMacro        bool
+	AllowScreencast   bool
+	AllowDownload     bool
+	AllowUpload       bool
 	StateDir          string
 	Headless          bool
 	NoRestore         bool
@@ -222,6 +226,10 @@ type FileConfig struct {
 	CdpURL            string `json:"cdpUrl,omitempty"`
 	Token             string `json:"token,omitempty"`
 	AllowEvaluate     *bool  `json:"allowEvaluate,omitempty"`
+	AllowMacro        *bool  `json:"allowMacro,omitempty"`
+	AllowScreencast   *bool  `json:"allowScreencast,omitempty"`
+	AllowDownload     *bool  `json:"allowDownload,omitempty"`
+	AllowUpload       *bool  `json:"allowUpload,omitempty"`
 	StateDir          string `json:"stateDir"`
 	ProfileDir        string `json:"profileDir"`
 	Headless          *bool  `json:"headless,omitempty"`
@@ -240,6 +248,10 @@ func Load() *RuntimeConfig {
 		CdpURL:            os.Getenv("CDP_URL"),
 		Token:             envMigrate("PINCHTAB_TOKEN", "BRIDGE_TOKEN"),
 		AllowEvaluate:     envBoolOrMigrate("PINCHTAB_ALLOW_EVALUATE", "BRIDGE_ALLOW_EVALUATE", false),
+		AllowMacro:        envBoolOrMigrate("PINCHTAB_ALLOW_MACRO", "BRIDGE_ALLOW_MACRO", false),
+		AllowScreencast:   envBoolOrMigrate("PINCHTAB_ALLOW_SCREENCAST", "BRIDGE_ALLOW_SCREENCAST", false),
+		AllowDownload:     envBoolOrMigrate("PINCHTAB_ALLOW_DOWNLOAD", "BRIDGE_ALLOW_DOWNLOAD", false),
+		AllowUpload:       envBoolOrMigrate("PINCHTAB_ALLOW_UPLOAD", "BRIDGE_ALLOW_UPLOAD", false),
 		StateDir:          envOrMigrate("PINCHTAB_STATE_DIR", "BRIDGE_STATE_DIR", userConfigDir()),
 		Headless:          envBoolOrMigrate("PINCHTAB_HEADLESS", "BRIDGE_HEADLESS", true),
 		NoRestore:         envBoolOrMigrate("PINCHTAB_NO_RESTORE", "BRIDGE_NO_RESTORE", false),
@@ -295,6 +307,18 @@ func Load() *RuntimeConfig {
 	}
 	if fc.AllowEvaluate != nil && !envMigrateIsSet("PINCHTAB_ALLOW_EVALUATE", "BRIDGE_ALLOW_EVALUATE") {
 		cfg.AllowEvaluate = *fc.AllowEvaluate
+	}
+	if fc.AllowMacro != nil && !envMigrateIsSet("PINCHTAB_ALLOW_MACRO", "BRIDGE_ALLOW_MACRO") {
+		cfg.AllowMacro = *fc.AllowMacro
+	}
+	if fc.AllowScreencast != nil && !envMigrateIsSet("PINCHTAB_ALLOW_SCREENCAST", "BRIDGE_ALLOW_SCREENCAST") {
+		cfg.AllowScreencast = *fc.AllowScreencast
+	}
+	if fc.AllowDownload != nil && !envMigrateIsSet("PINCHTAB_ALLOW_DOWNLOAD", "BRIDGE_ALLOW_DOWNLOAD") {
+		cfg.AllowDownload = *fc.AllowDownload
+	}
+	if fc.AllowUpload != nil && !envMigrateIsSet("PINCHTAB_ALLOW_UPLOAD", "BRIDGE_ALLOW_UPLOAD") {
+		cfg.AllowUpload = *fc.AllowUpload
 	}
 	if fc.StateDir != "" && !envMigrateIsSet("PINCHTAB_STATE_DIR", "BRIDGE_STATE_DIR") {
 		cfg.StateDir = fc.StateDir
@@ -389,6 +413,10 @@ func HandleConfigCommand(cfg *RuntimeConfig) {
 		fmt.Printf("  CDP URL:    %s\n", cfg.CdpURL)
 		fmt.Printf("  Token:      %s\n", MaskToken(cfg.Token))
 		fmt.Printf("  Eval JS:    %v\n", cfg.AllowEvaluate)
+		fmt.Printf("  Macro:      %v\n", cfg.AllowMacro)
+		fmt.Printf("  Screencast: %v\n", cfg.AllowScreencast)
+		fmt.Printf("  Download:   %v\n", cfg.AllowDownload)
+		fmt.Printf("  Upload:     %v\n", cfg.AllowUpload)
 		fmt.Printf("  State Dir:  %s\n", cfg.StateDir)
 		fmt.Printf("  Profile:    %s\n", cfg.ProfileDir)
 		fmt.Printf("  Headless:   %v\n", cfg.Headless)

--- a/internal/handlers/actions.go
+++ b/internal/handlers/actions.go
@@ -483,6 +483,10 @@ func (h *Handlers) handleActionsBatch(w http.ResponseWriter, r *http.Request, re
 }
 
 func (h *Handlers) HandleMacro(w http.ResponseWriter, r *http.Request) {
+	if !h.Config.AllowMacro {
+		web.ErrorCode(w, 403, "macro_disabled", "macro endpoint is disabled; set PINCHTAB_ALLOW_MACRO=1 to enable", false, nil)
+		return
+	}
 	var req struct {
 		TabID       string                 `json:"tabId"`
 		Owner       string                 `json:"owner"`

--- a/internal/handlers/actions_test.go
+++ b/internal/handlers/actions_test.go
@@ -254,7 +254,7 @@ func TestHandleAction_GetMissingKind(t *testing.T) {
 }
 
 func TestHandleMacro_EmptySteps(t *testing.T) {
-	h := New(&mockBridge{}, &config.RuntimeConfig{}, nil, nil, nil)
+	h := New(&mockBridge{}, &config.RuntimeConfig{AllowMacro: true}, nil, nil, nil)
 	req := httptest.NewRequest("POST", "/macro", bytes.NewReader([]byte(`{"tabId":"tab1","steps":[]}`)))
 	w := httptest.NewRecorder()
 	h.HandleMacro(w, req)
@@ -284,5 +284,15 @@ func TestHandleAction_InvalidJSON(t *testing.T) {
 	h.HandleAction(w, req)
 	if w.Code != 400 {
 		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandleMacro_Disabled(t *testing.T) {
+	h := New(&mockBridge{}, &config.RuntimeConfig{}, nil, nil, nil)
+	req := httptest.NewRequest("POST", "/macro", bytes.NewReader([]byte(`{"steps":[{"kind":"click","ref":"e0"}]}`)))
+	w := httptest.NewRecorder()
+	h.HandleMacro(w, req)
+	if w.Code != 403 {
+		t.Errorf("expected 403 when macro disabled, got %d", w.Code)
 	}
 }

--- a/internal/handlers/download.go
+++ b/internal/handlers/download.go
@@ -56,6 +56,10 @@ func validateDownloadURL(rawURL string) error {
 //
 // GET /download?url=<url>[&tabId=<id>][&output=file&path=/tmp/file][&raw=true]
 func (h *Handlers) HandleDownload(w http.ResponseWriter, r *http.Request) {
+	if !h.Config.AllowDownload {
+		web.ErrorCode(w, 403, "download_disabled", "download endpoint is disabled; set PINCHTAB_ALLOW_DOWNLOAD=1 to enable", false, nil)
+		return
+	}
 	dlURL := r.URL.Query().Get("url")
 	if dlURL == "" {
 		web.Error(w, 400, fmt.Errorf("url parameter required"))

--- a/internal/handlers/download_test.go
+++ b/internal/handlers/download_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestHandleDownload_MissingURL(t *testing.T) {
-	h := New(&mockBridge{}, &config.RuntimeConfig{}, nil, nil, nil)
+	h := New(&mockBridge{}, &config.RuntimeConfig{AllowDownload: true}, nil, nil, nil)
 	req := httptest.NewRequest("GET", "/download", nil)
 	w := httptest.NewRecorder()
 	h.HandleDownload(w, req)
@@ -19,7 +19,7 @@ func TestHandleDownload_MissingURL(t *testing.T) {
 }
 
 func TestHandleDownload_EmptyURL(t *testing.T) {
-	h := New(&mockBridge{}, &config.RuntimeConfig{}, nil, nil, nil)
+	h := New(&mockBridge{}, &config.RuntimeConfig{AllowDownload: true}, nil, nil, nil)
 	req := httptest.NewRequest("GET", "/download?url=", nil)
 	w := httptest.NewRecorder()
 	h.HandleDownload(w, req)
@@ -56,7 +56,7 @@ func TestValidateDownloadURL(t *testing.T) {
 }
 
 func TestHandleDownload_SSRFBlocked(t *testing.T) {
-	h := New(&mockBridge{}, &config.RuntimeConfig{}, nil, nil, nil)
+	h := New(&mockBridge{}, &config.RuntimeConfig{AllowDownload: true}, nil, nil, nil)
 	urls := []string{
 		"file:///etc/passwd",
 		"http://localhost:8080",
@@ -73,7 +73,7 @@ func TestHandleDownload_SSRFBlocked(t *testing.T) {
 }
 
 func TestHandleTabDownload_MissingTabID(t *testing.T) {
-	h := New(&mockBridge{}, &config.RuntimeConfig{}, nil, nil, nil)
+	h := New(&mockBridge{}, &config.RuntimeConfig{AllowDownload: true}, nil, nil, nil)
 	req := httptest.NewRequest("GET", "/tabs//download?url=https://example.com", nil)
 	w := httptest.NewRecorder()
 	h.HandleTabDownload(w, req)
@@ -83,12 +83,22 @@ func TestHandleTabDownload_MissingTabID(t *testing.T) {
 }
 
 func TestHandleTabDownload_NoTab(t *testing.T) {
-	h := New(&mockBridge{failTab: true}, &config.RuntimeConfig{}, nil, nil, nil)
+	h := New(&mockBridge{failTab: true}, &config.RuntimeConfig{AllowDownload: true}, nil, nil, nil)
 	req := httptest.NewRequest("GET", "/tabs/tab_abc/download?url=https://example.com", nil)
 	req.SetPathValue("id", "tab_abc")
 	w := httptest.NewRecorder()
 	h.HandleTabDownload(w, req)
 	if w.Code != http.StatusNotFound {
 		t.Errorf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestHandleDownload_Disabled(t *testing.T) {
+	h := New(&mockBridge{}, &config.RuntimeConfig{}, nil, nil, nil)
+	req := httptest.NewRequest("GET", "/download?url=https://example.com/file.txt", nil)
+	w := httptest.NewRecorder()
+	h.HandleDownload(w, req)
+	if w.Code != 403 {
+		t.Errorf("expected 403 when download disabled, got %d", w.Code)
 	}
 }

--- a/internal/handlers/screencast.go
+++ b/internal/handlers/screencast.go
@@ -19,6 +19,10 @@ import (
 // HandleScreencast upgrades to WebSocket and streams screencast frames for a tab.
 // Query params: tabId (required), quality (1-100, default 40), maxWidth (default 800), fps (1-30, default 5)
 func (h *Handlers) HandleScreencast(w http.ResponseWriter, r *http.Request) {
+	if !h.Config.AllowScreencast {
+		web.ErrorCode(w, 403, "screencast_disabled", "screencast endpoint is disabled; set PINCHTAB_ALLOW_SCREENCAST=1 to enable", false, nil)
+		return
+	}
 	tabID := r.URL.Query().Get("tabId")
 	if tabID == "" {
 		targets, err := h.Bridge.ListTargets()
@@ -143,6 +147,10 @@ func (h *Handlers) HandleScreencast(w http.ResponseWriter, r *http.Request) {
 
 // HandleScreencastAll returns info for building a multi-tab screencast view.
 func (h *Handlers) HandleScreencastAll(w http.ResponseWriter, r *http.Request) {
+	if !h.Config.AllowScreencast {
+		web.ErrorCode(w, 403, "screencast_disabled", "screencast endpoint is disabled; set PINCHTAB_ALLOW_SCREENCAST=1 to enable", false, nil)
+		return
+	}
 	type tabInfo struct {
 		ID    string `json:"id"`
 		URL   string `json:"url,omitempty"`

--- a/internal/handlers/screencast_test.go
+++ b/internal/handlers/screencast_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestHandleScreencast_AuthRejectsNoToken(t *testing.T) {
-	cfg := &config.RuntimeConfig{Token: "secret-token-123"}
+	cfg := &config.RuntimeConfig{Token: "secret-token-123", AllowScreencast: true}
 	h := New(&mockBridge{}, cfg, nil, nil, nil)
 
 	req := httptest.NewRequest("GET", "/screencast", nil)
@@ -23,7 +23,7 @@ func TestHandleScreencast_AuthRejectsNoToken(t *testing.T) {
 }
 
 func TestHandleScreencast_AuthRejectsWrongToken(t *testing.T) {
-	cfg := &config.RuntimeConfig{Token: "secret-token-123"}
+	cfg := &config.RuntimeConfig{Token: "secret-token-123", AllowScreencast: true}
 	h := New(&mockBridge{}, cfg, nil, nil, nil)
 
 	req := httptest.NewRequest("GET", "/screencast?token=wrong-token", nil)
@@ -37,7 +37,7 @@ func TestHandleScreencast_AuthRejectsWrongToken(t *testing.T) {
 }
 
 func TestHandleScreencast_AuthRejectsWrongHeader(t *testing.T) {
-	cfg := &config.RuntimeConfig{Token: "secret-token-123"}
+	cfg := &config.RuntimeConfig{Token: "secret-token-123", AllowScreencast: true}
 	h := New(&mockBridge{}, cfg, nil, nil, nil)
 
 	req := httptest.NewRequest("GET", "/screencast", nil)
@@ -65,5 +65,16 @@ func TestHandleScreencast_NoTokenConfigSkipsAuth(t *testing.T) {
 
 	if w.Code == http.StatusUnauthorized {
 		t.Errorf("should not get 401 when no token is configured, got %d", w.Code)
+	}
+}
+
+func TestHandleScreencast_Disabled(t *testing.T) {
+	cfg := &config.RuntimeConfig{}
+	h := New(&mockBridge{}, cfg, nil, nil, nil)
+	req := httptest.NewRequest("GET", "/screencast", nil)
+	w := httptest.NewRecorder()
+	h.HandleScreencast(w, req)
+	if w.Code != 403 {
+		t.Errorf("expected 403 when screencast disabled, got %d", w.Code)
 	}
 }

--- a/internal/handlers/upload.go
+++ b/internal/handlers/upload.go
@@ -36,6 +36,10 @@ type uploadRequest struct {
 // Either "files" (base64 data) or "paths" (local file paths) must be provided.
 // Both can be combined. Files are written to a temp dir and passed to CDP.
 func (h *Handlers) HandleUpload(w http.ResponseWriter, r *http.Request) {
+	if !h.Config.AllowUpload {
+		web.ErrorCode(w, 403, "upload_disabled", "upload endpoint is disabled; set PINCHTAB_ALLOW_UPLOAD=1 to enable", false, nil)
+		return
+	}
 	tabID := r.URL.Query().Get("tabId")
 
 	r.Body = http.MaxBytesReader(w, r.Body, 10<<20) // 10MB limit

--- a/internal/handlers/upload_test.go
+++ b/internal/handlers/upload_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestHandleUpload_BadJSON(t *testing.T) {
-	h := New(&mockBridge{}, &config.RuntimeConfig{}, nil, nil, nil)
+	h := New(&mockBridge{}, &config.RuntimeConfig{AllowUpload: true}, nil, nil, nil)
 	req := httptest.NewRequest("POST", "/upload", bytes.NewReader([]byte("not json")))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
@@ -22,7 +22,7 @@ func TestHandleUpload_BadJSON(t *testing.T) {
 }
 
 func TestHandleUpload_EmptyPaths(t *testing.T) {
-	h := New(&mockBridge{}, &config.RuntimeConfig{}, nil, nil, nil)
+	h := New(&mockBridge{}, &config.RuntimeConfig{AllowUpload: true}, nil, nil, nil)
 	body := `{"selector": "input[type=file]"}`
 	req := httptest.NewRequest("POST", "/upload", bytes.NewReader([]byte(body)))
 	req.Header.Set("Content-Type", "application/json")
@@ -34,7 +34,7 @@ func TestHandleUpload_EmptyPaths(t *testing.T) {
 }
 
 func TestHandleUpload_NonexistentPath(t *testing.T) {
-	h := New(&mockBridge{}, &config.RuntimeConfig{}, nil, nil, nil)
+	h := New(&mockBridge{}, &config.RuntimeConfig{AllowUpload: true}, nil, nil, nil)
 	body := `{"selector": "input[type=file]", "paths": ["/tmp/nonexistent-file-12345.jpg"]}`
 	req := httptest.NewRequest("POST", "/upload", bytes.NewReader([]byte(body)))
 	req.Header.Set("Content-Type", "application/json")
@@ -47,7 +47,7 @@ func TestHandleUpload_NonexistentPath(t *testing.T) {
 
 func TestHandleUpload_PathTraversal(t *testing.T) {
 	tmpDir := t.TempDir()
-	h := New(&mockBridge{}, &config.RuntimeConfig{StateDir: tmpDir}, nil, nil, nil)
+	h := New(&mockBridge{}, &config.RuntimeConfig{AllowUpload: true, StateDir: tmpDir}, nil, nil, nil)
 
 	tests := []struct {
 		name string
@@ -73,7 +73,7 @@ func TestHandleUpload_PathTraversal(t *testing.T) {
 }
 
 func TestHandleTabUpload_MissingTabID(t *testing.T) {
-	h := New(&mockBridge{}, &config.RuntimeConfig{}, nil, nil, nil)
+	h := New(&mockBridge{}, &config.RuntimeConfig{AllowUpload: true}, nil, nil, nil)
 	req := httptest.NewRequest("POST", "/tabs//upload", bytes.NewReader([]byte(`{"selector":"input[type=file]"}`)))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
@@ -84,7 +84,7 @@ func TestHandleTabUpload_MissingTabID(t *testing.T) {
 }
 
 func TestHandleTabUpload_NoTab(t *testing.T) {
-	h := New(&mockBridge{failTab: true}, &config.RuntimeConfig{}, nil, nil, nil)
+	h := New(&mockBridge{failTab: true}, &config.RuntimeConfig{AllowUpload: true}, nil, nil, nil)
 	req := httptest.NewRequest("POST", "/tabs/tab_abc/upload", bytes.NewReader([]byte(`{"files":["aGVsbG8="]}`)))
 	req.SetPathValue("id", "tab_abc")
 	req.Header.Set("Content-Type", "application/json")
@@ -96,7 +96,7 @@ func TestHandleTabUpload_NoTab(t *testing.T) {
 }
 
 func TestHandleUpload_BodyTooLarge(t *testing.T) {
-	h := New(&mockBridge{}, &config.RuntimeConfig{}, nil, nil, nil)
+	h := New(&mockBridge{}, &config.RuntimeConfig{AllowUpload: true}, nil, nil, nil)
 	// Create a body larger than 10MB
 	bigBody := make([]byte, 11<<20) // 11MB
 	req := httptest.NewRequest("POST", "/upload", bytes.NewReader(bigBody))
@@ -188,5 +188,15 @@ func TestSniffExt(t *testing.T) {
 				t.Errorf("sniffExt() = %q, want %q", got, tt.ext)
 			}
 		})
+	}
+}
+
+func TestHandleUpload_Disabled(t *testing.T) {
+	h := New(&mockBridge{}, &config.RuntimeConfig{}, nil, nil, nil)
+	req := httptest.NewRequest("POST", "/upload", bytes.NewReader([]byte(`{"paths":["/tmp/test.png"]}`)))
+	w := httptest.NewRecorder()
+	h.HandleUpload(w, req)
+	if w.Code != 403 {
+		t.Errorf("expected 403 when upload disabled, got %d", w.Code)
 	}
 }

--- a/tests/testutil/server.go
+++ b/tests/testutil/server.go
@@ -107,8 +107,17 @@ func StartServer(cfg ServerConfig) (*Server, error) {
 	if bin := os.Getenv("CHROME_BINARY"); bin != "" {
 		env = append(env, "CHROME_BINARY="+bin)
 	}
-	if allowEval := os.Getenv("PINCHTAB_ALLOW_EVALUATE"); allowEval != "" {
-		env = append(env, "PINCHTAB_ALLOW_EVALUATE="+allowEval)
+	// Pass through feature gates for integration tests
+	for _, gate := range []string{
+		"PINCHTAB_ALLOW_EVALUATE",
+		"PINCHTAB_ALLOW_MACRO",
+		"PINCHTAB_ALLOW_SCREENCAST",
+		"PINCHTAB_ALLOW_DOWNLOAD",
+		"PINCHTAB_ALLOW_UPLOAD",
+	} {
+		if v := os.Getenv(gate); v != "" {
+			env = append(env, gate+"="+v)
+		}
 	}
 
 	s.cmd = exec.Command(s.BinaryPath) // #nosec G204 -- BinaryPath is from os.MkdirTemp, not user input


### PR DESCRIPTION
## Summary

Disable high-risk endpoints by default to reduce attack surface and liability. Users must explicitly opt in.

## New Environment Variables

| Variable | Default | Endpoint |
|----------|---------|----------|
| `PINCHTAB_ALLOW_MACRO` | `false` | `POST /macro` |
| `PINCHTAB_ALLOW_SCREENCAST` | `false` | `GET /screencast`, `GET /screencast/tabs` |
| `PINCHTAB_ALLOW_DOWNLOAD` | `false` | `GET /download`, `GET /tabs/{id}/download` |
| `PINCHTAB_ALLOW_UPLOAD` | `false` | `POST /upload`, `POST /tabs/{id}/upload` |

Follows the pattern established by `PINCHTAB_ALLOW_EVALUATE` in v0.7.8.

## Why These Endpoints

Based on security analysis (`~/dev/pinchtab-analysis/`):

- **Macro**: Chains arbitrary actions including JS eval and navigation to attacker domains
- **Screencast**: Unlimited concurrent streams, no duration limits, streams sensitive page content
- **Download**: Silent file downloads, data exfiltration vector
- **Upload**: Can push local files to any page's file input without consent

## Behavior

- Disabled endpoints return `403` with a clear message: `"macro endpoint is disabled; set PINCHTAB_ALLOW_MACRO=1 to enable"`
- Config file support: `allowMacro`, `allowScreencast`, `allowDownload`, `allowUpload` in `~/.pinchtab/config.json`
- Backward-compatible `BRIDGE_ALLOW_*` env vars supported
- Startup banner shows enabled/disabled state for all gates

## Tests

- 4 new unit tests for disabled state (403 response)
- Existing tests updated with gates enabled
- CI workflow updated to enable all gates for integration tests