### PR TITLE
Added the io package to reuse http clients for http pooling

### DIFF
--- a/internal/orchestrator/proxy.go
+++ b/internal/orchestrator/proxy.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -130,7 +131,7 @@ func (o *Orchestrator) proxyToURL(w http.ResponseWriter, r *http.Request, target
 	}
 
 	w.WriteHeader(resp.StatusCode)
-	_, _ = w.Write(readResponseBody(resp))
+	_, _ = io.Copy(w, resp.Body)
 }
 
 // findRunningInstanceByTabID finds the instance that owns the given tab.
@@ -179,24 +180,6 @@ func (o *Orchestrator) handleProxyScreencast(w http.ResponseWriter, r *http.Requ
 
 	// Use WebSocket proxy for proper upgrade
 	handlers.ProxyWebSocket(w, r, targetURL)
-}
-
-func readResponseBody(resp *http.Response) []byte {
-	if resp.Body == nil {
-		return []byte{}
-	}
-	body := make([]byte, 0)
-	buf := make([]byte, 4096)
-	for {
-		n, err := resp.Body.Read(buf)
-		if n > 0 {
-			body = append(body, buf[:n]...)
-		}
-		if err != nil {
-			break
-		}
-	}
-	return body
 }
 
 // classifyLaunchError returns appropriate HTTP status code for launch errors.


### PR DESCRIPTION
## What Changed?

- Added io import
- Changed proxy response from buffered to streaming
- removed manual buffering helper

## Why?

- Lower memory usage per proxied request.
- Fewer allocations and less copy overhead.
- Faster first-byte delivery for larger responses.
- Behavior and status/header forwarding remain the same.

## Testing

-Command run: /usr/local/go/bin/go test internal.
- Command run: /usr/local/go/bin/go test Dev.

## Checklist
Partial compliance

**Automated (CI enforces):**
- [ ] gofmt + golangci-lint passes
- [ ] All tests pass
- [ ] Build succeeds

**Manual:**
- [ ] Error handling explicit (wrapped with `%w`)
- [ ] No regressions in stealth/performance/persistence
- [ ] README/CHANGELOG updated (if user-facing)
- [ ] npm install works (if npm changes)

## Impact
Expected performance improvement
---
