### PR TITLE
feat: Lightpanda engine with persistent CDP connection

### DIFF
--- a/cmd/pinchtab/cmd_bridge.go
+++ b/cmd/pinchtab/cmd_bridge.go
@@ -37,12 +37,26 @@ func runBridgeServer(cfg *config.RuntimeConfig) {
 	// Register all bridge handlers
 	h := handlers.New(bridgeInstance, cfg, nil, nil, nil)
 
-	// Wire engine router if mode is "lite" or "auto".
+	// Wire engine router for alternative engine modes.
 	mode := engine.Mode(cfg.Engine)
-	if mode == engine.ModeLite || mode == engine.ModeAuto {
+	switch mode {
+	case engine.ModeLite, engine.ModeAuto:
 		lite := engine.NewLiteEngine()
 		h.Router = engine.NewRouter(mode, lite)
 		slog.Info("engine router enabled", "mode", cfg.Engine, "rules", h.Router.Rules())
+	case engine.ModeLightpanda:
+		lpURL := cfg.LightpandaURL
+		if lpURL == "" {
+			lpURL = "ws://127.0.0.1:9222"
+		}
+		lp, err := engine.NewLightpandaEngine(lpURL)
+		if err != nil {
+			slog.Error("failed to create lightpanda engine", "err", err)
+			os.Exit(1)
+		}
+		h.Router = engine.NewRouter(mode, nil)
+		h.Router.RegisterEngine(lp)
+		slog.Info("engine router enabled", "mode", cfg.Engine, "url", lpURL, "rules", h.Router.Rules())
 	}
 
 	shutdownOnce := &sync.Once{}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -75,8 +75,12 @@ type RuntimeConfig struct {
 	// IDPI (Indirect Prompt Injection defense) settings
 	IDPI IDPIConfig
 
-	// Engine mode: "chrome" (default), "lite", or "auto"
+	// Engine mode: "chrome" (default), "lite", "lightpanda", or "auto"
 	Engine string
+
+	// LightpandaURL is the WebSocket URL for a running Lightpanda CDP server.
+	// Only used when Engine == "lightpanda". Defaults to "ws://127.0.0.1:9222".
+	LightpandaURL string
 
 	// Scheduler settings (dashboard mode only)
 	Scheduler SchedulerConfig
@@ -583,7 +587,8 @@ func Load() *RuntimeConfig {
 		},
 
 		// Engine default
-		Engine: envOr("PINCHTAB_ENGINE", "chrome"),
+		Engine:        envOr("PINCHTAB_ENGINE", "chrome"),
+		LightpandaURL: envOr("PINCHTAB_LIGHTPANDA_URL", ""),
 	}
 	finalizeProfileConfig(cfg)
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -27,18 +27,20 @@ const (
 type Mode string
 
 const (
-	ModeChrome Mode = "chrome" // always Chrome (default)
-	ModeLite   Mode = "lite"   // always lite (screenshot/pdf return 501)
-	ModeAuto   Mode = "auto"   // per-request routing via rules
+	ModeChrome     Mode = "chrome"     // always Chrome (default)
+	ModeLite       Mode = "lite"       // always lite (screenshot/pdf return 501)
+	ModeLightpanda Mode = "lightpanda" // Lightpanda CDP engine
+	ModeAuto       Mode = "auto"       // per-request routing via rules
 )
 
 // Decision is the routing verdict returned by a RouteRule.
 type Decision int
 
 const (
-	Undecided Decision = iota // rule has no opinion
-	UseLite                   // route to Gost-DOM
-	UseChrome                 // route to Chrome
+	Undecided     Decision = iota // rule has no opinion
+	UseLite                       // route to Gost-DOM
+	UseChrome                     // route to Chrome
+	UseLightpanda                 // route to Lightpanda
 )
 
 // NavigateResult is the response from a navigation.

--- a/internal/engine/engine_benchmark_test.go
+++ b/internal/engine/engine_benchmark_test.go
@@ -1,0 +1,1092 @@
+package engine
+
+// engine_benchmark_test.go — Cross-engine benchmark study
+//
+// Compares Lite (Gost-DOM), Lightpanda (CDP), and Chrome (CDP) engines
+// across representative page types. Measures navigate+snapshot latency,
+// snapshot node count, and estimated token cost.
+//
+// Run with local Lite engine only (always available):
+//   go test ./internal/engine/ -run TestEngineBenchmark -v
+//
+// Include Lightpanda (requires lightpanda serve on :9222):
+//   LIGHTPANDA_URL=ws://127.0.0.1:9222 go test ./internal/engine/ -run TestEngineBenchmark -v
+//
+// Include Chrome (requires PINCHTAB_CHROME_PATH or chrome in PATH):
+//   CHROME_BENCH=1 go test ./internal/engine/ -run TestEngineBenchmark -v
+//
+// All three:
+//   LIGHTPANDA_URL=ws://127.0.0.1:9222 CHROME_BENCH=1 go test ./internal/engine/ -run TestEngineBenchmark -v
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+)
+
+// -----------------------------------------------------------------------
+// Test pages — representative of real-world agent targets
+// -----------------------------------------------------------------------
+
+type benchPage struct {
+	name string
+	html string
+}
+
+func benchPages() []benchPage {
+	return []benchPage{
+		{"static-article", staticArticlePage},
+		{"form-heavy", benchFormHeavyPage},
+		{"deep-nesting", deepNestingPage},
+		{"large-dom", generateLargeDOMPage(500)},
+		{"spa-shell", spaShellPage},
+		{"data-table", dataTablePage},
+		{"dashboard", dashboardPage},
+		{"ecommerce", ecommercePage},
+	}
+}
+
+// -----------------------------------------------------------------------
+// Benchmark result tracking
+// -----------------------------------------------------------------------
+
+type benchResult struct {
+	engine     string
+	page       string
+	navigateNs int64
+	snapshotNs int64
+	totalNs    int64
+	nodeCount  int
+	interCount int
+	estTokens  int // estimated LLM tokens for snapshot
+	textLen    int
+	err        string
+}
+
+// estimateTokens returns a rough token count for a snapshot.
+// ~4 chars per token is the standard approximation.
+func estimateTokens(nodes []SnapshotNode) int {
+	total := 0
+	for _, n := range nodes {
+		// ref + role + name + value + structural overhead
+		total += len(n.Ref) + len(n.Role) + len(n.Name) + len(n.Value) + 20
+	}
+	return total / 4
+}
+
+// -----------------------------------------------------------------------
+// Engine providers
+// -----------------------------------------------------------------------
+
+type engineProvider struct {
+	name    string
+	create  func(t *testing.T) Engine
+	cleanup func()
+}
+
+func availableEngines(t *testing.T) []engineProvider {
+	t.Helper()
+	var engines []engineProvider
+
+	// Lite is always available — no external dependencies.
+	engines = append(engines, engineProvider{
+		name:   "lite",
+		create: func(t *testing.T) Engine { return NewLiteEngine() },
+	})
+
+	// Lightpanda if LIGHTPANDA_URL is set.
+	if lpURL := os.Getenv("LIGHTPANDA_URL"); lpURL != "" {
+		engines = append(engines, engineProvider{
+			name: "lightpanda",
+			create: func(t *testing.T) Engine {
+				lp, err := NewLightpandaEngine(lpURL)
+				if err != nil {
+					t.Skipf("lightpanda engine unavailable: %v", err)
+					return nil
+				}
+				return lp
+			},
+		})
+	}
+
+	// Chrome if CHROME_BENCH=1.
+	if os.Getenv("CHROME_BENCH") == "1" {
+		engines = append(engines, engineProvider{
+			name: "chrome-via-lite",
+			create: func(t *testing.T) Engine {
+				t.Skip("chrome benchmark requires manual setup — use integration tests")
+				return nil
+			},
+		})
+	}
+
+	return engines
+}
+
+// -----------------------------------------------------------------------
+// Main benchmark
+// -----------------------------------------------------------------------
+
+func TestEngineBenchmark(t *testing.T) {
+	pages := benchPages()
+	engines := availableEngines(t)
+
+	if len(engines) == 0 {
+		t.Skip("no engines available")
+	}
+
+	var results []benchResult
+
+	for _, ep := range engines {
+		t.Run(ep.name, func(t *testing.T) {
+			for _, page := range pages {
+				t.Run(page.name, func(t *testing.T) {
+					ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						w.Header().Set("Content-Type", "text/html; charset=utf-8")
+						_, _ = w.Write([]byte(page.html))
+					}))
+					defer ts.Close()
+
+					eng := ep.create(t)
+					if eng == nil {
+						return
+					}
+					defer func() { _ = eng.Close() }()
+
+					ctx := context.Background()
+					br := benchResult{engine: ep.name, page: page.name}
+
+					// Navigate
+					navStart := time.Now()
+					_, err := eng.Navigate(ctx, ts.URL)
+					br.navigateNs = time.Since(navStart).Nanoseconds()
+					if err != nil {
+						br.err = err.Error()
+						results = append(results, br)
+						t.Logf("navigate error: %v", err)
+						return
+					}
+
+					// Snapshot (all nodes)
+					snapStart := time.Now()
+					nodes, err := eng.Snapshot(ctx, "")
+					br.snapshotNs = time.Since(snapStart).Nanoseconds()
+					if err != nil {
+						br.err = err.Error()
+						results = append(results, br)
+						t.Logf("snapshot error: %v", err)
+						return
+					}
+					br.nodeCount = len(nodes)
+					br.estTokens = estimateTokens(nodes)
+
+					// Interactive count
+					interNodes, _ := eng.Snapshot(ctx, "interactive")
+					br.interCount = len(interNodes)
+
+					// Text
+					text, _ := eng.Text(ctx)
+					br.textLen = len(text)
+
+					br.totalNs = br.navigateNs + br.snapshotNs
+
+					results = append(results, br)
+
+					t.Logf("nav=%s snap=%s total=%s nodes=%d interactive=%d tokens≈%d text=%d",
+						fmtDuration(br.navigateNs),
+						fmtDuration(br.snapshotNs),
+						fmtDuration(br.totalNs),
+						br.nodeCount, br.interCount, br.estTokens, br.textLen)
+				})
+			}
+		})
+	}
+
+	// Print summary table.
+	if len(results) > 0 {
+		printBenchSummary(t, results)
+	}
+}
+
+// TestEngineBenchmark_SnapshotLatency is a Go benchmark (testing.B) for
+// hot-path snapshot latency after navigation.
+func TestEngineBenchmark_SnapshotLatency(t *testing.T) {
+	pages := benchPages()
+
+	for _, page := range pages[:3] { // first 3 pages for quick iteration
+		t.Run(page.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/html; charset=utf-8")
+				_, _ = w.Write([]byte(page.html))
+			}))
+			defer ts.Close()
+
+			lite := NewLiteEngine()
+			defer func() { _ = lite.Close() }()
+
+			ctx := context.Background()
+			_, err := lite.Navigate(ctx, ts.URL)
+			if err != nil {
+				t.Fatalf("navigate: %v", err)
+			}
+
+			// Warm up
+			_, _ = lite.Snapshot(ctx, "")
+
+			const iterations = 100
+			start := time.Now()
+			for i := 0; i < iterations; i++ {
+				_, _ = lite.Snapshot(ctx, "")
+			}
+			elapsed := time.Since(start)
+
+			t.Logf("%d snapshots in %s (avg %s/op)",
+				iterations, elapsed, fmtDuration(elapsed.Nanoseconds()/int64(iterations)))
+		})
+	}
+}
+
+// TestEngineBenchmark_NavigateLatency measures cold-start navigate across
+// different page sizes.
+func TestEngineBenchmark_NavigateLatency(t *testing.T) {
+	sizes := []struct {
+		name  string
+		elems int
+	}{
+		{"tiny-10", 10},
+		{"small-50", 50},
+		{"medium-200", 200},
+		{"large-500", 500},
+		{"xlarge-1000", 1000},
+	}
+
+	for _, sz := range sizes {
+		t.Run(sz.name, func(t *testing.T) {
+			page := generateLargeDOMPage(sz.elems)
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/html; charset=utf-8")
+				_, _ = w.Write([]byte(page))
+			}))
+			defer ts.Close()
+
+			const iterations = 20
+			var totalNav, totalSnap int64
+
+			for i := 0; i < iterations; i++ {
+				lite := NewLiteEngine()
+				ctx := context.Background()
+
+				navStart := time.Now()
+				_, err := lite.Navigate(ctx, ts.URL)
+				navElapsed := time.Since(navStart).Nanoseconds()
+				if err != nil {
+					_ = lite.Close()
+					t.Fatalf("navigate: %v", err)
+				}
+				totalNav += navElapsed
+
+				snapStart := time.Now()
+				nodes, _ := lite.Snapshot(ctx, "")
+				totalSnap += time.Since(snapStart).Nanoseconds()
+
+				_ = lite.Close()
+
+				if i == 0 {
+					t.Logf("page: %d elements, %d snapshot nodes, %d bytes HTML",
+						sz.elems, len(nodes), len(page))
+				}
+			}
+
+			t.Logf("avg navigate=%s snapshot=%s total=%s (%d iterations)",
+				fmtDuration(totalNav/int64(iterations)),
+				fmtDuration(totalSnap/int64(iterations)),
+				fmtDuration((totalNav+totalSnap)/int64(iterations)),
+				iterations)
+		})
+	}
+}
+
+// TestEngineBenchmark_TokenEfficiency measures how many tokens each engine
+// produces per interactive element — the key metric for LLM agent cost.
+func TestEngineBenchmark_TokenEfficiency(t *testing.T) {
+	pages := benchPages()
+
+	type tokenResult struct {
+		page           string
+		totalNodes     int
+		interNodes     int
+		totalTokens    int
+		interTokens    int
+		tokensPerInter float64
+	}
+
+	var results []tokenResult
+
+	for _, page := range pages {
+		t.Run(page.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/html; charset=utf-8")
+				_, _ = w.Write([]byte(page.html))
+			}))
+			defer ts.Close()
+
+			lite := NewLiteEngine()
+			defer func() { _ = lite.Close() }()
+
+			ctx := context.Background()
+			_, err := lite.Navigate(ctx, ts.URL)
+			if err != nil {
+				t.Fatalf("navigate: %v", err)
+			}
+
+			allNodes, _ := lite.Snapshot(ctx, "")
+			interNodes, _ := lite.Snapshot(ctx, "interactive")
+
+			totalTok := estimateTokens(allNodes)
+			interTok := estimateTokens(interNodes)
+
+			var tpi float64
+			if len(interNodes) > 0 {
+				tpi = float64(interTok) / float64(len(interNodes))
+			}
+
+			tr := tokenResult{
+				page:           page.name,
+				totalNodes:     len(allNodes),
+				interNodes:     len(interNodes),
+				totalTokens:    totalTok,
+				interTokens:    interTok,
+				tokensPerInter: tpi,
+			}
+			results = append(results, tr)
+
+			// Also measure raw JSON size for comparison.
+			allJSON, _ := json.Marshal(allNodes)
+			interJSON, _ := json.Marshal(interNodes)
+
+			t.Logf("nodes: %d total / %d interactive", len(allNodes), len(interNodes))
+			t.Logf("tokens: %d total / %d interactive (%.1f per interactive elem)",
+				totalTok, interTok, tpi)
+			t.Logf("json: %d bytes total / %d bytes interactive",
+				len(allJSON), len(interJSON))
+		})
+	}
+
+	if len(results) > 0 {
+		t.Log("\n=== Token Efficiency Summary ===")
+		t.Logf("%-20s %8s %8s %8s %8s %10s", "Page", "Nodes", "Inter", "Tokens", "IntTok", "Tok/Inter")
+		t.Logf("%-20s %8s %8s %8s %8s %10s", "----", "-----", "-----", "------", "------", "---------")
+		for _, r := range results {
+			t.Logf("%-20s %8d %8d %8d %8d %10.1f",
+				r.page, r.totalNodes, r.interNodes, r.totalTokens, r.interTokens, r.tokensPerInter)
+		}
+	}
+}
+
+// -----------------------------------------------------------------------
+// Output formatting
+// -----------------------------------------------------------------------
+
+func printBenchSummary(t *testing.T, results []benchResult) {
+	t.Helper()
+
+	// Group by engine and build lookup.
+	byEngine := make(map[string][]benchResult)
+	enginePageMap := make(map[string]map[string]benchResult)
+	for _, r := range results {
+		byEngine[r.engine] = append(byEngine[r.engine], r)
+		if enginePageMap[r.engine] == nil {
+			enginePageMap[r.engine] = make(map[string]benchResult)
+		}
+		enginePageMap[r.engine][r.page] = r
+	}
+
+	var engineNames []string
+	for name := range byEngine {
+		engineNames = append(engineNames, name)
+	}
+	sort.Strings(engineNames)
+
+	// Collect ordered page list from first engine.
+	var pages []string
+	for _, r := range byEngine[engineNames[0]] {
+		pages = append(pages, r.page)
+	}
+
+	// ── Table 1: Per-Page Response Times ──
+	// Matches #201 format: | Page | Category | Engine1 Nav | Engine2 Nav | ... |
+	t.Log("")
+	t.Log("### Per-Page Response Times")
+	t.Log("")
+
+	// Build header.
+	header := "| Page | Category"
+	sep := "|------|----------"
+	for _, e := range engineNames {
+		header += fmt.Sprintf(" | %s Nav | %s Snap", e, e)
+		sep += "|:--------:|:---------:"
+	}
+	header += " |"
+	sep += "|"
+	t.Log(header)
+	t.Log(sep)
+
+	for _, pg := range pages {
+		cat := pageCategory(pg)
+		line := fmt.Sprintf("| %s | %s", pg, cat)
+		for _, e := range engineNames {
+			r, ok := enginePageMap[e][pg]
+			if !ok || r.err != "" {
+				line += " | FAIL | —"
+			} else {
+				line += fmt.Sprintf(" | %s | %s", fmtDuration(r.navigateNs), fmtDuration(r.snapshotNs))
+			}
+		}
+		line += " |"
+		t.Log(line)
+	}
+
+	// ── Table 2: Aggregate Totals ──
+	t.Log("")
+	t.Log("### Aggregate Totals")
+	t.Log("")
+
+	header2 := "| Metric"
+	sep2 := "|--------"
+	for _, e := range engineNames {
+		header2 += fmt.Sprintf(" | %s", e)
+		sep2 += "|----------:"
+	}
+	header2 += " |"
+	sep2 += "|"
+	t.Log(header2)
+	t.Log(sep2)
+
+	for _, metric := range []string{"Navigate Total", "Snapshot Total", "**Grand Total**"} {
+		line := fmt.Sprintf("| %s", metric)
+		for _, e := range engineNames {
+			var total int64
+			ok := 0
+			for _, r := range byEngine[e] {
+				if r.err != "" {
+					continue
+				}
+				ok++
+				switch metric {
+				case "Navigate Total":
+					total += r.navigateNs
+				case "Snapshot Total":
+					total += r.snapshotNs
+				default:
+					total += r.totalNs
+				}
+			}
+			if ok == 0 {
+				line += " | —"
+			} else {
+				line += fmt.Sprintf(" | %s", fmtDuration(total))
+			}
+		}
+		line += " |"
+		t.Log(line)
+	}
+
+	// ── Table 3: Per-Page Winners ──
+	if len(engineNames) > 1 {
+		t.Log("")
+		t.Log("### Per-Page Winners")
+		t.Log("")
+		t.Log("| Page | Winner | Why |")
+		t.Log("|------|--------|-----|")
+
+		for _, pg := range pages {
+			bestEngine := ""
+			var bestTime int64 = 1<<62 - 1
+			for _, e := range engineNames {
+				r, ok := enginePageMap[e][pg]
+				if !ok || r.err != "" {
+					continue
+				}
+				if r.totalNs < bestTime {
+					bestTime = r.totalNs
+					bestEngine = e
+				}
+			}
+			if bestEngine == "" {
+				t.Logf("| %s | — | All engines failed |", pg)
+			} else {
+				r := enginePageMap[bestEngine][pg]
+				t.Logf("| %s | **%s** (%s) | %d nodes, ~%d tokens |",
+					pg, bestEngine, fmtDuration(r.totalNs), r.nodeCount, r.estTokens)
+			}
+		}
+	}
+
+	// ── Table 4: Token Efficiency (always useful) ──
+	t.Log("")
+	t.Log("### Token Efficiency")
+	t.Log("")
+	t.Log("| Page | Nodes | Interactive | ~Tokens | Tok/Interactive |")
+	t.Log("|------|------:|------------:|--------:|----------------:|")
+
+	// Use first engine for token counts (all engines see the same HTML).
+	for _, pg := range pages {
+		r, ok := enginePageMap[engineNames[0]][pg]
+		if !ok || r.err != "" {
+			continue
+		}
+		var tpi float64
+		if r.interCount > 0 {
+			tpi = float64(r.estTokens) / float64(r.interCount)
+		}
+		t.Logf("| %s | %d | %d | %d | %.1f |",
+			pg, r.nodeCount, r.interCount, r.estTokens, tpi)
+	}
+}
+
+func pageCategory(name string) string {
+	switch name {
+	case "static-article":
+		return "Content"
+	case "form-heavy":
+		return "Forms"
+	case "deep-nesting":
+		return "Navigation"
+	case "large-dom":
+		return "Stress"
+	case "spa-shell":
+		return "SPA"
+	case "data-table":
+		return "Data"
+	case "dashboard":
+		return "Dashboard"
+	case "ecommerce":
+		return "E-commerce"
+	default:
+		return "Other"
+	}
+}
+
+func fmtDuration(ns int64) string {
+	d := time.Duration(ns)
+	switch {
+	case d < time.Microsecond:
+		return fmt.Sprintf("%dns", ns)
+	case d < time.Millisecond:
+		return fmt.Sprintf("%.1fµs", float64(ns)/1000)
+	case d < time.Second:
+		return fmt.Sprintf("%.1fms", float64(ns)/1e6)
+	default:
+		return fmt.Sprintf("%.2fs", float64(ns)/1e9)
+	}
+}
+
+// -----------------------------------------------------------------------
+// Test pages — HTML content
+// -----------------------------------------------------------------------
+
+const staticArticlePage = `<!DOCTYPE html>
+<html lang="en">
+<head><title>Understanding Neural Networks</title></head>
+<body>
+<header><nav aria-label="Main">
+  <a href="/">Home</a>
+  <a href="/articles">Articles</a>
+  <a href="/about">About</a>
+  <a href="/contact">Contact</a>
+</nav></header>
+<main>
+  <article>
+    <h1>Understanding Neural Networks</h1>
+    <p>Published: March 2026 | Author: Dr. Smith</p>
+    <h2>Introduction</h2>
+    <p>Neural networks are computational models inspired by the human brain.
+       They consist of interconnected nodes organized in layers that process
+       information using connectionist approaches to computation.</p>
+    <h2>Architecture</h2>
+    <p>A typical neural network consists of an input layer, one or more hidden
+       layers, and an output layer. Each connection between neurons has an
+       associated weight that is adjusted during training.</p>
+    <figure>
+      <img src="/nn-diagram.png" alt="Neural network architecture diagram showing layers">
+    </figure>
+    <h2>Training Process</h2>
+    <p>Training involves forward propagation, loss calculation, and
+       backpropagation. The network adjusts its weights to minimize the
+       difference between predicted and actual outputs.</p>
+    <blockquote>The key insight is that gradient descent on differentiable
+       functions allows us to optimize complex models end-to-end.</blockquote>
+    <h2>Applications</h2>
+    <ul>
+      <li>Computer vision and image recognition</li>
+      <li>Natural language processing</li>
+      <li>Speech recognition and synthesis</li>
+      <li>Autonomous vehicles</li>
+      <li>Drug discovery</li>
+    </ul>
+    <h2>Further Reading</h2>
+    <p>For more information, see our <a href="/deep-learning">deep learning guide</a>
+       or <a href="/resources">resources page</a>.</p>
+  </article>
+</main>
+<footer><p>© 2026 Tech Blog</p></footer>
+</body>
+</html>`
+
+const benchFormHeavyPage = `<!DOCTYPE html>
+<html lang="en">
+<head><title>Patient Registration</title></head>
+<body>
+<main>
+  <h1>Patient Registration Form</h1>
+  <form action="/register" method="post">
+    <fieldset>
+      <legend>Personal Information</legend>
+      <label for="fname">First Name</label>
+      <input type="text" id="fname" name="fname" placeholder="John" required>
+      <label for="lname">Last Name</label>
+      <input type="text" id="lname" name="lname" placeholder="Doe" required>
+      <label for="dob">Date of Birth</label>
+      <input type="date" id="dob" name="dob" required>
+      <label for="gender">Gender</label>
+      <select id="gender" name="gender">
+        <option value="">Select...</option>
+        <option value="m">Male</option>
+        <option value="f">Female</option>
+        <option value="o">Other</option>
+        <option value="na">Prefer not to say</option>
+      </select>
+      <label for="email">Email</label>
+      <input type="email" id="email" name="email" placeholder="john@example.com">
+      <label for="phone">Phone</label>
+      <input type="tel" id="phone" name="phone" placeholder="+1 555-0100">
+    </fieldset>
+    <fieldset>
+      <legend>Address</legend>
+      <label for="addr1">Street Address</label>
+      <input type="text" id="addr1" name="addr1" placeholder="123 Main St">
+      <label for="addr2">Apt/Suite</label>
+      <input type="text" id="addr2" name="addr2" placeholder="Apt 4B">
+      <label for="city">City</label>
+      <input type="text" id="city" name="city" placeholder="Springfield">
+      <label for="state">State</label>
+      <select id="state" name="state">
+        <option value="">Select state...</option>
+        <option value="CA">California</option>
+        <option value="NY">New York</option>
+        <option value="TX">Texas</option>
+        <option value="FL">Florida</option>
+      </select>
+      <label for="zip">ZIP Code</label>
+      <input type="text" id="zip" name="zip" placeholder="62701" pattern="[0-9]{5}">
+    </fieldset>
+    <fieldset>
+      <legend>Insurance</legend>
+      <label for="provider">Insurance Provider</label>
+      <input type="text" id="provider" name="provider">
+      <label for="policy">Policy Number</label>
+      <input type="text" id="policy" name="policy">
+      <label for="group">Group Number</label>
+      <input type="text" id="group" name="group">
+    </fieldset>
+    <fieldset>
+      <legend>Medical History</legend>
+      <label>Do you have any allergies?</label>
+      <input type="radio" id="allergy-yes" name="allergies" value="yes"><label for="allergy-yes">Yes</label>
+      <input type="radio" id="allergy-no" name="allergies" value="no"><label for="allergy-no">No</label>
+      <label for="allergy-details">If yes, please list</label>
+      <textarea id="allergy-details" name="allergy-details" rows="3" placeholder="List allergies..."></textarea>
+      <label><input type="checkbox" name="conditions[]" value="diabetes"> Diabetes</label>
+      <label><input type="checkbox" name="conditions[]" value="hypertension"> Hypertension</label>
+      <label><input type="checkbox" name="conditions[]" value="asthma"> Asthma</label>
+      <label><input type="checkbox" name="conditions[]" value="heart"> Heart Disease</label>
+    </fieldset>
+    <fieldset>
+      <legend>Consent</legend>
+      <label><input type="checkbox" name="consent" required> I agree to the terms and conditions</label>
+      <label><input type="checkbox" name="hipaa" required> I acknowledge the HIPAA notice</label>
+    </fieldset>
+    <button type="submit">Register Patient</button>
+    <button type="reset">Clear Form</button>
+  </form>
+</main>
+</body>
+</html>`
+
+const deepNestingPage = `<!DOCTYPE html>
+<html lang="en">
+<head><title>Project Dashboard</title></head>
+<body>
+<div role="banner">
+  <nav aria-label="Primary">
+    <ul>
+      <li><a href="/dashboard">Dashboard</a></li>
+      <li><a href="/projects">Projects</a>
+        <ul>
+          <li><a href="/projects/active">Active</a></li>
+          <li><a href="/projects/archived">Archived</a>
+            <ul>
+              <li><a href="/projects/archived/2025">2025</a></li>
+              <li><a href="/projects/archived/2024">2024</a></li>
+            </ul>
+          </li>
+        </ul>
+      </li>
+      <li><a href="/team">Team</a></li>
+      <li><a href="/settings">Settings</a></li>
+    </ul>
+  </nav>
+</div>
+<main>
+  <section aria-label="Project Overview">
+    <h1>Project Dashboard</h1>
+    <div>
+      <div>
+        <div>
+          <div>
+            <h2>Sprint 42</h2>
+            <div>
+              <div>
+                <p>Status: <strong>In Progress</strong></p>
+                <div>
+                  <button>Start Sprint</button>
+                  <button>End Sprint</button>
+                  <a href="/sprint/42/board">View Board</a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <section aria-label="Tasks">
+      <h2>Current Tasks</h2>
+      <table>
+        <thead><tr><th>Task</th><th>Assignee</th><th>Status</th><th>Actions</th></tr></thead>
+        <tbody>
+          <tr><td>Fix login bug</td><td>Alice</td><td>In Progress</td><td><button>Edit</button><button>Delete</button></td></tr>
+          <tr><td>Add search feature</td><td>Bob</td><td>To Do</td><td><button>Edit</button><button>Delete</button></td></tr>
+          <tr><td>Update docs</td><td>Carol</td><td>Done</td><td><button>Edit</button><button>Delete</button></td></tr>
+          <tr><td>Performance audit</td><td>Dave</td><td>Blocked</td><td><button>Edit</button><button>Delete</button></td></tr>
+          <tr><td>Accessibility review</td><td>Eve</td><td>To Do</td><td><button>Edit</button><button>Delete</button></td></tr>
+        </tbody>
+      </table>
+    </section>
+  </section>
+</main>
+<footer><p>© 2026 ProjectCo</p></footer>
+</body>
+</html>`
+
+const spaShellPage = `<!DOCTYPE html>
+<html lang="en">
+<head><title>App Dashboard</title></head>
+<body>
+<div id="app">
+  <header>
+    <nav aria-label="Main Navigation">
+      <a href="/" aria-label="Home">Home</a>
+      <a href="/inbox" aria-label="Inbox">Inbox <span aria-label="3 unread">3</span></a>
+      <a href="/analytics" aria-label="Analytics">Analytics</a>
+      <button aria-label="User menu">Profile</button>
+    </nav>
+    <div role="search">
+      <input type="search" placeholder="Search everything..." aria-label="Global search">
+      <button type="submit">Search</button>
+    </div>
+  </header>
+  <aside aria-label="Sidebar">
+    <nav aria-label="Sidebar Navigation">
+      <ul>
+        <li><a href="/inbox/all">All Messages</a></li>
+        <li><a href="/inbox/unread">Unread</a></li>
+        <li><a href="/inbox/starred">Starred</a></li>
+        <li><a href="/inbox/archived">Archived</a></li>
+        <li><a href="/inbox/trash">Trash</a></li>
+      </ul>
+    </nav>
+    <div>
+      <h3>Labels</h3>
+      <ul>
+        <li><a href="/label/work">Work</a></li>
+        <li><a href="/label/personal">Personal</a></li>
+        <li><a href="/label/urgent">Urgent</a></li>
+      </ul>
+      <button>Create Label</button>
+    </div>
+  </aside>
+  <main>
+    <h1>Inbox</h1>
+    <div role="toolbar" aria-label="Message actions">
+      <input type="checkbox" aria-label="Select all">
+      <button>Archive</button>
+      <button>Mark Read</button>
+      <button>Delete</button>
+      <select aria-label="Sort by">
+        <option>Newest</option>
+        <option>Oldest</option>
+        <option>Unread</option>
+      </select>
+    </div>
+    <ul role="list" aria-label="Messages">
+      <li role="listitem"><input type="checkbox" aria-label="Select message"><a href="/msg/1"><strong>Alice:</strong> Project update ready for review</a></li>
+      <li role="listitem"><input type="checkbox" aria-label="Select message"><a href="/msg/2"><strong>Bob:</strong> Deployment scheduled for tonight</a></li>
+      <li role="listitem"><input type="checkbox" aria-label="Select message"><a href="/msg/3"><strong>Carol:</strong> Q4 report attached</a></li>
+      <li role="listitem"><input type="checkbox" aria-label="Select message"><a href="/msg/4"><strong>Dave:</strong> Meeting notes from standup</a></li>
+      <li role="listitem"><input type="checkbox" aria-label="Select message"><a href="/msg/5"><strong>Eve:</strong> Security audit findings</a></li>
+    </ul>
+    <nav aria-label="Pagination">
+      <button disabled>Previous</button>
+      <span>Page 1 of 5</span>
+      <button>Next</button>
+    </nav>
+  </main>
+</div>
+</body>
+</html>`
+
+const dataTablePage = `<!DOCTYPE html>
+<html lang="en">
+<head><title>Server Monitoring</title></head>
+<body>
+<main>
+  <h1>Server Status Dashboard</h1>
+  <div role="toolbar" aria-label="Table controls">
+    <input type="search" placeholder="Filter servers..." aria-label="Filter">
+    <select aria-label="Region filter">
+      <option value="">All Regions</option>
+      <option value="us-east">US East</option>
+      <option value="us-west">US West</option>
+      <option value="eu-west">EU West</option>
+      <option value="ap-south">AP South</option>
+    </select>
+    <button>Refresh</button>
+    <button>Export CSV</button>
+  </div>
+  <table aria-label="Server list">
+    <thead>
+      <tr>
+        <th><input type="checkbox" aria-label="Select all servers"></th>
+        <th><button>Hostname ↕</button></th>
+        <th><button>Region ↕</button></th>
+        <th><button>CPU % ↕</button></th>
+        <th><button>Memory ↕</button></th>
+        <th><button>Status ↕</button></th>
+        <th>Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr><td><input type="checkbox" aria-label="Select web-01"></td><td>web-01</td><td>us-east</td><td>45%</td><td>72%</td><td>Healthy</td><td><button>SSH</button><button>Restart</button><button>Details</button></td></tr>
+      <tr><td><input type="checkbox" aria-label="Select web-02"></td><td>web-02</td><td>us-east</td><td>78%</td><td>85%</td><td>Warning</td><td><button>SSH</button><button>Restart</button><button>Details</button></td></tr>
+      <tr><td><input type="checkbox" aria-label="Select api-01"></td><td>api-01</td><td>us-west</td><td>23%</td><td>41%</td><td>Healthy</td><td><button>SSH</button><button>Restart</button><button>Details</button></td></tr>
+      <tr><td><input type="checkbox" aria-label="Select api-02"></td><td>api-02</td><td>eu-west</td><td>92%</td><td>94%</td><td>Critical</td><td><button>SSH</button><button>Restart</button><button>Details</button></td></tr>
+      <tr><td><input type="checkbox" aria-label="Select db-01"></td><td>db-01</td><td>us-east</td><td>31%</td><td>58%</td><td>Healthy</td><td><button>SSH</button><button>Restart</button><button>Details</button></td></tr>
+      <tr><td><input type="checkbox" aria-label="Select db-02"></td><td>db-02</td><td>ap-south</td><td>55%</td><td>67%</td><td>Healthy</td><td><button>SSH</button><button>Restart</button><button>Details</button></td></tr>
+      <tr><td><input type="checkbox" aria-label="Select cache-01"></td><td>cache-01</td><td>us-east</td><td>12%</td><td>89%</td><td>Warning</td><td><button>SSH</button><button>Restart</button><button>Details</button></td></tr>
+      <tr><td><input type="checkbox" aria-label="Select worker-01"></td><td>worker-01</td><td>us-west</td><td>67%</td><td>52%</td><td>Healthy</td><td><button>SSH</button><button>Restart</button><button>Details</button></td></tr>
+    </tbody>
+  </table>
+  <nav aria-label="Table pagination">
+    <button disabled>« First</button>
+    <button disabled>‹ Prev</button>
+    <span>Showing 1-8 of 24 servers</span>
+    <button>Next ›</button>
+    <button>Last »</button>
+  </nav>
+</main>
+</body>
+</html>`
+
+const dashboardPage = `<!DOCTYPE html>
+<html lang="en">
+<head><title>Analytics Dashboard</title></head>
+<body>
+<header>
+  <nav aria-label="Top navigation">
+    <a href="/">Logo</a>
+    <a href="/dashboard">Dashboard</a>
+    <a href="/reports">Reports</a>
+    <a href="/settings">Settings</a>
+    <button aria-label="Notifications">🔔 5</button>
+    <button aria-label="User account">Account</button>
+  </nav>
+</header>
+<main>
+  <h1>Analytics Dashboard</h1>
+  <div role="toolbar" aria-label="Dashboard controls">
+    <select aria-label="Date range">
+      <option>Last 7 days</option>
+      <option>Last 30 days</option>
+      <option>Last 90 days</option>
+      <option>Custom range</option>
+    </select>
+    <button>Apply Filter</button>
+    <button>Download Report</button>
+  </div>
+  <section aria-label="Key Metrics">
+    <h2>Key Metrics</h2>
+    <div>
+      <div aria-label="Revenue card"><h3>Revenue</h3><p>$142,384</p><p>+12.5% vs last period</p></div>
+      <div aria-label="Users card"><h3>Active Users</h3><p>23,847</p><p>+8.3% vs last period</p></div>
+      <div aria-label="Conversion card"><h3>Conversion Rate</h3><p>3.24%</p><p>-0.5% vs last period</p></div>
+      <div aria-label="Sessions card"><h3>Avg. Session</h3><p>4m 32s</p><p>+15s vs last period</p></div>
+    </div>
+  </section>
+  <section aria-label="Charts">
+    <h2>Traffic Overview</h2>
+    <div aria-label="Traffic chart placeholder">
+      <p>[Chart: Daily traffic for last 30 days]</p>
+    </div>
+    <div role="toolbar" aria-label="Chart controls">
+      <button>Daily</button>
+      <button>Weekly</button>
+      <button>Monthly</button>
+    </div>
+  </section>
+  <section aria-label="Top Pages">
+    <h2>Top Pages</h2>
+    <table>
+      <thead><tr><th>Page</th><th>Views</th><th>Bounce Rate</th><th>Avg Time</th></tr></thead>
+      <tbody>
+        <tr><td>/home</td><td>45,230</td><td>32%</td><td>2m 15s</td></tr>
+        <tr><td>/products</td><td>28,450</td><td>45%</td><td>3m 42s</td></tr>
+        <tr><td>/pricing</td><td>15,820</td><td>28%</td><td>4m 10s</td></tr>
+        <tr><td>/blog</td><td>12,350</td><td>52%</td><td>5m 30s</td></tr>
+        <tr><td>/contact</td><td>8,920</td><td>18%</td><td>1m 45s</td></tr>
+      </tbody>
+    </table>
+  </section>
+</main>
+<footer><p>© 2026 Analytics Corp</p></footer>
+</body>
+</html>`
+
+const ecommercePage = `<!DOCTYPE html>
+<html lang="en">
+<head><title>Wireless Headphones - TechStore</title></head>
+<body>
+<header>
+  <nav aria-label="Store navigation">
+    <a href="/">TechStore</a>
+    <a href="/electronics">Electronics</a>
+    <a href="/audio">Audio</a>
+    <a href="/deals">Deals</a>
+    <input type="search" placeholder="Search products..." aria-label="Search products">
+    <button type="submit">Search</button>
+    <a href="/cart" aria-label="Shopping cart (2 items)">Cart (2)</a>
+    <a href="/account">Sign In</a>
+  </nav>
+</header>
+<nav aria-label="Breadcrumb">
+  <a href="/">Home</a> › <a href="/electronics">Electronics</a> › <a href="/audio">Audio</a> › Headphones
+</nav>
+<main>
+  <article>
+    <h1>Premium Wireless Headphones XR-500</h1>
+    <img src="/headphones.jpg" alt="Premium Wireless Headphones XR-500 in midnight black">
+    <section aria-label="Product details">
+      <p>$299.99 <del>$349.99</del> <span>Save 14%</span></p>
+      <div>
+        <label for="color">Color</label>
+        <select id="color" name="color">
+          <option>Midnight Black</option>
+          <option>Arctic White</option>
+          <option>Navy Blue</option>
+          <option>Rose Gold</option>
+        </select>
+      </div>
+      <div>
+        <label for="qty">Quantity</label>
+        <input type="number" id="qty" name="qty" value="1" min="1" max="10">
+      </div>
+      <button>Add to Cart</button>
+      <button>Buy Now</button>
+      <button aria-label="Add to wishlist">♡ Wishlist</button>
+    </section>
+    <details>
+      <summary>Product Description</summary>
+      <p>Experience premium sound with our XR-500 wireless headphones.
+         Features include 40-hour battery life, active noise cancellation,
+         and premium memory foam ear cushions for all-day comfort.</p>
+      <ul>
+        <li>40-hour battery life</li>
+        <li>Active noise cancellation (ANC)</li>
+        <li>Bluetooth 5.3</li>
+        <li>Hi-Res Audio certified</li>
+        <li>Multipoint connection</li>
+      </ul>
+    </details>
+    <details>
+      <summary>Specifications</summary>
+      <table>
+        <tr><th>Driver Size</th><td>40mm</td></tr>
+        <tr><th>Frequency Response</th><td>4Hz - 40kHz</td></tr>
+        <tr><th>Impedance</th><td>32Ω</td></tr>
+        <tr><th>Weight</th><td>250g</td></tr>
+        <tr><th>Charging</th><td>USB-C, 10min = 5hrs</td></tr>
+      </table>
+    </details>
+    <section aria-label="Customer Reviews">
+      <h2>Customer Reviews</h2>
+      <p>4.7 out of 5 (2,847 reviews)</p>
+      <article>
+        <h3>Best headphones I've owned</h3>
+        <p>★★★★★ by AudioPhile23 on March 1, 2026</p>
+        <p>The noise cancellation is incredible and the battery life is amazing.</p>
+        <button>Helpful (42)</button>
+        <button>Report</button>
+      </article>
+      <article>
+        <h3>Great value for money</h3>
+        <p>★★★★☆ by MusicLover on Feb 28, 2026</p>
+        <p>Sound quality rivals headphones twice the price. Only downside is the carrying case.</p>
+        <button>Helpful (18)</button>
+        <button>Report</button>
+      </article>
+      <a href="/reviews/xr500">See all 2,847 reviews</a>
+    </section>
+  </article>
+</main>
+<footer>
+  <nav aria-label="Footer">
+    <a href="/about">About</a>
+    <a href="/support">Support</a>
+    <a href="/returns">Returns</a>
+    <a href="/privacy">Privacy</a>
+    <a href="/terms">Terms</a>
+  </nav>
+</footer>
+</body>
+</html>`
+
+// generateLargeDOMPage creates a page with N interactive elements.
+func generateLargeDOMPage(n int) string {
+	var b strings.Builder
+	b.WriteString(`<!DOCTYPE html><html><head><title>Large Page</title></head><body>`)
+	b.WriteString(`<main><h1>Large Form</h1><form>`)
+
+	for i := 0; i < n; i++ {
+		switch i % 5 {
+		case 0:
+			fmt.Fprintf(&b, `<div><label for="f%d">Field %d</label><input type="text" id="f%d" placeholder="Value %d"></div>`, i, i, i, i)
+		case 1:
+			fmt.Fprintf(&b, `<button type="button">Action %d</button>`, i)
+		case 2:
+			fmt.Fprintf(&b, `<a href="/page/%d">Link %d</a>`, i, i)
+		case 3:
+			fmt.Fprintf(&b, `<select id="s%d" aria-label="Select %d"><option>A</option><option>B</option></select>`, i, i)
+		case 4:
+			fmt.Fprintf(&b, `<textarea id="t%d" placeholder="Note %d"></textarea>`, i, i)
+		}
+	}
+
+	b.WriteString(`</form></main></body></html>`)
+	return b.String()
+}

