### PR TITLE
feat: add drag action for sliders and drag-and-drop

### DIFF
--- a/internal/bridge/actions.go
+++ b/internal/bridge/actions.go
@@ -19,6 +19,7 @@ const (
 	ActionHover      = "hover"
 	ActionSelect     = "select"
 	ActionScroll     = "scroll"
+	ActionDrag       = "drag"
 	ActionHumanClick = "humanClick"
 	ActionHumanType  = "humanType"
 )
@@ -126,6 +127,35 @@ func (b *Bridge) InitActionRegistry() {
 			}
 			return map[string]any{"scrolled": true, "y": 800},
 				chromedp.Run(ctx, chromedp.Evaluate("window.scrollBy(0, 800)", nil))
+		},
+		ActionDrag: func(ctx context.Context, req ActionRequest) (map[string]any, error) {
+			if req.DragX == 0 && req.DragY == 0 {
+				return nil, fmt.Errorf("dragX or dragY required for drag")
+			}
+			if req.NodeID > 0 {
+				err := DragByNodeID(ctx, req.NodeID, req.DragX, req.DragY)
+				if err != nil {
+					return nil, err
+				}
+				return map[string]any{"dragged": true, "dragX": req.DragX, "dragY": req.DragY}, nil
+			}
+			if req.Selector != "" {
+				var nodes []*cdp.Node
+				if err := chromedp.Run(ctx,
+					chromedp.Nodes(req.Selector, &nodes, chromedp.ByQuery),
+				); err != nil {
+					return nil, err
+				}
+				if len(nodes) == 0 {
+					return nil, fmt.Errorf("element not found: %s", req.Selector)
+				}
+				err := DragByNodeID(ctx, int64(nodes[0].BackendNodeID), req.DragX, req.DragY)
+				if err != nil {
+					return nil, err
+				}
+				return map[string]any{"dragged": true, "dragX": req.DragX, "dragY": req.DragY}, nil
+			}
+			return nil, fmt.Errorf("need selector, ref, or nodeId")
 		},
 		ActionHumanClick: func(ctx context.Context, req ActionRequest) (map[string]any, error) {
 			if req.NodeID > 0 {

--- a/internal/bridge/bridge.go
+++ b/internal/bridge/bridge.go
@@ -210,6 +210,8 @@ type ActionRequest struct {
 	NodeID   int64  `json:"nodeId"`
 	ScrollX  int    `json:"scrollX"`
 	ScrollY  int    `json:"scrollY"`
+	DragX    int    `json:"dragX"`
+	DragY    int    `json:"dragY"`
 	WaitNav  bool   `json:"waitNav"`
 	Fast     bool   `json:"fast"`
 	Owner    string `json:"owner"`

--- a/internal/bridge/cdp.go
+++ b/internal/bridge/cdp.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/chromedp/cdproto/network"
@@ -197,6 +198,71 @@ func getElementCenterJS(ctx context.Context, backendNodeID int64) (float64, floa
 	}
 
 	return callRes.Result.Value.X, callRes.Result.Value.Y, nil
+}
+
+// DragByNodeID drags an element by (dx, dy) pixels using mousePressed → mouseMoved → mouseReleased.
+func DragByNodeID(ctx context.Context, nodeID int64, dx, dy int) error {
+	x, y, err := getElementCenter(ctx, nodeID)
+	if err != nil {
+		return err
+	}
+
+	endX := x + float64(dx)
+	endY := y + float64(dy)
+
+	// Number of intermediate mouseMoved events — proportional to distance,
+	// clamped to [5, 40] to keep the drag smooth without flooding CDP.
+	dist := math.Sqrt(float64(dx*dx + dy*dy))
+	steps := int(dist / 10)
+	if steps < 5 {
+		steps = 5
+	}
+	if steps > 40 {
+		steps = 40
+	}
+
+	return chromedp.Run(ctx,
+		chromedp.ActionFunc(func(ctx context.Context) error {
+			return chromedp.FromContext(ctx).Target.Execute(ctx, "DOM.scrollIntoViewIfNeeded", map[string]any{"backendNodeId": nodeID}, nil)
+		}),
+		chromedp.ActionFunc(func(ctx context.Context) error {
+			return chromedp.FromContext(ctx).Target.Execute(ctx, "Input.dispatchMouseEvent", map[string]any{
+				"type": "mouseMoved",
+				"x":    x, "y": y,
+			}, nil)
+		}),
+		chromedp.ActionFunc(func(ctx context.Context) error {
+			return chromedp.FromContext(ctx).Target.Execute(ctx, "Input.dispatchMouseEvent", map[string]any{
+				"type":       "mousePressed",
+				"button":     "left",
+				"clickCount": 1,
+				"x":          x, "y": y,
+			}, nil)
+		}),
+		chromedp.ActionFunc(func(ctx context.Context) error {
+			for i := 1; i <= steps; i++ {
+				t := float64(i) / float64(steps)
+				mx := x + t*float64(dx)
+				my := y + t*float64(dy)
+				if err := chromedp.FromContext(ctx).Target.Execute(ctx, "Input.dispatchMouseEvent", map[string]any{
+					"type":    "mouseMoved",
+					"buttons": 1,
+					"x":       mx, "y": my,
+				}, nil); err != nil {
+					return err
+				}
+			}
+			return nil
+		}),
+		chromedp.ActionFunc(func(ctx context.Context) error {
+			return chromedp.FromContext(ctx).Target.Execute(ctx, "Input.dispatchMouseEvent", map[string]any{
+				"type":       "mouseReleased",
+				"button":     "left",
+				"clickCount": 1,
+				"x":          endX, "y": endY,
+			}, nil)
+		}),
+	)
 }
 
 // namedKeyDefs maps friendly key names (as accepted by the CLI "press" command)


### PR DESCRIPTION
## Summary

- Adds a new `drag` action kind that performs mouse drag gestures (mousedown → mousemove series → mouseup)
- Covers sliders, drag-and-drop reordering, range inputs, canvas drawing, and swipe-like interactions
- Supports `ref`, `nodeId`, and CSS `selector` targeting
- Intermediate `mouseMoved` events include `buttons: 1` so pages detect an active drag

## Usage

```bash
# Drag a slider handle 200px to the right
curl -X POST http://localhost:9867/action \
  -d '{"kind":"drag", "ref":"[5]", "dragX":200, "dragY":0}'

# Drag by CSS selector
curl -X POST http://localhost:9867/action \
  -d '{"kind":"drag", "selector":".slider-thumb", "dragX":100, "dragY":0}'

# Vertical drag (reorder list item down)
curl -X POST http://localhost:9867/action \
  -d '{"kind":"drag", "nodeId":42, "dragX":0, "dragY":150}'
```

## Implementation

Three files changed, 98 lines added:

- **`internal/bridge/bridge.go`** — `DragX`/`DragY` fields on `ActionRequest`
- **`internal/bridge/cdp.go`** — `DragByNodeID()` function: scrolls element into view, dispatches CDP mouse events with distance-proportional step count (clamped to [5, 40])
- **`internal/bridge/actions.go`** — `ActionDrag` constant + handler with nodeId/selector support

Follows existing patterns from `ClickByNodeID`, `HoverByNodeID`, and `ActionHumanClick`.

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test ./...` — all tests pass
- [ ] Manual: drag an `<input type="range">` slider
- [ ] Manual: drag-and-drop reorder in a sortable list
- [ ] Verify semantic synonym mapping (`"drag" → {"move", "reorder"}`) works with the new action

🤖 Generated with [Claude Code](https://claude.com/claude-code)