### PR TITLE
fix(cli): detect fill refs by numeric element id

### DIFF
--- a/internal/cli/actions/actions_element.go
+++ b/internal/cli/actions/actions_element.go
@@ -10,6 +10,18 @@ import (
 	"strings"
 )
 
+func isElementRef(value string) bool {
+	if len(value) < 2 || value[0] != 'e' {
+		return false
+	}
+	for i := 1; i < len(value); i++ {
+		if value[i] < '0' || value[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
 func Action(client *http.Client, base, token, kind, refArg string, cmd *cobra.Command) {
 	body := map[string]any{"kind": kind}
 
@@ -44,7 +56,7 @@ func ActionSimple(client *http.Client, base, token, kind string, args []string, 
 		body["ref"] = args[0]
 		body["text"] = strings.Join(args[1:], " ")
 	case "fill":
-		if strings.HasPrefix(args[0], "e") {
+		if isElementRef(args[0]) {
 			body["ref"] = args[0]
 		} else {
 			body["selector"] = args[0]

--- a/internal/cli/actions/actions_element_test.go
+++ b/internal/cli/actions/actions_element_test.go
@@ -191,9 +191,20 @@ func TestFill(t *testing.T) {
 	}
 
 	ActionSimple(client, m.base(), "", "fill", []string{"#email", "user@test.com"}, cmd)
+	body = nil
 	_ = json.Unmarshal([]byte(m.lastBody), &body)
 	if body["selector"] != "#email" {
 		t.Errorf("expected selector=#email, got %v", body["selector"])
+	}
+
+	ActionSimple(client, m.base(), "", "fill", []string{"embed", "inline content"}, cmd)
+	body = nil
+	_ = json.Unmarshal([]byte(m.lastBody), &body)
+	if body["selector"] != "embed" {
+		t.Errorf("expected selector=embed, got %v", body["selector"])
+	}
+	if _, hasRef := body["ref"]; hasRef {
+		t.Errorf("expected no ref for selector embed, got %v", body["ref"])
 	}
 }
 
@@ -211,12 +222,14 @@ func TestScroll(t *testing.T) {
 	}
 
 	ActionSimple(client, m.base(), "", "scroll", []string{"800"}, cmd)
+	body = nil
 	_ = json.Unmarshal([]byte(m.lastBody), &body)
 	if body["scrollY"] != float64(800) {
 		t.Errorf("expected scrollY=800, got %v", body["scrollY"])
 	}
 
 	ActionSimple(client, m.base(), "", "scroll", []string{"down"}, cmd)
+	body = nil
 	_ = json.Unmarshal([]byte(m.lastBody), &body)
 	if body["scrollY"] != float64(800) {
 		t.Errorf("expected scrollY=800 for direction=down, got %v", body["scrollY"])


### PR DESCRIPTION
## Summary
- treat CLI `fill` targets as element refs only when they match `e` followed by digits
- keep CSS selectors like `embed` flowing through `selector` instead of misclassifying them as refs
- add focused regression coverage in `internal/cli/actions`

## Testing
- `PATH=/tmp/pinchtab-fix-x9upXm/go1.25/bin:$PATH go test ./internal/cli/actions -run 'Test(Fill|Scroll)' -count=1`
- `PATH=/tmp/pinchtab-fix-x9upXm/go1.25/bin:$PATH go test ./internal/cli/actions -count=1`
