### PR TITLE
test: add Linux legacy config fallback regression tests (issue #224)

### DIFF
--- a/internal/config/config_utils_test.go
+++ b/internal/config/config_utils_test.go
@@ -1,6 +1,11 @@
 package config
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
 
 func TestCompareVersions(t *testing.T) {
 	tests := []struct {
@@ -52,5 +57,80 @@ func TestIsFirstRun(t *testing.T) {
 	}
 	if IsFirstRun(&FileConfig{ConfigVersion: "0.8.0"}) {
 		t.Error("expected not IsFirstRun for versioned config")
+	}
+}
+
+// TestUserConfigDirLegacyConfigFilePriority tests that when legacy config FILE exists
+// but the XDG config directory already exists (without config.json), the legacy path
+// is still used. This exercises the full userConfigDir path resolution for issue #224.
+func TestUserConfigDirLegacyConfigFilePriority(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Linux-specific XDG path test")
+	}
+
+	tmpHome, err := os.MkdirTemp("", "pinchtab-home-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp home: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpHome) }()
+
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmpHome, ".config"))
+
+	legacyDir := filepath.Join(tmpHome, ".pinchtab")
+	newDir := filepath.Join(tmpHome, ".config", "pinchtab")
+	if err := os.MkdirAll(legacyDir, 0755); err != nil {
+		t.Fatalf("Failed to create legacy dir: %v", err)
+	}
+	if err := os.MkdirAll(newDir, 0755); err != nil {
+		t.Fatalf("Failed to create new dir: %v", err)
+	}
+
+	legacyConfig := filepath.Join(legacyDir, "config.json")
+	if err := os.WriteFile(legacyConfig, []byte(`{"server":{"port":"9876"}}`), 0644); err != nil {
+		t.Fatalf("Failed to create legacy config: %v", err)
+	}
+
+	got := userConfigDir()
+	if got != legacyDir {
+		t.Fatalf("userConfigDir() = %q, want legacy path %q", got, legacyDir)
+	}
+}
+
+func TestUserConfigDirPrefersNewConfigFileWhenPresent(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Linux-specific XDG path test")
+	}
+
+	tmpHome, err := os.MkdirTemp("", "pinchtab-home-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp home: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpHome) }()
+
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmpHome, ".config"))
+
+	legacyDir := filepath.Join(tmpHome, ".pinchtab")
+	newDir := filepath.Join(tmpHome, ".config", "pinchtab")
+	if err := os.MkdirAll(legacyDir, 0755); err != nil {
+		t.Fatalf("Failed to create legacy dir: %v", err)
+	}
+	if err := os.MkdirAll(newDir, 0755); err != nil {
+		t.Fatalf("Failed to create new dir: %v", err)
+	}
+
+	for _, path := range []string{
+		filepath.Join(legacyDir, "config.json"),
+		filepath.Join(newDir, "config.json"),
+	} {
+		if err := os.WriteFile(path, []byte(`{"server":{"port":"9876"}}`), 0644); err != nil {
+			t.Fatalf("Failed to create config %s: %v", path, err)
+		}
+	}
+
+	got := userConfigDir()
+	if got != newDir {
+		t.Fatalf("userConfigDir() = %q, want new XDG path %q", got, newDir)
 	}
 }


### PR DESCRIPTION
Port of #246 to the new file structure after #251 merged.

Tests moved to `config_utils_test.go` (where `userConfigDir()` lives post file-split). Uses `t.Setenv` to properly exercise the full path resolution.

Two tests:
1. Legacy config file wins when XDG dir exists but has no config.json
2. New XDG path wins when both locations have config.json

Closes #224