### PR TITLE
feat: support click/hover by x/y coordinates

### DIFF
--- a/cmd/pinchtab/cmd_cli.go
+++ b/cmd/pinchtab/cmd_cli.go
@@ -327,8 +327,12 @@ func init() {
 	downloadCmd.Flags().StringP("output", "o", "", "Save downloaded file to path")
 
 	clickCmd.Flags().String("css", "", "CSS selector instead of ref")
+	clickCmd.Flags().Float64("x", 0, "X coordinate for click")
+	clickCmd.Flags().Float64("y", 0, "Y coordinate for click")
 	clickCmd.Flags().Bool("wait-nav", false, "Wait for navigation after click")
 	hoverCmd.Flags().String("css", "", "CSS selector instead of ref")
+	hoverCmd.Flags().Float64("x", 0, "X coordinate for hover")
+	hoverCmd.Flags().Float64("y", 0, "Y coordinate for hover")
 
 	snapCmd.Flags().BoolP("interactive", "i", false, "Filter interactive elements only")
 	snapCmd.Flags().BoolP("compact", "c", false, "Compact output format")

--- a/internal/bridge/actions.go
+++ b/internal/bridge/actions.go
@@ -31,8 +31,10 @@ func (b *Bridge) InitActionRegistry() {
 				err = chromedp.Run(ctx, chromedp.Click(req.Selector, chromedp.ByQuery))
 			} else if req.NodeID > 0 {
 				err = ClickByNodeID(ctx, req.NodeID)
+			} else if req.HasXY {
+				err = ClickByCoordinate(ctx, req.X, req.Y)
 			} else {
-				return nil, fmt.Errorf("need selector, ref, or nodeId")
+				return nil, fmt.Errorf("need selector, ref, nodeId, or x/y coordinates")
 			}
 			if err != nil {
 				return nil, err
@@ -95,7 +97,10 @@ func (b *Bridge) InitActionRegistry() {
 					chromedp.Evaluate(fmt.Sprintf(`document.querySelector(%q)?.dispatchEvent(new MouseEvent('mouseover', {bubbles:true}))`, req.Selector), nil),
 				)
 			}
-			return nil, fmt.Errorf("need selector or ref")
+			if req.HasXY {
+				return map[string]any{"hovered": true}, HoverByCoordinate(ctx, req.X, req.Y)
+			}
+			return nil, fmt.Errorf("need selector, ref, nodeId, or x/y coordinates")
 		},
 		ActionSelect: func(ctx context.Context, req ActionRequest) (map[string]any, error) {
 			val := req.Value

--- a/internal/bridge/actions_test.go
+++ b/internal/bridge/actions_test.go
@@ -1,0 +1,39 @@
+package bridge
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/pinchtab/pinchtab/internal/config"
+)
+
+func TestClickAction_UsesCoordinatePathIncludingZeroZero(t *testing.T) {
+	b := New(context.TODO(), nil, &config.RuntimeConfig{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := b.Actions[ActionClick](ctx, ActionRequest{HasXY: true, X: 0, Y: 0})
+	if err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+	if strings.Contains(err.Error(), "need selector") {
+		t.Fatalf("expected coordinate path, got selector/ref validation error: %v", err)
+	}
+}
+
+func TestHoverAction_UsesCoordinatePath(t *testing.T) {
+	b := New(context.TODO(), nil, &config.RuntimeConfig{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := b.Actions[ActionHover](ctx, ActionRequest{HasXY: true, X: 12.5, Y: 34.5})
+	if err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+	if strings.Contains(err.Error(), "need selector") {
+		t.Fatalf("expected coordinate path, got selector/ref validation error: %v", err)
+	}
+}

--- a/internal/bridge/bridge.go
+++ b/internal/bridge/bridge.go
@@ -225,19 +225,22 @@ type ActionFunc func(ctx context.Context, req ActionRequest) (map[string]any, er
 
 // ActionRequest defines the parameters for a browser action.
 type ActionRequest struct {
-	TabID    string `json:"tabId"`
-	Kind     string `json:"kind"`
-	Ref      string `json:"ref"`
-	Selector string `json:"selector"`
-	Text     string `json:"text"`
-	Key      string `json:"key"`
-	Value    string `json:"value"`
-	NodeID   int64  `json:"nodeId"`
-	ScrollX  int    `json:"scrollX"`
-	ScrollY  int    `json:"scrollY"`
-	DragX    int    `json:"dragX"`
-	DragY    int    `json:"dragY"`
-	WaitNav  bool   `json:"waitNav"`
-	Fast     bool   `json:"fast"`
-	Owner    string `json:"owner"`
+	TabID    string  `json:"tabId"`
+	Kind     string  `json:"kind"`
+	Ref      string  `json:"ref"`
+	Selector string  `json:"selector"`
+	Text     string  `json:"text"`
+	Key      string  `json:"key"`
+	Value    string  `json:"value"`
+	NodeID   int64   `json:"nodeId"`
+	X        float64 `json:"x"`
+	Y        float64 `json:"y"`
+	HasXY    bool    `json:"hasXY,omitempty"`
+	ScrollX  int     `json:"scrollX"`
+	ScrollY  int     `json:"scrollY"`
+	DragX    int     `json:"dragX"`
+	DragY    int     `json:"dragY"`
+	WaitNav  bool    `json:"waitNav"`
+	Fast     bool    `json:"fast"`
+	Owner    string  `json:"owner"`
 }

--- a/internal/bridge/cdp.go
+++ b/internal/bridge/cdp.go
@@ -154,6 +154,35 @@ func SetResourceBlocking(ctx context.Context, patterns []string) error {
 	)
 }
 
+func ClickByCoordinate(ctx context.Context, x, y float64) error {
+	if x < 0 || y < 0 {
+		return fmt.Errorf("x/y coordinates must be >= 0")
+	}
+
+	return chromedp.Run(ctx,
+		chromedp.ActionFunc(func(ctx context.Context) error {
+			return chromedp.FromContext(ctx).Target.Execute(ctx,
+				"Input.dispatchMouseEvent", map[string]any{
+					"type":       "mousePressed",
+					"button":     "left",
+					"clickCount": 1,
+					"x":          x,
+					"y":          y,
+				}, nil)
+		}),
+		chromedp.ActionFunc(func(ctx context.Context) error {
+			return chromedp.FromContext(ctx).Target.Execute(ctx,
+				"Input.dispatchMouseEvent", map[string]any{
+					"type":       "mouseReleased",
+					"button":     "left",
+					"clickCount": 1,
+					"x":          x,
+					"y":          y,
+				}, nil)
+		}),
+	)
+}
+
 func ClickByNodeID(ctx context.Context, nodeID int64) error {
 	// Get element position via box model
 	x, y, err := getElementCenter(ctx, nodeID)
@@ -443,6 +472,22 @@ func TypeByNodeID(ctx context.Context, nodeID int64, text string) error {
 			return chromedp.FromContext(ctx).Target.Execute(ctx, "DOM.focus", map[string]any{"backendNodeId": nodeID}, nil)
 		}),
 		chromedp.KeyEvent(text),
+	)
+}
+
+func HoverByCoordinate(ctx context.Context, x, y float64) error {
+	if x < 0 || y < 0 {
+		return fmt.Errorf("x/y coordinates must be >= 0")
+	}
+
+	return chromedp.Run(ctx,
+		chromedp.ActionFunc(func(ctx context.Context) error {
+			return chromedp.FromContext(ctx).Target.Execute(ctx, "Input.dispatchMouseEvent", map[string]any{
+				"type": "mouseMoved",
+				"x":    x,
+				"y":    y,
+			}, nil)
+		}),
 	)
 }
 

--- a/internal/bridge/cdp_test.go
+++ b/internal/bridge/cdp_test.go
@@ -167,3 +167,34 @@ func TestDispatchNamedKey_KnownKeyOnCancelledCtx(t *testing.T) {
 		t.Error("expected error dispatching Enter on cancelled context")
 	}
 }
+
+func TestClickByCoordinate_ContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := ClickByCoordinate(ctx, 0, 0)
+	if err == nil {
+		t.Fatal("expected error for cancelled context")
+	}
+}
+
+func TestHoverByCoordinate_ContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := HoverByCoordinate(ctx, 10, 20)
+	if err == nil {
+		t.Fatal("expected error for cancelled context")
+	}
+}
+
+func TestCoordinateActions_RejectNegativeCoordinates(t *testing.T) {
+	ctx := context.Background()
+
+	if err := ClickByCoordinate(ctx, -1, 0); err == nil {
+		t.Fatal("expected click negative coordinate to fail")
+	}
+	if err := HoverByCoordinate(ctx, 0, -1); err == nil {
+		t.Fatal("expected hover negative coordinate to fail")
+	}
+}

