### PR TITLE
fix(orchestrator): proxy screencast WebSocket instead of returning JSON URL

### DIFF
--- a/internal/orchestrator/proxy.go
+++ b/internal/orchestrator/proxy.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/pinchtab/pinchtab/internal/handlers"
 	"github.com/pinchtab/pinchtab/internal/web"
 )
 
@@ -159,7 +160,6 @@ func (o *Orchestrator) findRunningInstanceByTabID(tabID string) (*InstanceIntern
 
 func (o *Orchestrator) handleProxyScreencast(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
-	tabID := r.URL.Query().Get("tabId")
 
 	o.mu.RLock()
 	inst, ok := o.instances[id]
@@ -169,8 +169,16 @@ func (o *Orchestrator) handleProxyScreencast(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	targetURL := fmt.Sprintf("ws://localhost:%s/screencast?tabId=%s", inst.Port, tabID)
-	web.JSON(w, 200, map[string]string{"wsUrl": targetURL})
+	// Build target URL preserving all query params (tabId, quality, maxWidth, fps)
+	targetURL := fmt.Sprintf("http://localhost:%s/screencast?%s", inst.Port, r.URL.RawQuery)
+
+	// Inject child auth token if configured
+	if o.childAuthToken != "" {
+		r.Header.Set("Authorization", "Bearer "+o.childAuthToken)
+	}
+
+	// Use WebSocket proxy for proper upgrade
+	handlers.ProxyWebSocket(w, r, targetURL)
 }
 
 func readResponseBody(resp *http.Response) []byte {


### PR DESCRIPTION
## Summary

- **Bug**: `handleProxyScreencast` returned a JSON `{"wsUrl": "ws://localhost:PORT/screencast?tabId=..."}` instead of actually proxying the WebSocket connection. The dashboard then tried to open a direct WebSocket to that URL, which fails when the child instance is bound to `localhost` and unreachable from the user's browser (common in remote/production setups behind a reverse proxy).
- **Fix**: Replace the JSON response with a real WebSocket tunnel using the existing `handlers.ProxyWebSocket` helper. The orchestrator now hijacks the connection and pipes it bidirectionally to the child instance.
- **Auth**: When `childAuthToken` is configured, the orchestrator injects `Authorization: Bearer <token>` into the proxied request, so the child's auth middleware accepts the connection.

## Context

This is the orchestrator-side complement to PR #196 which fixed the child-side of the same pipeline (adding `http.Hijacker` to `statusRecorder` in the logging middleware).

Together these two fixes resolve the "Connection lost" error in the Live View dashboard when running PinchTab behind a reverse proxy (e.g., Caddy, nginx) on a remote server.

Partially addresses #122 — the orchestrator now authenticates to child instances when proxying screencast WebSocket connections.

## Test plan

- [x] `go build ./...` — compiles cleanly
- [x] `go test ./internal/orchestrator/...` — passes
- [x] Manual test: dashboard Live View shows live screencast frames through Caddy → orchestrator → child pipeline
- [ ] Verify screencast works with multiple concurrent instances
- [ ] Verify screencast reconnects after child restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)