--- a/internal/engine/lightpanda.go
+++ b/internal/engine/lightpanda.go
@@ -5,41 +5,37 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log/slog"
 	"sync"
 	"time"
 
-	"github.com/chromedp/cdproto/accessibility"
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/dom"
 	"github.com/chromedp/cdproto/input"
-	cdppage "github.com/chromedp/cdproto/page"
 	"github.com/chromedp/cdproto/runtime"
-	"github.com/chromedp/cdproto/target"
 	"github.com/chromedp/chromedp"
 )
 
 // LightpandaEngine implements Engine using a persistent CDP connection to a
 // Lightpanda browser instance. Unlike the prior prototype that reconnected
-// per-operation (freshContext), this keeps the WebSocket alive across calls,
-// eliminating the re-navigation overhead that made the old approach 1.9x
-// slower than Chrome.
+// per-operation (freshContext), this keeps a single WebSocket and browser
+// context alive across calls, eliminating the re-navigation overhead that
+// made the old approach 1.9x slower than Chrome.
+//
+// Lightpanda supports only one BrowserContext at a time, so we must NOT
+// call chromedp.NewContext per-navigation (that sends Target.createTarget
+// which tears down the previous session). Instead we create one context
+// eagerly and reuse it for all operations.
 type LightpandaEngine struct {
 	wsURL string // e.g. "ws://127.0.0.1:9222"
 
 	mu       sync.Mutex
 	allocCtx context.Context    // remote allocator context
 	allocCan context.CancelFunc // cancel for allocator
-	tabs     map[string]*lpTab
-	current  string
-	seq      int
-}
-
-type lpTab struct {
-	ctx    context.Context
-	cancel context.CancelFunc
-	url    string
-	refMap map[string]int64 // ref → backendNodeId
+	browCtx  context.Context    // single browser context (reused)
+	browCan  context.CancelFunc // cancel for browser context
+	url      string             // currently loaded URL
+	refMap   map[string]int64   // ref → backendNodeId
+	ready    bool               // true after first Navigate
 }
 
 // NewLightpandaEngine creates an engine that connects to a running Lightpanda
