### PR TITLE
Add shell completion command

### DIFF
--- a/cmd/pinchtab/cmd_completion.go
+++ b/cmd/pinchtab/cmd_completion.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var completionCmd = &cobra.Command{
+	Use:   "completion [bash|zsh|fish|powershell]",
+	Short: "Generate shell completion script",
+	Long: `Generate a shell completion script for pinchtab.
+
+To load completions:
+
+Bash:
+  $ source <(pinchtab completion bash)
+
+  # To load completions for each session, execute once:
+  # Linux:
+  $ pinchtab completion bash > /etc/bash_completion.d/pinchtab
+  # macOS:
+  $ pinchtab completion bash > $(brew --prefix)/etc/bash_completion.d/pinchtab
+
+Zsh:
+  # If shell completion is not already enabled in your environment,
+  # you will need to enable it. You can execute the following once:
+  $ echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+  # To load completions for each session, execute once:
+  $ pinchtab completion zsh > "${fpath[1]}/_pinchtab"
+
+  # You will need to start a new shell for this setup to take effect.
+
+Fish:
+  $ pinchtab completion fish | source
+
+  # To load completions for each session, execute once:
+  $ pinchtab completion fish > ~/.config/fish/completions/pinchtab.fish
+
+PowerShell:
+  PS> pinchtab completion powershell | Out-String | Invoke-Expression
+
+  # To load completions for every new session, add the output to your profile:
+  PS> pinchtab completion powershell > pinchtab.ps1
+  # and source this file from your PowerShell profile.
+`,
+	DisableFlagsInUseLine: true,
+	ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+	Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		switch args[0] {
+		case "bash":
+			return rootCmd.GenBashCompletion(os.Stdout)
+		case "zsh":
+			return rootCmd.GenZshCompletion(os.Stdout)
+		case "fish":
+			return rootCmd.GenFishCompletion(os.Stdout, true)
+		case "powershell":
+			return rootCmd.GenPowerShellCompletionWithDesc(os.Stdout)
+		}
+		return nil
+	},
+}
+
+func init() {
+	completionCmd.GroupID = "config"
+	rootCmd.AddCommand(completionCmd)
+}


### PR DESCRIPTION
## Summary

Adds a `pinchtab completion [bash|zsh|fish|powershell]` command that generates shell completion scripts using Cobra's built-in completion generation.

<img width="589" height="340" alt="Screenshot 2026-03-14 at 09 38 40" src="https://github.com/user-attachments/assets/b83c8296-6ba2-4b5b-b71e-6aa127dced17" />

## Problem

Cobra provides a built-in `completion` command and a hidden `__complete` command for dynamic completions. However, neither works in pinchtab because `rootCmd` has a `Run` handler that catches all unrecognized subcommands and falls through to `server.RunDashboard()`. This means both `pinchtab completion zsh` and the dynamic `pinchtab __complete ""` (used by shell completion scripts at runtime) are swallowed by the root handler and start the server instead.

Additionally, when installed via npm (`npm install -g pinchtab`), there is a Node.js wrapper at `/opt/homebrew/bin/pinchtab` that spawns the Go binary at `~/.pinchtab/bin/<version>/pinchtab-darwin-<arch>`. The orchestrator's `installStableBinary()` re-copies the running binary to `~/.pinchtab/bin/pinchtab` on every server start. This creates a second issue: even with the completion command added, the dynamic `__complete` calls from the shell completion script go through the Node wrapper -> Go binary at the `~/.pinchtab/bin/` path, where the binary hangs (likely due to the orchestrator detecting its own binary path).

**The completions work correctly when the Go binary is invoked directly** (not through the Node wrapper).

## What this PR does

- Adds `cmd/pinchtab/cmd_completion.go` with an explicit `completion` subcommand in the "config" command group
- Supports all four shells: bash, zsh, fish, powershell
- Includes usage instructions in the command's long description

## Usage

```sh
# Generate and install zsh completions
pinchtab completion zsh > "${fpath[1]}/_pinchtab"

# Generate bash completions
pinchtab completion bash > /etc/bash_completion.d/pinchtab

# Generate fish completions
pinchtab completion fish > ~/.config/fish/completions/pinchtab.fish
```

## Note on npm wrapper

For dynamic completions to work at runtime (tab-completing subcommands and flags), the shell needs to call `pinchtab __complete ...` which must reach the Go binary directly. This does not work through the npm Node.js wrapper because the spawned Go binary at `~/.pinchtab/bin/` hangs instead of handling the `__complete` subcommand.

Users installing via npm will need to either:
1. Add the Go binary directly to their PATH (e.g., `cp ~/.pinchtab/bin/<version>/pinchtab-darwin-arm64 ~/bin/pinchtab`)
2. Or use `pinchtab completion <shell>` to generate a static script and modify it to point to the Go binary

It may be worth considering distributing pinchtab as a standalone binary (via Homebrew, GitHub releases, etc.) rather than through npm, which would avoid this issue entirely.

## Test plan

- [x] `pinchtab completion zsh` outputs valid zsh completion script
- [x] `pinchtab completion bash` outputs valid bash completion script
- [x] `pinchtab completion fish` outputs valid fish completion script
- [x] `pinchtab completion powershell` outputs valid powershell completion script
- [x] Tab completion works in zsh when using the Go binary directly
- [ ] Verify no regressions in existing commands