### PR TITLE
fix(e2e): scheduler validation test flake

### DIFF
--- a/tests/e2e/scenarios/39-scheduler.sh
+++ b/tests/e2e/scenarios/39-scheduler.sh
@@ -207,7 +207,7 @@ end_test
 # ─────────────────────────────────────────────────────────────────
 start_test "POST /tasks — missing action → 400"
 
-pt_post /tasks -d "{\"agentId\":\"${AGENT}\"}"
+pt_post /tasks -d "{\"agentId\":\"validation-agent-$$\"}"
 assert_http_status "400" "missing action rejected"
 
 end_test


### PR DESCRIPTION
The `POST /tasks — missing action → 400` test reused `$AGENT` which could hit the per-agent queue limit (`maxPerAgent=3`) left over from the 429 flood test, causing a flaky 429 instead of the expected 400.

Fix: use a unique agent ID for the validation test.