### PR TITLE
fix: update main and types entry paths in package.json

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -2,8 +2,8 @@
   "name": "pinchtab",
   "version": "0.7.6",
   "description": "Browser control API for AI agents",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
   "bin": {
     "pinchtab": "bin/pinchtab"
   },


### PR DESCRIPTION
The current `package.json` points to `dist/index.js` and `dist/index.d.ts`, but the actual build output is generated inside the `dist/src/` directory. 

This PR updates the `main` and `types` fields to reflect the correct paths, ensuring the package resolves properly for users after installation.