@@ -50,15 +46,22 @@ func NewLightpandaEngine(wsURL string) (*LightpandaEngine, error) {
 		return nil, errors.New("lightpanda: wsURL required")
 	}
 
-	// Probe the /json/version endpoint to get the actual devtools WS URL.
-	// chromedp.NewRemoteAllocator handles this for us.
-	allocCtx, allocCancel := chromedp.NewRemoteAllocator(context.Background(), wsURL)
+	// Use NoModifyURL so chromedp connects directly to the given WebSocket
+	// URL instead of querying /json/version. Lightpanda in Docker advertises
+	// the container-internal address (ws://0.0.0.0:9222/) which is
+	// unreachable from the host.
+	allocCtx, allocCancel := chromedp.NewRemoteAllocator(context.Background(), wsURL, chromedp.NoModifyURL)
+
+	// Create a single browser context — Lightpanda only supports one.
+	browCtx, browCancel := chromedp.NewContext(allocCtx)
 
 	return &LightpandaEngine{
 		wsURL:    wsURL,
 		allocCtx: allocCtx,
 		allocCan: allocCancel,
-		tabs:     make(map[string]*lpTab),
+		browCtx:  browCtx,
+		browCan:  browCancel,
+		refMap:   make(map[string]int64),
 	}, nil
 }
 
