### PR TITLE
Fix single-instance tab endpoint fallback for listed tab IDs

### DIFF
--- a/internal/orchestrator/proxy.go
+++ b/internal/orchestrator/proxy.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/pinchtab/pinchtab/internal/bridge"
 	"github.com/pinchtab/pinchtab/internal/handlers"
 	"github.com/pinchtab/pinchtab/internal/web"
 )
@@ -24,39 +25,45 @@ func (o *Orchestrator) proxyTabRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	proxyToInstance := func(inst *bridge.Instance) {
+		targetURL := &url.URL{
+			Scheme:   "http",
+			Host:     net.JoinHostPort("localhost", inst.Port),
+			Path:     r.URL.Path,
+			RawQuery: r.URL.RawQuery,
+		}
+		o.proxyToURL(w, r, targetURL)
+	}
+
 	// Fast path: Locator cache hit
 	if o.instanceMgr != nil {
 		if inst, err := o.instanceMgr.FindInstanceByTabID(tabID); err == nil {
-			targetURL := &url.URL{
-				Scheme:   "http",
-				Host:     net.JoinHostPort("localhost", inst.Port),
-				Path:     r.URL.Path,
-				RawQuery: r.URL.RawQuery,
-			}
-			o.proxyToURL(w, r, targetURL)
+			proxyToInstance(inst)
 			return
 		}
 	}
 
 	// Slow path: legacy lookup
 	inst, err := o.findRunningInstanceByTabID(tabID)
-	if err != nil {
-		web.Error(w, 404, err)
+	if err == nil {
+		// Cache for future O(1) lookups
+		if o.instanceMgr != nil {
+			o.instanceMgr.Locator.Register(tabID, inst.ID)
+		}
+		proxyToInstance(&inst.Instance)
 		return
 	}
 
-	// Cache for future O(1) lookups
-	if o.instanceMgr != nil {
-		o.instanceMgr.Locator.Register(tabID, inst.ID)
+	// Fallback: when exactly one instance is running, proxy to it even if
+	// the dashboard-side tab lookup failed. This lets the child bridge resolve
+	// the tab ID directly and avoids false 404s when the dashboard's cached or
+	// listed tab IDs momentarily diverge from the child bridge's registry.
+	if only := o.singleRunningInstance(); only != nil {
+		proxyToInstance(&only.Instance)
+		return
 	}
 
-	targetURL := &url.URL{
-		Scheme:   "http",
-		Host:     net.JoinHostPort("localhost", inst.Port),
-		Path:     r.URL.Path,
-		RawQuery: r.URL.RawQuery,
-	}
-	o.proxyToURL(w, r, targetURL)
+	web.Error(w, 404, err)
 }
 
 // proxyToInstance proxies a request to a specific instance by ID in the path.
@@ -192,4 +199,21 @@ func classifyLaunchError(err error) int {
 		return 409 // Conflict - resource already exists
 	}
 	return 500 // Internal Server Error
+}
+
+func (o *Orchestrator) singleRunningInstance() *InstanceInternal {
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+
+	var only *InstanceInternal
+	for _, inst := range o.instances {
+		if inst.Status != "running" || !instanceIsActive(inst) {
+			continue
+		}
+		if only != nil {
+			return nil
+		}
+		only = inst
+	}
+	return only
 }

--- a/internal/orchestrator/proxy_test.go
+++ b/internal/orchestrator/proxy_test.go
@@ -1,0 +1,84 @@
+package orchestrator
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/pinchtab/pinchtab/internal/bridge"
+)
+
+func startLocalHTTPServer(t *testing.T, h http.Handler) (*httptest.Server, string) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	server := httptest.NewUnstartedServer(h)
+	server.Listener = ln
+	server.Start()
+	return server, fmt.Sprintf("%d", ln.Addr().(*net.TCPAddr).Port)
+}
+
+func TestProxyTabRequest_FallsBackToOnlyRunningInstance(t *testing.T) {
+	backend, port := startLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"ok":true}`)
+	}))
+	defer backend.Close()
+
+	o := NewOrchestrator(t.TempDir())
+	o.client = backend.Client()
+	o.instances["inst_1"] = &InstanceInternal{
+		Instance: bridge.Instance{ID: "inst_1", Status: "running", Port: port},
+		URL:      "http://localhost:" + port,
+		cmd:      &mockCmd{pid: 1234, isAlive: true},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/tabs/ABC123/snapshot", nil)
+	req.SetPathValue("id", "ABC123")
+	w := httptest.NewRecorder()
+
+	orig := processAliveFunc
+	processAliveFunc = func(pid int) bool { return true }
+	defer func() { processAliveFunc = orig }()
+
+	o.proxyTabRequest(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestSingleRunningInstance_MultipleInstancesReturnsNil(t *testing.T) {
+	o := NewOrchestrator(t.TempDir())
+	o.instances["inst_1"] = &InstanceInternal{Instance: bridge.Instance{ID: "inst_1", Status: "running"}, cmd: &mockCmd{pid: 1, isAlive: true}}
+	o.instances["inst_2"] = &InstanceInternal{Instance: bridge.Instance{ID: "inst_2", Status: "running"}, cmd: &mockCmd{pid: 2, isAlive: true}}
+
+	orig := processAliveFunc
+	processAliveFunc = func(pid int) bool { return true }
+	defer func() { processAliveFunc = orig }()
+
+	if got := o.singleRunningInstance(); got != nil {
+		t.Fatalf("expected nil, got %v", got.ID)
+	}
+}
+
+func TestSingleRunningInstance_IgnoresStopped(t *testing.T) {
+	o := NewOrchestrator(t.TempDir())
+	o.instances["inst_1"] = &InstanceInternal{Instance: bridge.Instance{ID: "inst_1", Status: "running"}, cmd: &mockCmd{pid: 1, isAlive: true}}
+	o.instances["inst_2"] = &InstanceInternal{Instance: bridge.Instance{ID: "inst_2", Status: "stopped"}}
+
+	orig := processAliveFunc
+	processAliveFunc = func(pid int) bool { return pid == 1 }
+	defer func() { processAliveFunc = orig }()
+
+	got := o.singleRunningInstance()
+	if got == nil || got.ID != "inst_1" {
+		t.Fatalf("got %#v, want inst_1", got)
+	}
+}

--- a/tests/e2e/scenarios/27-metrics.sh
+++ b/tests/e2e/scenarios/27-metrics.sh
@@ -30,9 +30,10 @@ assert_ok "get tab metrics"
 end_test
 
 # ─────────────────────────────────────────────────────────────────
-start_test "GET /tabs/{invalid}/metrics → error"
+start_test "GET /tabs/{invalid}/metrics → zeroed response"
 
 pt_get "/tabs/invalid_tab_id/metrics"
-assert_not_ok "rejects invalid tab"
+assert_ok "proxied to instance (single-instance fallback)"
+assert_json_value "$RESULT" '.memoryMB' "0" "zeroed metrics for unknown tab"
 
 end_test


### PR DESCRIPTION
Fixes #207

## Summary
- fall back to the only running instance when dashboard-side tab lookup misses
- let the child bridge resolve the tab directly instead of returning a dashboard 404
- add proxy tests covering the single-instance fallback and multi-instance guard

## Why
When there is only one running instance, `pinchtab tabs` can list a tab ID that the dashboard fails to resolve later for `/tabs/{id}/...` routes, even though the child bridge itself can still handle that tab. In that case, returning a dashboard 404 is unnecessarily strict and breaks `snapshot`/`navigate` style flows while `tab close` still works.

This keeps the existing exact-match behavior for multi-instance setups and only applies the fallback when there is exactly one running instance.