--- a/internal/cli/actions/actions_element.go
+++ b/internal/cli/actions/actions_element.go
@@ -26,12 +26,23 @@ func Action(client *http.Client, base, token, kind, refArg string, cmd *cobra.Co
 	body := map[string]any{"kind": kind}
 
 	css, _ := cmd.Flags().GetString("css")
+	hasX := cmd.Flags().Changed("x")
+	hasY := cmd.Flags().Changed("y")
+	x, _ := cmd.Flags().GetFloat64("x")
+	y, _ := cmd.Flags().GetFloat64("y")
+	hasXY := hasX || hasY
+	if hasXY {
+		body["x"] = x
+		body["y"] = y
+		body["hasXY"] = true
+	}
+
 	if css != "" {
 		body["selector"] = css
 	} else if refArg != "" {
 		body["ref"] = refArg
-	} else {
-		cli.Fatal("Usage: pinchtab %s <ref> or pinchtab %s --css <selector>", kind, kind)
+	} else if !hasXY {
+		cli.Fatal("Usage: pinchtab %s <ref> or pinchtab %s --css <selector> or pinchtab %s --x <num> --y <num>", kind, kind, kind)
 	}
 
 	if kind == "click" {

--- a/internal/handlers/actions.go
+++ b/internal/handlers/actions.go
@@ -63,6 +63,23 @@ func (h *Handlers) HandleAction(w http.ResponseWriter, r *http.Request) {
 				req.NodeID = n
 			}
 		}
+		if v := q.Get("x"); v != "" {
+			if n, err := strconv.ParseFloat(v, 64); err == nil {
+				req.X = n
+				req.HasXY = true
+			}
+		}
+		if v := q.Get("y"); v != "" {
+			if n, err := strconv.ParseFloat(v, 64); err == nil {
+				req.Y = n
+				req.HasXY = true
+			}
+		}
+		if v := q.Get("hasXY"); v != "" {
+			if b, err := strconv.ParseBool(v); err == nil {
+				req.HasXY = b
+			}
+		}
 	} else {
 		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxBodySize)).Decode(&req); err != nil {
 			web.Error(w, 400, fmt.Errorf("decode: %w", err))


### PR DESCRIPTION
## Summary
- add `x`, `y`, and `hasXY` fields to `bridge.ActionRequest`
- add CDP helpers `ClickByCoordinate` and `HoverByCoordinate`
- wire coordinate paths into `click` and `hover` action handlers
- reject negative coordinates for coordinate-based click/hover
- add CLI `--x` and `--y` flags for `pinchtab click` and `pinchtab hover`
- update HTTP GET action parsing to accept coordinate params
- add unit tests for coordinate dispatch and coordinate CDP helpers

## Validation

### `go build ./...` ✅
No errors.

### `go test ./...` ✅
```
ok   github.com/pinchtab/pinchtab/cmd/pinchtab             0.085s
ok   github.com/pinchtab/pinchtab/internal/allocation       0.019s
ok   github.com/pinchtab/pinchtab/internal/bridge           5.491s
ok   github.com/pinchtab/pinchtab/internal/cli              (cached)
ok   github.com/pinchtab/pinchtab/internal/cli/actions      0.117s
ok   github.com/pinchtab/pinchtab/internal/config           (cached)
ok   github.com/pinchtab/pinchtab/internal/dashboard        0.080s
ok   github.com/pinchtab/pinchtab/internal/engine           (cached)
ok   github.com/pinchtab/pinchtab/internal/handlers         3.512s
ok   github.com/pinchtab/pinchtab/internal/human            (cached)
ok   github.com/pinchtab/pinchtab/internal/idpi             (cached)
ok   github.com/pinchtab/pinchtab/internal/idutil           (cached)
ok   github.com/pinchtab/pinchtab/internal/instance         0.013s
ok   github.com/pinchtab/pinchtab/internal/mcp              (cached)
ok   github.com/pinchtab/pinchtab/internal/orchestrator     0.554s
ok   github.com/pinchtab/pinchtab/internal/profiles         0.336s
ok   github.com/pinchtab/pinchtab/internal/proxy            0.043s
ok   github.com/pinchtab/pinchtab/internal/scheduler        1.067s
ok   github.com/pinchtab/pinchtab/internal/semantic         (cached)
ok   github.com/pinchtab/pinchtab/internal/server           0.012s
ok   github.com/pinchtab/pinchtab/internal/strategy         0.017s
ok   github.com/pinchtab/pinchtab/internal/strategy/autorestart  0.227s
ok   github.com/pinchtab/pinchtab/internal/strategy/simple  0.067s
ok   github.com/pinchtab/pinchtab/internal/uameta           (cached)
ok   github.com/pinchtab/pinchtab/internal/web              (cached)
ok   github.com/pinchtab/pinchtab/tests/release             (cached)
```

### `go vet ./...` ✅
No issues.

## New tests added

**`internal/bridge/actions_test.go`** (new file):
- `TestClickAction_UsesCoordinatePathIncludingZeroZero` — verifies coordinate dispatch including (0,0)
- `TestHoverAction_UsesCoordinatePath` — verifies hover coordinate dispatch

**`internal/bridge/cdp_test.go`** (extended):
- `TestClickByCoordinate_ContextCancelled`
- `TestHoverByCoordinate_ContextCancelled`
- `TestCoordinateActions_RejectNegativeCoordinates`

## Design note: `HasXY` field
Using `HasXY bool` instead of `x != 0 || y != 0` to correctly support clicking at coordinate (0, 0) (top-left corner).

Closes #218.