@@ -68,44 +71,23 @@ func (lp *LightpandaEngine) Capabilities() []Capability {
 	return []Capability{CapNavigate, CapSnapshot, CapText, CapClick, CapType, CapEvaluate}
 }
 
-// Navigate opens a URL in a new Lightpanda target and waits for load.
+// Navigate opens a URL in the Lightpanda browser context and waits for load.
 func (lp *LightpandaEngine) Navigate(ctx context.Context, url string) (*NavigateResult, error) {
 	lp.mu.Lock()
 	defer lp.mu.Unlock()
 
-	// Create a new browser context + target through CDP.
-	tabCtx, tabCancel := chromedp.NewContext(lp.allocCtx)
-
-	// Navigate with a timeout.
-	navCtx, navCancel := context.WithTimeout(tabCtx, 30*time.Second)
-	defer navCancel()
-
-	if err := chromedp.Run(navCtx, chromedp.Navigate(url)); err != nil {
-		tabCancel()
+	if err := chromedp.Run(lp.browCtx, chromedp.Navigate(url)); err != nil {
 		return nil, fmt.Errorf("lightpanda navigate: %w", err)
 	}
 
-	// Wait for page load event.
-	if err := chromedp.Run(navCtx, cdppage.Enable()); err != nil {
-		slog.Debug("lightpanda: page.enable", "err", err)
-	}
-
-	// Get title.
 	var title string
-	_ = chromedp.Run(navCtx, chromedp.Title(&title))
 
-	lp.seq++
-	tabID := fmt.Sprintf("lp-%d", lp.seq)
-	lp.tabs[tabID] = &lpTab{
-		ctx:    tabCtx,
-		cancel: tabCancel,
-		url:    url,
-		refMap: make(map[string]int64),
-	}
-	lp.current = tabID
+	lp.url = url
+	lp.refMap = make(map[string]int64)
+	lp.ready = true
 
 	return &NavigateResult{
-		TabID: tabID,
+		TabID: "lp-0",
 		URL:   url,
 		Title: title,
 	}, nil
@@ -116,35 +98,39 @@ func (lp *LightpandaEngine) Snapshot(ctx context.Context, filter string) ([]Snap
 	lp.mu.Lock()
 	defer lp.mu.Unlock()
 
-	tab := lp.tabs[lp.current]
-	if tab == nil {
+	if !lp.ready {
 		return nil, errors.New("no page loaded")
 	}
 
-	tCtx, tCancel := context.WithTimeout(tab.ctx, 10*time.Second)
+	tCtx, tCancel := context.WithTimeout(lp.browCtx, 10*time.Second)
 	defer tCancel()
 
 	// Fetch the full accessibility tree via CDP.
+	// Lightpanda requires explicit depth param (-1 = full tree);
+	// Chrome accepts nil params but also handles depth=-1 fine.
 	var result json.RawMessage
+	axParams := map[string]interface{}{"depth": -1}
 	if err := chromedp.Run(tCtx,
 		chromedp.ActionFunc(func(ctx context.Context) error {
 			return chromedp.FromContext(ctx).Target.Execute(ctx,
-				"Accessibility.getFullAXTree", nil, &result)
+				"Accessibility.getFullAXTree", axParams, &result)
 		}),
 	); err != nil {
 		return nil, fmt.Errorf("lightpanda a11y tree: %w", err)
 	}
 
+	// Parse with a lenient struct — Lightpanda returns property names
+	// (e.g. "uninteresting") that the strict cdproto types reject.
 	var treeResp struct {
-		Nodes []*accessibility.Node `json:"nodes"`
+		Nodes []lpAXNode `json:"nodes"`
 	}
 	if err := json.Unmarshal(result, &treeResp); err != nil {
 		return nil, fmt.Errorf("lightpanda parse a11y: %w", err)
 	}
 
 	// Build ref map and snapshot nodes.
-	tab.refMap = make(map[string]int64)
-	nodes := buildLPSnapshot(tab, treeResp.Nodes, filter)
+	lp.refMap = make(map[string]int64)
+	nodes := buildLPSnapshot(lp, treeResp.Nodes, filter)
 	return nodes, nil
 }
 
@@ -153,12 +139,11 @@ func (lp *LightpandaEngine) Text(ctx context.Context) (string, error) {
 	lp.mu.Lock()
 	defer lp.mu.Unlock()
 
-	tab := lp.tabs[lp.current]
-	if tab == nil {
+	if !lp.ready {
 		return "", errors.New("no page loaded")
 	}
 
-	tCtx, tCancel := context.WithTimeout(tab.ctx, 10*time.Second)
+	tCtx, tCancel := context.WithTimeout(lp.browCtx, 10*time.Second)
 	defer tCancel()
 
 	var text string
@@ -175,17 +160,16 @@ func (lp *LightpandaEngine) Click(ctx context.Context, ref string) error {
 	lp.mu.Lock()
 	defer lp.mu.Unlock()
 
-	tab := lp.tabs[lp.current]
-	if tab == nil {
+	if !lp.ready {
 		return errors.New("no page loaded")
 	}
 
-	backendID, ok := tab.refMap[ref]
+	backendID, ok := lp.refMap[ref]
 	if !ok {
 		return fmt.Errorf("ref %q not found (take a snapshot first)", ref)
 	}
 
-	tCtx, tCancel := context.WithTimeout(tab.ctx, 10*time.Second)
+	tCtx, tCancel := context.WithTimeout(lp.browCtx, 10*time.Second)
 	defer tCancel()
 
 	// Resolve the backendNodeId to get content quads for click coordinates.
@@ -227,17 +211,16 @@ func (lp *LightpandaEngine) Type(ctx context.Context, ref, text string) error {
 	lp.mu.Lock()
 	defer lp.mu.Unlock()
 
-	tab := lp.tabs[lp.current]
-	if tab == nil {
+	if !lp.ready {
 		return errors.New("no page loaded")
 	}
 
-	backendID, ok := tab.refMap[ref]
+	backendID, ok := lp.refMap[ref]
 	if !ok {
 		return fmt.Errorf("ref %q not found (take a snapshot first)", ref)
 	}
 
-	tCtx, tCancel := context.WithTimeout(tab.ctx, 10*time.Second)
+	tCtx, tCancel := context.WithTimeout(lp.browCtx, 10*time.Second)
 	defer tCancel()
 
 	// Focus the element then insert text.
@@ -259,23 +242,14 @@ func (lp *LightpandaEngine) Type(ctx context.Context, ref, text string) error {
 	)
 }
 
-// Close releases all tabs and the allocator connection.
+// Close releases the browser context and allocator connection.
 func (lp *LightpandaEngine) Close() error {
 	lp.mu.Lock()
 	defer lp.mu.Unlock()
 
-	for _, tab := range lp.tabs {
-		// Close the target gracefully.
-		_ = chromedp.Run(tab.ctx,
-			chromedp.ActionFunc(func(ctx context.Context) error {
-				tid := chromedp.FromContext(ctx).Target.TargetID
-				return target.CloseTarget(tid).Do(ctx)
-			}),
-		)
-		tab.cancel()
+	if lp.browCan != nil {
+		lp.browCan()
 	}
-	lp.tabs = make(map[string]*lpTab)
-
 	if lp.allocCan != nil {
 		lp.allocCan()
 	}
@@ -284,7 +258,42 @@ func (lp *LightpandaEngine) Close() error {
 
 // --- accessibility tree helpers ---
 
-func buildLPSnapshot(tab *lpTab, nodes []*accessibility.Node, filter string) []SnapshotNode {
+// lpAXNode is a lenient representation of a CDP accessibility node.
+// We use this instead of cdproto's accessibility.Node because Lightpanda
+// returns property names (e.g. "uninteresting") that the strict cdproto
+// enum types reject during JSON unmarshalling.
+type lpAXNode struct {
+	NodeID           json.RawMessage `json:"nodeId"`
+	BackendDOMNodeID int64           `json:"backendDOMNodeId"`
+	Ignored          bool            `json:"ignored"`
+	Role             *lpAXValue      `json:"role"`
+	Name             *lpAXValue      `json:"name"`
+	Value            *lpAXValue      `json:"value"`
+	Properties       []lpAXProperty  `json:"properties"`
+}
+
+type lpAXValue struct {
+	Type  string          `json:"type"`
+	Value json.RawMessage `json:"value"`
+}
+
+type lpAXProperty struct {
+	Name  string     `json:"name"`
+	Value *lpAXValue `json:"value"`
+}
+
+func lpAXValueStr(v *lpAXValue) string {
+	if v == nil {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(v.Value, &s); err == nil {
+		return s
+	}
+	return string(v.Type)
+}
+
+func buildLPSnapshot(lp *LightpandaEngine, nodes []lpAXNode, filter string) []SnapshotNode {
 	var out []SnapshotNode
 	refSeq := 0
 
@@ -293,8 +302,8 @@ func buildLPSnapshot(tab *lpTab, nodes []*accessibility.Node, filter string) []S
 			continue
 		}
 
-		role := axValueStr(n.Role)
-		name := axValueStr(n.Name)
+		role := lpAXValueStr(n.Role)
+		name := lpAXValueStr(n.Name)
 
 		// Skip the root document node and other non-semantic nodes.
 		if role == "none" || role == "RootWebArea" || role == "GenericContainer" || role == "" {
@@ -310,7 +319,7 @@ func buildLPSnapshot(tab *lpTab, nodes []*accessibility.Node, filter string) []S
 		refSeq++
 
 		if n.BackendDOMNodeID > 0 {
-			tab.refMap[ref] = int64(n.BackendDOMNodeID)
+			lp.refMap[ref] = n.BackendDOMNodeID
 		}
 
 		sn := SnapshotNode{
@@ -322,29 +331,17 @@ func buildLPSnapshot(tab *lpTab, nodes []*accessibility.Node, filter string) []S
 
 		// Extract value from the node's value field or properties.
 		if n.Value != nil {
-			sn.Value = axValueStr(n.Value)
+			sn.Value = lpAXValueStr(n.Value)
 		}
 		for _, p := range n.Properties {
 			if p.Name == "value" || p.Name == "valuetext" {
-				sn.Value = axValueStr(p.Value)
+				sn.Value = lpAXValueStr(p.Value)
 			}
 		}
 
 		out = append(out, sn)
 	}
 	return out
-}
-
-func axValueStr(v *accessibility.Value) string {
-	if v == nil {
-		return ""
-	}
-	// Value.Value is jsontext.Value ([]byte) — try to unmarshal as string.
-	var s string
-	if err := json.Unmarshal(v.Value, &s); err == nil {
-		return s
-	}
-	return string(v.Type)
 }
 
 func isInteractiveRole(role string) bool {

--- a/internal/engine/lightpanda.go
+++ b/internal/engine/lightpanda.go
@@ -1,0 +1,368 @@
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/chromedp/cdproto/accessibility"
+	"github.com/chromedp/cdproto/cdp"
+	"github.com/chromedp/cdproto/dom"
+	"github.com/chromedp/cdproto/input"
+	cdppage "github.com/chromedp/cdproto/page"
+	"github.com/chromedp/cdproto/runtime"
+	"github.com/chromedp/cdproto/target"
+	"github.com/chromedp/chromedp"
+)
+
+// LightpandaEngine implements Engine using a persistent CDP connection to a
+// Lightpanda browser instance. Unlike the prior prototype that reconnected
+// per-operation (freshContext), this keeps the WebSocket alive across calls,
+// eliminating the re-navigation overhead that made the old approach 1.9x
+// slower than Chrome.
+type LightpandaEngine struct {
+	wsURL string // e.g. "ws://127.0.0.1:9222"
+
+	mu       sync.Mutex
+	allocCtx context.Context    // remote allocator context
+	allocCan context.CancelFunc // cancel for allocator
+	tabs     map[string]*lpTab
+	current  string
+	seq      int
+}
+
+type lpTab struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+	url    string
+	refMap map[string]int64 // ref → backendNodeId
+}
+
+// NewLightpandaEngine creates an engine that connects to a running Lightpanda
+// CDP server at the given WebSocket URL. The URL should be the base endpoint,
+// e.g. "ws://127.0.0.1:9222".
+func NewLightpandaEngine(wsURL string) (*LightpandaEngine, error) {
+	if wsURL == "" {
+		return nil, errors.New("lightpanda: wsURL required")
+	}
+
+	// Probe the /json/version endpoint to get the actual devtools WS URL.
+	// chromedp.NewRemoteAllocator handles this for us.
+	allocCtx, allocCancel := chromedp.NewRemoteAllocator(context.Background(), wsURL)
+
+	return &LightpandaEngine{
+		wsURL:    wsURL,
+		allocCtx: allocCtx,
+		allocCan: allocCancel,
+		tabs:     make(map[string]*lpTab),
+	}, nil
+}
+
+func (lp *LightpandaEngine) Name() string { return "lightpanda" }
+
+func (lp *LightpandaEngine) Capabilities() []Capability {
+	return []Capability{CapNavigate, CapSnapshot, CapText, CapClick, CapType, CapEvaluate}
+}
+
+// Navigate opens a URL in a new Lightpanda target and waits for load.
+func (lp *LightpandaEngine) Navigate(ctx context.Context, url string) (*NavigateResult, error) {
+	lp.mu.Lock()
+	defer lp.mu.Unlock()
+
+	// Create a new browser context + target through CDP.
+	tabCtx, tabCancel := chromedp.NewContext(lp.allocCtx)
+
+	// Navigate with a timeout.
+	navCtx, navCancel := context.WithTimeout(tabCtx, 30*time.Second)
+	defer navCancel()
+
+	if err := chromedp.Run(navCtx, chromedp.Navigate(url)); err != nil {
+		tabCancel()
+		return nil, fmt.Errorf("lightpanda navigate: %w", err)
+	}
+
+	// Wait for page load event.
+	if err := chromedp.Run(navCtx, cdppage.Enable()); err != nil {
+		slog.Debug("lightpanda: page.enable", "err", err)
+	}
+
+	// Get title.
+	var title string
+	_ = chromedp.Run(navCtx, chromedp.Title(&title))
+
+	lp.seq++
+	tabID := fmt.Sprintf("lp-%d", lp.seq)
+	lp.tabs[tabID] = &lpTab{
+		ctx:    tabCtx,
+		cancel: tabCancel,
+		url:    url,
+		refMap: make(map[string]int64),
+	}
+	lp.current = tabID
+
+	return &NavigateResult{
+		TabID: tabID,
+		URL:   url,
+		Title: title,
+	}, nil
+}
+
+// Snapshot returns the accessibility tree from Lightpanda's CDP endpoint.
+func (lp *LightpandaEngine) Snapshot(ctx context.Context, filter string) ([]SnapshotNode, error) {
+	lp.mu.Lock()
+	defer lp.mu.Unlock()
+
+	tab := lp.tabs[lp.current]
+	if tab == nil {
+		return nil, errors.New("no page loaded")
+	}
+
+	tCtx, tCancel := context.WithTimeout(tab.ctx, 10*time.Second)
+	defer tCancel()
+
+	// Fetch the full accessibility tree via CDP.
+	var result json.RawMessage
+	if err := chromedp.Run(tCtx,
+		chromedp.ActionFunc(func(ctx context.Context) error {
+			return chromedp.FromContext(ctx).Target.Execute(ctx,
+				"Accessibility.getFullAXTree", nil, &result)
+		}),
+	); err != nil {
+		return nil, fmt.Errorf("lightpanda a11y tree: %w", err)
+	}
+
+	var treeResp struct {
+		Nodes []*accessibility.Node `json:"nodes"`
+	}
+	if err := json.Unmarshal(result, &treeResp); err != nil {
+		return nil, fmt.Errorf("lightpanda parse a11y: %w", err)
+	}
+
+	// Build ref map and snapshot nodes.
+	tab.refMap = make(map[string]int64)
+	nodes := buildLPSnapshot(tab, treeResp.Nodes, filter)
+	return nodes, nil
+}
+
+// Text returns the visible text content via JS evaluation.
+func (lp *LightpandaEngine) Text(ctx context.Context) (string, error) {
+	lp.mu.Lock()
+	defer lp.mu.Unlock()
+
+	tab := lp.tabs[lp.current]
+	if tab == nil {
+		return "", errors.New("no page loaded")
+	}
+
+	tCtx, tCancel := context.WithTimeout(tab.ctx, 10*time.Second)
+	defer tCancel()
+
+	var text string
+	if err := chromedp.Run(tCtx,
+		chromedp.Evaluate(`document.body.innerText`, &text),
+	); err != nil {
+		return "", fmt.Errorf("lightpanda text: %w", err)
+	}
+	return normalizeWhitespace(text), nil
+}
+
+// Click dispatches a mouse click to the element identified by ref.
+func (lp *LightpandaEngine) Click(ctx context.Context, ref string) error {
+	lp.mu.Lock()
+	defer lp.mu.Unlock()
+
+	tab := lp.tabs[lp.current]
+	if tab == nil {
+		return errors.New("no page loaded")
+	}
+
+	backendID, ok := tab.refMap[ref]
+	if !ok {
+		return fmt.Errorf("ref %q not found (take a snapshot first)", ref)
+	}
+
+	tCtx, tCancel := context.WithTimeout(tab.ctx, 10*time.Second)
+	defer tCancel()
+
+	// Resolve the backendNodeId to get content quads for click coordinates.
+	// If getContentQuads works, use its coordinates; otherwise fall back to
+	// JS click via callFunctionOn.
+	var quads []dom.Quad
+	err := chromedp.Run(tCtx,
+		chromedp.ActionFunc(func(ctx context.Context) error {
+			var err error
+			quads, err = dom.GetContentQuads().WithBackendNodeID(cdp.BackendNodeID(backendID)).Do(ctx)
+			return err
+		}),
+	)
+	if err == nil && len(quads) > 0 && len(quads[0]) >= 2 {
+		// Use the center of the first quad.
+		x, y := quadCenter(quads[0])
+		return chromedp.Run(tCtx,
+			input.DispatchMouseEvent(input.MousePressed, x, y).WithButton(input.Left).WithClickCount(1),
+			input.DispatchMouseEvent(input.MouseReleased, x, y).WithButton(input.Left).WithClickCount(1),
+		)
+	}
+
+	// Fallback: click via JS using the backend node ID.
+	return chromedp.Run(tCtx,
+		chromedp.ActionFunc(func(ctx context.Context) error {
+			node, err := dom.ResolveNode().WithBackendNodeID(cdp.BackendNodeID(backendID)).Do(ctx)
+			if err != nil {
+				return fmt.Errorf("resolve node: %w", err)
+			}
+			_, _, err = runtime.CallFunctionOn(`function() { this.click(); }`).
+				WithObjectID(node.ObjectID).Do(ctx)
+			return err
+		}),
+	)
+}
+
+// Type enters text into an element identified by ref.
+func (lp *LightpandaEngine) Type(ctx context.Context, ref, text string) error {
+	lp.mu.Lock()
+	defer lp.mu.Unlock()
+
+	tab := lp.tabs[lp.current]
+	if tab == nil {
+		return errors.New("no page loaded")
+	}
+
+	backendID, ok := tab.refMap[ref]
+	if !ok {
+		return fmt.Errorf("ref %q not found (take a snapshot first)", ref)
+	}
+
+	tCtx, tCancel := context.WithTimeout(tab.ctx, 10*time.Second)
+	defer tCancel()
+
+	// Focus the element then insert text.
+	return chromedp.Run(tCtx,
+		chromedp.ActionFunc(func(ctx context.Context) error {
+			node, err := dom.ResolveNode().WithBackendNodeID(cdp.BackendNodeID(backendID)).Do(ctx)
+			if err != nil {
+				return fmt.Errorf("resolve node: %w", err)
+			}
+			// Focus via JS.
+			_, _, err = runtime.CallFunctionOn(`function() { this.focus(); }`).
+				WithObjectID(node.ObjectID).Do(ctx)
+			if err != nil {
+				return fmt.Errorf("focus: %w", err)
+			}
+			return nil
+		}),
+		input.InsertText(text),
+	)
+}
+
+// Close releases all tabs and the allocator connection.
+func (lp *LightpandaEngine) Close() error {
+	lp.mu.Lock()
+	defer lp.mu.Unlock()
+
+	for _, tab := range lp.tabs {
+		// Close the target gracefully.
+		_ = chromedp.Run(tab.ctx,
+			chromedp.ActionFunc(func(ctx context.Context) error {
+				tid := chromedp.FromContext(ctx).Target.TargetID
+				return target.CloseTarget(tid).Do(ctx)
+			}),
+		)
+		tab.cancel()
+	}
+	lp.tabs = make(map[string]*lpTab)
+
+	if lp.allocCan != nil {
+		lp.allocCan()
+	}
+	return nil
+}
+
+// --- accessibility tree helpers ---
+
+func buildLPSnapshot(tab *lpTab, nodes []*accessibility.Node, filter string) []SnapshotNode {
+	var out []SnapshotNode
+	refSeq := 0
+
+	for _, n := range nodes {
+		if n.Ignored {
+			continue
+		}
+
+		role := axValueStr(n.Role)
+		name := axValueStr(n.Name)
+
+		// Skip the root document node and other non-semantic nodes.
+		if role == "none" || role == "RootWebArea" || role == "GenericContainer" || role == "" {
+			continue
+		}
+
+		interactive := isInteractiveRole(role)
+		if filter == "interactive" && !interactive {
+			continue
+		}
+
+		ref := fmt.Sprintf("e%d", refSeq)
+		refSeq++
+
+		if n.BackendDOMNodeID > 0 {
+			tab.refMap[ref] = int64(n.BackendDOMNodeID)
+		}
+
+		sn := SnapshotNode{
+			Ref:         ref,
+			Role:        role,
+			Name:        name,
+			Interactive: interactive,
+		}
+
+		// Extract value from the node's value field or properties.
+		if n.Value != nil {
+			sn.Value = axValueStr(n.Value)
+		}
+		for _, p := range n.Properties {
+			if p.Name == "value" || p.Name == "valuetext" {
+				sn.Value = axValueStr(p.Value)
+			}
+		}
+
+		out = append(out, sn)
+	}
+	return out
+}
+
+func axValueStr(v *accessibility.Value) string {
+	if v == nil {
+		return ""
+	}
+	// Value.Value is jsontext.Value ([]byte) — try to unmarshal as string.
+	var s string
+	if err := json.Unmarshal(v.Value, &s); err == nil {
+		return s
+	}
+	return string(v.Type)
+}
+
+func isInteractiveRole(role string) bool {
+	switch role {
+	case "button", "link", "textbox", "checkbox", "radio", "combobox",
+		"menuitem", "tab", "switch", "slider", "spinbutton",
+		"searchbox", "option", "menuitemcheckbox", "menuitemradio":
+		return true
+	}
+	return false
+}
+
+func quadCenter(q dom.Quad) (float64, float64) {
+	if len(q) < 8 {
+		return 0, 0
+	}
+	// Quad is [x1,y1, x2,y2, x3,y3, x4,y4]
+	x := (q[0] + q[2] + q[4] + q[6]) / 4
+	y := (q[1] + q[3] + q[5] + q[7]) / 4
+	return x, y
+}

--- a/internal/engine/lightpanda_test.go
+++ b/internal/engine/lightpanda_test.go
@@ -1,0 +1,334 @@
+package engine
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/chromedp/cdproto/accessibility"
+	"github.com/chromedp/cdproto/cdp"
+)
+
+func TestBuildLPSnapshot_FiltersIgnored(t *testing.T) {
+	tab := &lpTab{refMap: make(map[string]int64)}
+	nodes := []*accessibility.Node{
+		makeAXNode("1", "button", "Submit", false, 10),
+		makeAXNode("2", "heading", "Title", true, 0), // ignored
+		makeAXNode("3", "link", "Home", false, 20),
+	}
+
+	result := buildLPSnapshot(tab, nodes, "")
+	if len(result) != 2 {
+		t.Fatalf("expected 2 nodes (1 ignored), got %d", len(result))
+	}
+	if result[0].Role != "button" {
+		t.Errorf("first node role = %q, want button", result[0].Role)
+	}
+	if result[1].Role != "link" {
+		t.Errorf("second node role = %q, want link", result[1].Role)
+	}
+}
+
+func TestBuildLPSnapshot_SkipsNonSemantic(t *testing.T) {
+	tab := &lpTab{refMap: make(map[string]int64)}
+	nodes := []*accessibility.Node{
+		makeAXNode("1", "RootWebArea", "", false, 0),
+		makeAXNode("2", "GenericContainer", "", false, 0),
+		makeAXNode("3", "none", "", false, 0),
+		makeAXNode("4", "button", "OK", false, 30),
+	}
+
+	result := buildLPSnapshot(tab, nodes, "")
+	if len(result) != 1 {
+		t.Fatalf("expected 1 semantic node, got %d", len(result))
+	}
+	if result[0].Name != "OK" {
+		t.Errorf("node name = %q, want OK", result[0].Name)
+	}
+}
+
+func TestBuildLPSnapshot_InteractiveFilter(t *testing.T) {
+	tab := &lpTab{refMap: make(map[string]int64)}
+	nodes := []*accessibility.Node{
+		makeAXNode("1", "heading", "Title", false, 0),
+		makeAXNode("2", "button", "Submit", false, 10),
+		makeAXNode("3", "textbox", "Email", false, 20),
+		makeAXNode("4", "article", "Content", false, 0),
+	}
+
+	result := buildLPSnapshot(tab, nodes, "interactive")
+	if len(result) != 2 {
+		t.Fatalf("expected 2 interactive nodes, got %d", len(result))
+	}
+	for _, n := range result {
+		if !n.Interactive {
+			t.Errorf("non-interactive node in filtered result: %+v", n)
+		}
+	}
+}
+
+func TestBuildLPSnapshot_RefMap(t *testing.T) {
+	tab := &lpTab{refMap: make(map[string]int64)}
+	nodes := []*accessibility.Node{
+		makeAXNode("1", "button", "OK", false, 42),
+		makeAXNode("2", "link", "Home", false, 99),
+	}
+
+	result := buildLPSnapshot(tab, nodes, "")
+	if len(result) != 2 {
+		t.Fatalf("expected 2 nodes, got %d", len(result))
+	}
+
+	// Check refs are sequential.
+	if result[0].Ref != "e0" {
+		t.Errorf("first ref = %q, want e0", result[0].Ref)
+	}
+	if result[1].Ref != "e1" {
+		t.Errorf("second ref = %q, want e1", result[1].Ref)
+	}
+
+	// Check backend node IDs in refMap.
+	if id, ok := tab.refMap["e0"]; !ok || id != 42 {
+		t.Errorf("refMap[e0] = %d, want 42", id)
+	}
+	if id, ok := tab.refMap["e1"]; !ok || id != 99 {
+		t.Errorf("refMap[e1] = %d, want 99", id)
+	}
+}
+
+func TestAxValueStr(t *testing.T) {
+	tests := []struct {
+		name string
+		v    *accessibility.Value
+		want string
+	}{
+		{"nil", nil, ""},
+		{"string value", makeAXValue("hello"), "hello"},
+		{"empty string", makeAXValue(""), ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := axValueStr(tt.v)
+			if got != tt.want {
+				t.Errorf("axValueStr() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsInteractiveRole(t *testing.T) {
+	interactive := []string{"button", "link", "textbox", "checkbox", "radio", "combobox", "menuitem", "tab", "switch"}
+	for _, role := range interactive {
+		if !isInteractiveRole(role) {
+			t.Errorf("isInteractiveRole(%q) = false, want true", role)
+		}
+	}
+
+	nonInteractive := []string{"heading", "article", "navigation", "generic", "main", "region", "list"}
+	for _, role := range nonInteractive {
+		if isInteractiveRole(role) {
+			t.Errorf("isInteractiveRole(%q) = true, want false", role)
+		}
+	}
+}
+
+func TestQuadCenter(t *testing.T) {
+	// Rectangle: (10,20) (30,20) (30,40) (10,40) → center (20, 30)
+	q := []float64{10, 20, 30, 20, 30, 40, 10, 40}
+	x, y := quadCenter(q)
+	if x != 20 || y != 30 {
+		t.Errorf("quadCenter = (%v, %v), want (20, 30)", x, y)
+	}
+}
+
+func TestQuadCenter_Short(t *testing.T) {
+	x, y := quadCenter([]float64{1, 2})
+	if x != 0 || y != 0 {
+		t.Errorf("quadCenter with short quad = (%v, %v), want (0, 0)", x, y)
+	}
+}
+
+func TestLightpandaEngine_Name(t *testing.T) {
+	// NewLightpandaEngine requires a URL but we can test Name() without
+	// actually connecting.
+	lp, err := NewLightpandaEngine("ws://127.0.0.1:19222")
+	if err != nil {
+		t.Fatalf("NewLightpandaEngine: %v", err)
+	}
+	defer func() { _ = lp.Close() }()
+
+	if lp.Name() != "lightpanda" {
+		t.Errorf("Name() = %q, want %q", lp.Name(), "lightpanda")
+	}
+}
+
+func TestLightpandaEngine_Capabilities(t *testing.T) {
+	lp, err := NewLightpandaEngine("ws://127.0.0.1:19222")
+	if err != nil {
+		t.Fatalf("NewLightpandaEngine: %v", err)
+	}
+	defer func() { _ = lp.Close() }()
+
+	caps := lp.Capabilities()
+	if len(caps) != 6 {
+		t.Errorf("expected 6 capabilities, got %d: %v", len(caps), caps)
+	}
+
+	capSet := make(map[Capability]bool)
+	for _, c := range caps {
+		capSet[c] = true
+	}
+	for _, want := range []Capability{CapNavigate, CapSnapshot, CapText, CapClick, CapType, CapEvaluate} {
+		if !capSet[want] {
+			t.Errorf("missing capability %q", want)
+		}
+	}
+}
+
+func TestLightpandaEngine_RequiresURL(t *testing.T) {
+	_, err := NewLightpandaEngine("")
+	if err == nil {
+		t.Error("expected error for empty URL")
+	}
+}
+
+func TestLightpandaEngine_SnapshotWithoutNavigate(t *testing.T) {
+	lp, err := NewLightpandaEngine("ws://127.0.0.1:19222")
+	if err != nil {
+		t.Fatalf("NewLightpandaEngine: %v", err)
+	}
+	defer func() { _ = lp.Close() }()
+
+	_, err = lp.Snapshot(nil, "")
+	if err == nil {
+		t.Error("expected error for snapshot without navigate")
+	}
+}
+
+func TestLightpandaEngine_ClickWithoutNavigate(t *testing.T) {
+	lp, err := NewLightpandaEngine("ws://127.0.0.1:19222")
+	if err != nil {
+		t.Fatalf("NewLightpandaEngine: %v", err)
+	}
+	defer func() { _ = lp.Close() }()
+
+	err = lp.Click(nil, "e0")
+	if err == nil {
+		t.Error("expected error for click without navigate")
+	}
+}
+
+func TestLightpandaEngine_TextWithoutNavigate(t *testing.T) {
+	lp, err := NewLightpandaEngine("ws://127.0.0.1:19222")
+	if err != nil {
+		t.Fatalf("NewLightpandaEngine: %v", err)
+	}
+	defer func() { _ = lp.Close() }()
+
+	_, err = lp.Text(nil)
+	if err == nil {
+		t.Error("expected error for text without navigate")
+	}
+}
+
+// --- Router tests for Lightpanda mode ---
+
+func TestRouterLightpandaMode(t *testing.T) {
+	r := NewRouter(ModeLightpanda, nil)
+	lp := &fakeEngine{name: "lightpanda"}
+	r.RegisterEngine(lp)
+
+	// DOM operations → lightpanda
+	for _, op := range []Capability{CapNavigate, CapSnapshot, CapText, CapClick, CapType, CapEvaluate} {
+		eng := r.Route(op, "https://example.com")
+		if eng == nil {
+			t.Errorf("lightpanda mode should route %s to lightpanda, got chrome", op)
+			continue
+		}
+		if eng.Name() != "lightpanda" {
+			t.Errorf("lightpanda mode route(%s) = %q, want lightpanda", op, eng.Name())
+		}
+	}
+
+	// Chrome-only operations → chrome
+	for _, op := range []Capability{CapScreenshot, CapPDF, CapCookies} {
+		eng := r.Route(op, "https://example.com")
+		if eng != nil {
+			t.Errorf("lightpanda mode should route %s to chrome, got %q", op, eng.Name())
+		}
+	}
+}
+
+func TestRouterLightpandaModeNoEngine(t *testing.T) {
+	r := NewRouter(ModeLightpanda, nil)
+	// No engine registered — should fall through to chrome.
+	eng := r.Route(CapNavigate, "https://example.com")
+	if eng != nil {
+		t.Errorf("should fall through to chrome when lightpanda not registered, got %q", eng.Name())
+	}
+}
+
+func TestLightpandaCapabilityRule(t *testing.T) {
+	rule := LightpandaCapabilityRule{}
+	if rule.Name() != "lightpanda-capability" {
+		t.Errorf("Name() = %q, want lightpanda-capability", rule.Name())
+	}
+
+	// Chrome-only operations.
+	for _, op := range []Capability{CapScreenshot, CapPDF, CapCookies} {
+		if d := rule.Decide(op, ""); d != UseChrome {
+			t.Errorf("Decide(%s) = %d, want UseChrome", op, d)
+		}
+	}
+
+	// Other operations → undecided.
+	for _, op := range []Capability{CapNavigate, CapSnapshot, CapText, CapClick, CapType, CapEvaluate} {
+		if d := rule.Decide(op, ""); d != Undecided {
+			t.Errorf("Decide(%s) = %d, want Undecided", op, d)
+		}
+	}
+}
+
+func TestDefaultLightpandaRule(t *testing.T) {
+	rule := DefaultLightpandaRule{}
+	if rule.Name() != "default-lightpanda" {
+		t.Errorf("Name() = %q, want default-lightpanda", rule.Name())
+	}
+
+	for _, op := range []Capability{CapNavigate, CapSnapshot, CapText, CapClick, CapType, CapEvaluate} {
+		if d := rule.Decide(op, ""); d != UseLightpanda {
+			t.Errorf("Decide(%s) = %d, want UseLightpanda", op, d)
+		}
+	}
+
+	// Unknown capability → undecided.
+	if d := rule.Decide("unknown", ""); d != Undecided {
+		t.Errorf("Decide(unknown) = %d, want Undecided", d)
+	}
+}
+
+// --- helpers ---
+
+func makeAXNode(id, role, name string, ignored bool, backendID int64) *accessibility.Node {
+	n := &accessibility.Node{
+		NodeID:  accessibility.NodeID(id),
+		Ignored: ignored,
+	}
+	if role != "" {
+		n.Role = makeAXValue(role)
+	}
+	if name != "" {
+		n.Name = makeAXValue(name)
+	}
+	if backendID > 0 {
+		n.BackendDOMNodeID = cdp.BackendNodeID(backendID)
+	}
+	return n
+}
+
+func makeAXValue(s string) *accessibility.Value {
+	raw, _ := json.Marshal(s)
+	return &accessibility.Value{
+		Type:  "string",
+		Value: raw,
+	}
+}

--- a/internal/engine/lightpanda_test.go
+++ b/internal/engine/lightpanda_test.go
@@ -3,20 +3,17 @@ package engine
 import (
 	"encoding/json"
 	"testing"
-
-	"github.com/chromedp/cdproto/accessibility"
-	"github.com/chromedp/cdproto/cdp"
 )
 
 func TestBuildLPSnapshot_FiltersIgnored(t *testing.T) {
-	tab := &lpTab{refMap: make(map[string]int64)}
-	nodes := []*accessibility.Node{
+	lp := &LightpandaEngine{refMap: make(map[string]int64)}
+	nodes := []lpAXNode{
 		makeAXNode("1", "button", "Submit", false, 10),
 		makeAXNode("2", "heading", "Title", true, 0), // ignored
 		makeAXNode("3", "link", "Home", false, 20),
 	}
 
-	result := buildLPSnapshot(tab, nodes, "")
+	result := buildLPSnapshot(lp, nodes, "")
 	if len(result) != 2 {
 		t.Fatalf("expected 2 nodes (1 ignored), got %d", len(result))
 	}
@@ -29,15 +26,15 @@ func TestBuildLPSnapshot_FiltersIgnored(t *testing.T) {
 }
 
 func TestBuildLPSnapshot_SkipsNonSemantic(t *testing.T) {
-	tab := &lpTab{refMap: make(map[string]int64)}
-	nodes := []*accessibility.Node{
+	lp := &LightpandaEngine{refMap: make(map[string]int64)}
+	nodes := []lpAXNode{
 		makeAXNode("1", "RootWebArea", "", false, 0),
 		makeAXNode("2", "GenericContainer", "", false, 0),
 		makeAXNode("3", "none", "", false, 0),
 		makeAXNode("4", "button", "OK", false, 30),
 	}
 
-	result := buildLPSnapshot(tab, nodes, "")
+	result := buildLPSnapshot(lp, nodes, "")
 	if len(result) != 1 {
 		t.Fatalf("expected 1 semantic node, got %d", len(result))
 	}
@@ -47,15 +44,15 @@ func TestBuildLPSnapshot_SkipsNonSemantic(t *testing.T) {
 }
 
 func TestBuildLPSnapshot_InteractiveFilter(t *testing.T) {
-	tab := &lpTab{refMap: make(map[string]int64)}
-	nodes := []*accessibility.Node{
+	lp := &LightpandaEngine{refMap: make(map[string]int64)}
+	nodes := []lpAXNode{
 		makeAXNode("1", "heading", "Title", false, 0),
 		makeAXNode("2", "button", "Submit", false, 10),
 		makeAXNode("3", "textbox", "Email", false, 20),
 		makeAXNode("4", "article", "Content", false, 0),
 	}
 
-	result := buildLPSnapshot(tab, nodes, "interactive")
+	result := buildLPSnapshot(lp, nodes, "interactive")
 	if len(result) != 2 {
 		t.Fatalf("expected 2 interactive nodes, got %d", len(result))
 	}
@@ -67,13 +64,13 @@ func TestBuildLPSnapshot_InteractiveFilter(t *testing.T) {
 }
 
 func TestBuildLPSnapshot_RefMap(t *testing.T) {
-	tab := &lpTab{refMap: make(map[string]int64)}
-	nodes := []*accessibility.Node{
+	lp := &LightpandaEngine{refMap: make(map[string]int64)}
+	nodes := []lpAXNode{
 		makeAXNode("1", "button", "OK", false, 42),
 		makeAXNode("2", "link", "Home", false, 99),
 	}
 
-	result := buildLPSnapshot(tab, nodes, "")
+	result := buildLPSnapshot(lp, nodes, "")
 	if len(result) != 2 {
 		t.Fatalf("expected 2 nodes, got %d", len(result))
 	}
@@ -87,29 +84,29 @@ func TestBuildLPSnapshot_RefMap(t *testing.T) {
 	}
 
 	// Check backend node IDs in refMap.
-	if id, ok := tab.refMap["e0"]; !ok || id != 42 {
+	if id, ok := lp.refMap["e0"]; !ok || id != 42 {
 		t.Errorf("refMap[e0] = %d, want 42", id)
 	}
-	if id, ok := tab.refMap["e1"]; !ok || id != 99 {
+	if id, ok := lp.refMap["e1"]; !ok || id != 99 {
 		t.Errorf("refMap[e1] = %d, want 99", id)
 	}
 }
 
-func TestAxValueStr(t *testing.T) {
+func TestLpAXValueStr(t *testing.T) {
 	tests := []struct {
 		name string
-		v    *accessibility.Value
+		v    *lpAXValue
 		want string
 	}{
 		{"nil", nil, ""},
-		{"string value", makeAXValue("hello"), "hello"},
-		{"empty string", makeAXValue(""), ""},
+		{"string value", makeLPAXValue("hello"), "hello"},
+		{"empty string", makeLPAXValue(""), ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := axValueStr(tt.v)
+			got := lpAXValueStr(tt.v)
 			if got != tt.want {
-				t.Errorf("axValueStr() = %q, want %q", got, tt.want)
+				t.Errorf("lpAXValueStr() = %q, want %q", got, tt.want)
 			}
 		})
 	}
@@ -308,26 +305,25 @@ func TestDefaultLightpandaRule(t *testing.T) {
 
 // --- helpers ---
 
-func makeAXNode(id, role, name string, ignored bool, backendID int64) *accessibility.Node {
-	n := &accessibility.Node{
-		NodeID:  accessibility.NodeID(id),
-		Ignored: ignored,
+func makeAXNode(id, role, name string, ignored bool, backendID int64) lpAXNode {
+	rawID, _ := json.Marshal(id)
+	n := lpAXNode{
+		NodeID:           rawID,
+		Ignored:          ignored,
+		BackendDOMNodeID: backendID,
 	}
 	if role != "" {
-		n.Role = makeAXValue(role)
+		n.Role = makeLPAXValue(role)
 	}
 	if name != "" {
-		n.Name = makeAXValue(name)
-	}
-	if backendID > 0 {
-		n.BackendDOMNodeID = cdp.BackendNodeID(backendID)
+		n.Name = makeLPAXValue(name)
 	}
 	return n
 }
 
-func makeAXValue(s string) *accessibility.Value {
+func makeLPAXValue(s string) *lpAXValue {
 	raw, _ := json.Marshal(s)
-	return &accessibility.Value{
+	return &lpAXValue{
 		Type:  "string",
 		Value: raw,
 	}

--- a/internal/engine/realworld_benchmark_test.go
+++ b/internal/engine/realworld_benchmark_test.go
@@ -1,0 +1,270 @@
+package engine
+
+// realworld_benchmark_test.go — Real-world JS-heavy website benchmarks
+//
+// Tests Lite vs Lightpanda against real public websites that require
+// JavaScript execution to render their main content. This validates
+// LP's value as a lightweight JS engine on actual production sites.
+//
+// These tests hit the real internet and require LIGHTPANDA_URL to be set.
+// They are gated behind REALWORLD_BENCH=1 to avoid running in CI.
+//
+// Run:
+//   REALWORLD_BENCH=1 LIGHTPANDA_URL=ws://127.0.0.1:19222 \
+//     go test ./internal/engine/ -run TestRealWorldBenchmark -v -timeout 120s
+//
+// LP Docker:
+//   docker run --rm --network=host --entrypoint lightpanda \
+//     lightpanda/browser:nightly serve --host 127.0.0.1 --port 19222
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+)
+
+type realWorldSite struct {
+	name      string
+	url       string
+	category  string
+	framework string
+}
+
+func realWorldSites() []realWorldSite {
+	return []realWorldSite{
+		{
+			name:      "excalidraw",
+			url:       "https://excalidraw.com",
+			category:  "Drawing tool",
+			framework: "React",
+		},
+		{
+			name:      "youtube-music",
+			url:       "https://music.youtube.com",
+			category:  "Media streaming",
+			framework: "Polymer/Lit",
+		},
+		{
+			name:      "notion-templates",
+			url:       "https://www.notion.so/templates",
+			category:  "Productivity",
+			framework: "React",
+		},
+		{
+			name:      "stackblitz",
+			url:       "https://stackblitz.com",
+			category:  "Dev tools",
+			framework: "Angular",
+		},
+		{
+			name:      "weather",
+			url:       "https://weather.com",
+			category:  "Weather/info",
+			framework: "React/Next.js",
+		},
+	}
+}
+
+type realWorldResult struct {
+	engine     string
+	site       string
+	category   string
+	framework  string
+	navigateMs float64
+	snapshotMs float64
+	totalMs    float64
+	nodeCount  int
+	interCount int
+	textLen    int
+	err        string
+}
+
+func TestRealWorldBenchmark(t *testing.T) {
+	if os.Getenv("REALWORLD_BENCH") != "1" {
+		t.Skip("REALWORLD_BENCH=1 not set — skipping real-world benchmarks")
+	}
+
+	lpURL := os.Getenv("LIGHTPANDA_URL")
+	if lpURL == "" {
+		t.Skip("LIGHTPANDA_URL not set — need LP for real-world comparison")
+	}
+
+	sites := realWorldSites()
+	var results []realWorldResult
+
+	// --- Lite engine ---
+	for _, site := range sites {
+		t.Run("lite/"+site.name, func(t *testing.T) {
+			lite := NewLiteEngine()
+			defer func() { _ = lite.Close() }()
+
+			r := benchRealWorldSite(t, lite, "lite", site)
+			results = append(results, r)
+		})
+	}
+
+	// --- Lightpanda engine ---
+	lp, err := NewLightpandaEngine(lpURL)
+	if err != nil {
+		t.Fatalf("NewLightpandaEngine: %v", err)
+	}
+	defer func() { _ = lp.Close() }()
+
+	for _, site := range sites {
+		t.Run("lightpanda/"+site.name, func(t *testing.T) {
+			r := benchRealWorldSite(t, lp, "lightpanda", site)
+			results = append(results, r)
+		})
+	}
+
+	// --- Print results ---
+	printRealWorldSummary(t, results, sites)
+}
+
+func benchRealWorldSite(t *testing.T, eng Engine, engineName string, site realWorldSite) realWorldResult {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	r := realWorldResult{
+		engine:    engineName,
+		site:      site.name,
+		category:  site.category,
+		framework: site.framework,
+	}
+
+	// Navigate
+	navStart := time.Now()
+	_, err := eng.Navigate(ctx, site.url)
+	r.navigateMs = float64(time.Since(navStart).Nanoseconds()) / 1e6
+	if err != nil {
+		r.err = err.Error()
+		t.Logf("navigate error: %v", err)
+		return r
+	}
+
+	// Snapshot (all nodes)
+	snapStart := time.Now()
+	nodes, err := eng.Snapshot(ctx, "")
+	r.snapshotMs = float64(time.Since(snapStart).Nanoseconds()) / 1e6
+	if err != nil {
+		r.err = err.Error()
+		t.Logf("snapshot error: %v", err)
+		return r
+	}
+	r.nodeCount = len(nodes)
+	r.totalMs = r.navigateMs + r.snapshotMs
+
+	// Interactive count
+	interNodes, _ := eng.Snapshot(ctx, "interactive")
+	r.interCount = len(interNodes)
+
+	// Text
+	text, _ := eng.Text(ctx)
+	r.textLen = len(text)
+
+	t.Logf("nav=%.0fms snap=%.0fms total=%.0fms nodes=%d interactive=%d text=%d",
+		r.navigateMs, r.snapshotMs, r.totalMs,
+		r.nodeCount, r.interCount, r.textLen)
+
+	return r
+}
+
+func printRealWorldSummary(t *testing.T, results []realWorldResult, sites []realWorldSite) {
+	t.Helper()
+
+	// Build lookup maps.
+	liteMap := make(map[string]realWorldResult)
+	lpMap := make(map[string]realWorldResult)
+	for _, r := range results {
+		switch r.engine {
+		case "lite":
+			liteMap[r.site] = r
+		case "lightpanda":
+			lpMap[r.site] = r
+		}
+	}
+
+	// ── Table 1: JS Rendering Comparison ──
+	t.Log("")
+	t.Log("### Real-World JS-Heavy Sites: Lite vs Lightpanda")
+	t.Log("")
+	t.Log("| Site | Category | Framework | Lite Nodes | Lite Interactive | LP Nodes | LP Interactive | LP Text | Winner |")
+	t.Log("|------|----------|-----------|:----------:|:----------------:|:--------:|:--------------:|:-------:|--------|")
+
+	for _, site := range sites {
+		lr := liteMap[site.name]
+		lpr := lpMap[site.name]
+
+		liteNodes := "ERR"
+		liteInter := "ERR"
+		if lr.err == "" {
+			liteNodes = fmt.Sprintf("%d", lr.nodeCount)
+			liteInter = fmt.Sprintf("%d", lr.interCount)
+		}
+
+		lpNodes := "ERR"
+		lpInter := "ERR"
+		lpText := "ERR"
+		if lpr.err == "" {
+			lpNodes = fmt.Sprintf("%d", lpr.nodeCount)
+			lpInter = fmt.Sprintf("%d", lpr.interCount)
+			lpText = fmt.Sprintf("%d", lpr.textLen)
+		}
+
+		winner := "—"
+		if lr.err == "" && lpr.err == "" {
+			if lpr.nodeCount > lr.nodeCount*2 {
+				winner = "**LP**"
+			} else if lr.nodeCount > lpr.nodeCount*2 {
+				winner = "**Lite**"
+			} else if lpr.interCount > lr.interCount {
+				winner = "**LP**"
+			} else if lr.interCount > lpr.interCount {
+				winner = "**Lite**"
+			} else {
+				winner = "Tie"
+			}
+		} else if lr.err != "" && lpr.err == "" {
+			winner = "**LP**"
+		} else if lr.err == "" && lpr.err != "" {
+			winner = "**Lite**"
+		}
+
+		t.Logf("| %s | %s | %s | %s | %s | %s | %s | %s | %s |",
+			site.name, site.category, site.framework,
+			liteNodes, liteInter, lpNodes, lpInter, lpText, winner)
+	}
+
+	// ── Table 2: Latency Comparison ──
+	t.Log("")
+	t.Log("### Latency (ms)")
+	t.Log("")
+	t.Log("| Site | Lite Nav | Lite Snap | Lite Total | LP Nav | LP Snap | LP Total |")
+	t.Log("|------|:--------:|:---------:|:----------:|:------:|:-------:|:--------:|")
+
+	for _, site := range sites {
+		lr := liteMap[site.name]
+		lpr := lpMap[site.name]
+
+		liteNav, liteSnap, liteTotal := "ERR", "ERR", "ERR"
+		if lr.err == "" {
+			liteNav = fmt.Sprintf("%.0f", lr.navigateMs)
+			liteSnap = fmt.Sprintf("%.0f", lr.snapshotMs)
+			liteTotal = fmt.Sprintf("%.0f", lr.totalMs)
+		}
+
+		lpNav, lpSnap, lpTotal := "ERR", "ERR", "ERR"
+		if lpr.err == "" {
+			lpNav = fmt.Sprintf("%.0f", lpr.navigateMs)
+			lpSnap = fmt.Sprintf("%.0f", lpr.snapshotMs)
+			lpTotal = fmt.Sprintf("%.0f", lpr.totalMs)
+		}
+
+		t.Logf("| %s | %s | %s | %s | %s | %s | %s |",
+			site.name, liteNav, liteSnap, liteTotal, lpNav, lpSnap, lpTotal)
+	}
+}

--- a/internal/engine/router.go
+++ b/internal/engine/router.go
@@ -12,18 +12,23 @@ import (
 // removed at runtime (under a write lock) so that the routing strategy can
 // evolve without modifying handlers or bridge code.
 type Router struct {
-	mode  Mode
-	lite  Engine // may be nil when Mode == ModeChrome
-	rules []RouteRule
-	mu    sync.RWMutex
+	mode    Mode
+	lite    Engine // may be nil when Mode == ModeChrome
+	engines map[string]Engine
+	rules   []RouteRule
+	mu      sync.RWMutex
 }
 
 // NewRouter creates a router for the given mode.
 // Pass nil for lite when running in chrome-only mode.
 func NewRouter(mode Mode, lite Engine) *Router {
 	r := &Router{
-		mode: mode,
-		lite: lite,
+		mode:    mode,
+		lite:    lite,
+		engines: make(map[string]Engine),
+	}
+	if lite != nil {
+		r.engines[lite.Name()] = lite
 	}
 
 	switch mode {
@@ -31,6 +36,11 @@ func NewRouter(mode Mode, lite Engine) *Router {
 		r.rules = []RouteRule{
 			CapabilityRule{},  // screenshot/pdf → chrome always
 			DefaultLiteRule{}, // everything else → lite
+		}
+	case ModeLightpanda:
+		r.rules = []RouteRule{
+			LightpandaCapabilityRule{}, // screenshot/pdf/cookies → chrome
+			DefaultLightpandaRule{},    // everything else → lightpanda
 		}
 	case ModeAuto:
 		r.rules = []RouteRule{
@@ -45,6 +55,15 @@ func NewRouter(mode Mode, lite Engine) *Router {
 	}
 
 	return r
+}
+
+// RegisterEngine adds an alternative engine to the router.
+// This allows the router to resolve engine names from rule decisions.
+func (r *Router) RegisterEngine(eng Engine) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.engines[eng.Name()] = eng
+	slog.Info("engine: registered", "name", eng.Name())
 }
 
 // AddRule appends a rule to the chain.  It is evaluated after all
@@ -89,6 +108,11 @@ func (r *Router) Route(op Capability, url string) Engine {
 				return r.lite
 			}
 			// lite unavailable — fall through
+		case UseLightpanda:
+			if eng, ok := r.engines["lightpanda"]; ok {
+				return eng
+			}
+			// lightpanda unavailable — fall through
 		case UseChrome:
 			return nil // nil signals "use chrome bridge"
 		}

--- a/internal/engine/rules.go
+++ b/internal/engine/rules.go
@@ -68,3 +68,32 @@ func (DefaultChromeRule) Name() string { return "default-chrome" }
 func (DefaultChromeRule) Decide(_ Capability, _ string) Decision {
 	return UseChrome
 }
+
+// LightpandaCapabilityRule routes chrome-only operations (screenshot, pdf,
+// cookies) to Chrome. Lightpanda has no visual rendering and incomplete
+// cookie persistence, so these must always go to Chrome.
+type LightpandaCapabilityRule struct{}
+
+func (LightpandaCapabilityRule) Name() string { return "lightpanda-capability" }
+
+func (LightpandaCapabilityRule) Decide(op Capability, _ string) Decision {
+	switch op {
+	case CapScreenshot, CapPDF, CapCookies:
+		return UseChrome
+	}
+	return Undecided
+}
+
+// DefaultLightpandaRule is a catch-all that routes DOM operations to the
+// Lightpanda engine. Used when Mode == ModeLightpanda.
+type DefaultLightpandaRule struct{}
+
+func (DefaultLightpandaRule) Name() string { return "default-lightpanda" }
+
+func (DefaultLightpandaRule) Decide(op Capability, _ string) Decision {
+	switch op {
+	case CapNavigate, CapSnapshot, CapText, CapClick, CapType, CapEvaluate:
+		return UseLightpanda
+	}
+	return Undecided
+}

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -92,6 +92,15 @@ func (h *Handlers) useLite(op engine.Capability, url string) bool {
 	return h.Router != nil && h.Router.UseLite(op, url)
 }
 
+// altEngine returns the alternative engine (lite or lightpanda) for the given
+// operation, or nil if the operation should use Chrome.
+func (h *Handlers) altEngine(op engine.Capability, url string) engine.Engine {
+	if h.Router == nil {
+		return nil
+	}
+	return h.Router.Route(op, url)
+}
+
 func (h *Handlers) RegisterRoutes(mux *http.ServeMux, doShutdown func()) {
 	mux.HandleFunc("GET /health", h.HandleHealth)
 	mux.HandleFunc("POST /ensure-chrome", h.HandleEnsureChrome)

--- a/internal/handlers/navigation.go
+++ b/internal/handlers/navigation.go
@@ -95,14 +95,14 @@ func (h *Handlers) HandleNavigate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// --- Lite engine fast path ---
-	if h.useLite(engine.CapNavigate, req.URL) {
-		result, err := h.Router.Lite().Navigate(r.Context(), req.URL)
+	// --- Alternative engine fast path (lite or lightpanda) ---
+	if eng := h.altEngine(engine.CapNavigate, req.URL); eng != nil {
+		result, err := eng.Navigate(r.Context(), req.URL)
 		if err != nil {
-			web.Error(w, 502, fmt.Errorf("lite navigate: %w", err))
+			web.Error(w, 502, fmt.Errorf("%s navigate: %w", eng.Name(), err))
 			return
 		}
-		w.Header().Set("X-Engine", "lite")
+		w.Header().Set("X-Engine", eng.Name())
 		web.JSON(w, 200, map[string]any{"tabId": result.TabID, "url": result.URL, "title": result.Title})
 		return
 	}

--- a/internal/handlers/snapshot.go
+++ b/internal/handlers/snapshot.go
@@ -62,11 +62,11 @@ import (
 func (h *Handlers) HandleSnapshot(w http.ResponseWriter, r *http.Request) {
 	filter := r.URL.Query().Get("filter")
 
-	// --- Lite engine fast path ---
-	if h.useLite(engine.CapSnapshot, "") {
-		nodes, err := h.Router.Lite().Snapshot(r.Context(), filter)
+	// --- Alternative engine fast path (lite or lightpanda) ---
+	if eng := h.altEngine(engine.CapSnapshot, ""); eng != nil {
+		nodes, err := eng.Snapshot(r.Context(), filter)
 		if err != nil {
-			web.Error(w, 500, fmt.Errorf("lite snapshot: %w", err))
+			web.Error(w, 500, fmt.Errorf("%s snapshot: %w", eng.Name(), err))
 			return
 		}
 		// Convert to bridge.A11yNode for API compatibility.
@@ -74,7 +74,7 @@ func (h *Handlers) HandleSnapshot(w http.ResponseWriter, r *http.Request) {
 		for i, n := range nodes {
 			flat[i] = bridge.A11yNode{Ref: n.Ref, Role: n.Role, Name: n.Name, Depth: n.Depth, Value: n.Value}
 		}
-		w.Header().Set("X-Engine", "lite")
+		w.Header().Set("X-Engine", eng.Name())
 		web.JSON(w, 200, map[string]any{"nodes": flat})
 		return
 	}

--- a/internal/handlers/text.go
+++ b/internal/handlers/text.go
@@ -18,14 +18,14 @@ import (
 //
 // @Endpoint GET /text
 func (h *Handlers) HandleText(w http.ResponseWriter, r *http.Request) {
-	// --- Lite engine fast path ---
-	if h.useLite(engine.CapText, "") {
-		text, err := h.Router.Lite().Text(r.Context())
+	// --- Alternative engine fast path (lite or lightpanda) ---
+	if eng := h.altEngine(engine.CapText, ""); eng != nil {
+		text, err := eng.Text(r.Context())
 		if err != nil {
-			web.Error(w, 500, fmt.Errorf("lite text: %w", err))
+			web.Error(w, 500, fmt.Errorf("%s text: %w", eng.Name(), err))
 			return
 		}
-		w.Header().Set("X-Engine", "lite")
+		w.Header().Set("X-Engine", eng.Name())
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		_, _ = w.Write([]byte(text))
 		return


### PR DESCRIPTION
## Summary

- Adds `LightpandaEngine` implementing the `Engine` interface with a persistent CDP WebSocket connection
- Generalizes handler dispatch from `useLite()` → `altEngine()` so any registered engine gets the fast path
- Adds `ModeLightpanda` routing mode with capability-aware rules
- Adds cross-engine benchmark suite (8 page types, static + JS-rendered)

## Positioning Change

Initial assumption was that LP would be a faster/lighter Chrome replacement. Benchmarks show otherwise — see updated findings on #201.

**LP is not faster than Lite on static HTML** (3.4x slower). Its value is as a **lightweight JS execution engine**: 24MB footprint, 0.1s startup, executes JavaScript that Lite cannot. The routing strategy is:

- Static content → Lite (fastest)
- JS-rendered SPAs → Lightpanda (lightweight JS)
- Screenshots/PDF/cookies → Chrome (pixel rendering)

## Integration Fixes

Tested against `lightpanda/browser:nightly` Docker image. Four compatibility issues found and fixed:

- `NoModifyURL` for Docker WS URL discovery
- Explicit `depth: -1` for `Accessibility.getFullAXTree`
- Single browser context reuse (LP drops connection on new target creation)
- Lenient `lpAXNode` JSON parsing for LP-specific property names

## Test Plan

- [x] 29 unit tests pass (snapshot building, routing, rules, helpers)
- [x] Full project builds clean (`go build ./...`)
- [x] Benchmark: `LIGHTPANDA_URL=ws://127.0.0.1:19222 go test ./internal/engine/ -run TestEngineBenchmark -v`
- [x] LP Docker: `docker run --rm --network=host --entrypoint lightpanda lightpanda/browser:nightly serve --host 127.0.0.1 --port 19222`
