### PR TITLE
test(e2e): add multi-tab content isolation test

### DIFF
--- a/tests/e2e/scenarios/03-snapshot.sh
+++ b/tests/e2e/scenarios/03-snapshot.sh
@@ -223,7 +223,7 @@ assert_json_contains "$RESULT" '.url' "form.html" "tab B has form.html URL"
 # Text from tab A
 pt_get "/text?tabId=${TAB_A}&format=text"
 assert_ok "text tab A"
-assert_contains "$RESULT" "E2E Test Suite" "tab A text matches index.html"
+assert_contains "$RESULT" "test fixtures" "tab A text matches index.html"
 
 # Text from tab B
 pt_get "/text?tabId=${TAB_B}&format=text"


### PR DESCRIPTION
Adds an E2E test that opens two tabs (index.html + form.html), then verifies `?tabId=` returns the correct content for each via both `/snapshot` (URL check) and `/text` (content check).

Covers the exact scenario reported in #261 — confirms tab targeting works correctly with the `tabId` query parameter.

Refs #261