### PR TITLE
fix: recognize proceed-to-payment checkout intent

### DIFF
--- a/internal/semantic/improvements_test.go
+++ b/internal/semantic/improvements_test.go
@@ -542,6 +542,26 @@ func TestCombined_Synonym_Purchase_Checkout(t *testing.T) {
 	}
 }
 
+func TestCombined_Synonym_ProceedToPayment_PlaceOrder(t *testing.T) {
+	sites := buildRealWorldElements()
+	matcher := NewCombinedMatcher(NewHashingEmbedder(128))
+
+	result, err := matcher.Find(context.Background(), "proceed to payment", sites["ecommerce"], FindOptions{
+		Threshold: 0.15,
+		TopK:      5,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("Query='proceed to payment': BestRef=%s Score=%.3f", result.BestRef, result.BestScore)
+	for _, m := range result.Matches {
+		t.Logf("  match: ref=%s score=%.3f role=%s name=%s", m.Ref, m.Score, m.Role, m.Name)
+	}
+	if result.BestRef != "e8" {
+		t.Fatalf("expected 'proceed to payment' to match 'Place Order' (e8), got %s", result.BestRef)
+	}
+}
+
 func TestCombined_Synonym_Dismiss_Close(t *testing.T) {
 	sites := buildRealWorldElements()
 	matcher := NewCombinedMatcher(NewHashingEmbedder(128))

--- a/internal/semantic/synonyms.go
+++ b/internal/semantic/synonyms.go
@@ -55,7 +55,7 @@ var uiSynonyms = map[string][]string{
 
 	// Shopping & e-commerce
 	"cart":     {"basket", "bag", "shopping cart"},
-	"checkout": {"pay", "purchase", "buy", "place order", "order"},
+	"checkout": {"pay", "payment", "purchase", "buy", "place order", "order", "proceed to payment"},
 	"price":    {"cost", "amount", "total"},
 	"quantity": {"qty", "count", "amount"},
 


### PR DESCRIPTION
## Summary
- add `payment` and `proceed to payment` as checkout-family semantic synonyms
- cover the real-world regression with a focused matcher test for `proceed to payment` → `Place Order`
- verify the broader semantic package still passes, including the benchmark study suite

## Why
Fixes part of #143.

The semantic matcher still missed a common checkout phrasing: `proceed to payment` ranked `Buy Now` above `Place Order`, and the hard-case benchmark still marked that synonym case as a miss on main.

This keeps the change narrow and low-risk by extending the existing static synonym table instead of changing matcher weights or ranking behavior globally.

## Testing
- `go test ./internal/semantic -run 'TestCombined_Synonym_ProceedToPayment_PlaceOrder|TestBenchmarkStudy' -v`
- `go test ./internal/semantic/...`
