### PR TITLE
Add manual dashboard screenshot preview

### DIFF
--- a/dashboard/src/pages/MonitoringPage.test.tsx
+++ b/dashboard/src/pages/MonitoringPage.test.tsx
@@ -1,0 +1,164 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import MonitoringPage from "./MonitoringPage";
+import { useAppStore } from "../stores/useAppStore";
+import type { Instance, InstanceTab, Settings } from "../generated/types";
+
+const apiMock = vi.hoisted(() => ({
+  fetchTabScreenshot: vi.fn(),
+  stopInstance: vi.fn(),
+}));
+
+vi.mock("../services/api", () => apiMock);
+
+vi.mock("../components/molecules", () => ({
+  TabsChart: () => <div data-testid="tabs-chart" />,
+  InstanceListItem: ({
+    instance,
+    onClick,
+    selected,
+  }: {
+    instance: Instance;
+    onClick: () => void;
+    selected: boolean;
+  }) => (
+    <button onClick={onClick} aria-pressed={selected}>
+      {instance.profileName}
+    </button>
+  ),
+  TabItem: ({ tab }: { tab: InstanceTab }) => <div>{tab.title}</div>,
+}));
+
+const baseSettings: Settings = {
+  screencast: { fps: 1, quality: 30, maxWidth: 800 },
+  stealth: "light",
+  browser: { blockImages: false, blockMedia: false, noAnimations: false },
+  monitoring: { memoryMetrics: false, pollInterval: 30 },
+};
+
+const instances: Instance[] = [
+  {
+    id: "inst_headless",
+    profileId: "prof_headless",
+    profileName: "Headless worker",
+    port: "9988",
+    headless: true,
+    status: "running",
+    startTime: "2026-03-06T10:00:00Z",
+    attached: false,
+  },
+  {
+    id: "inst_empty",
+    profileId: "prof_empty",
+    profileName: "No tabs",
+    port: "9989",
+    headless: false,
+    status: "running",
+    startTime: "2026-03-06T11:00:00Z",
+    attached: false,
+  },
+];
+
+const tabsByInstance: Record<string, InstanceTab[]> = {
+  inst_headless: [
+    {
+      id: "tab_primary",
+      instanceId: "inst_headless",
+      title: "PinchTab Dashboard",
+      url: "https://pinchtab.dev/dashboard",
+    },
+  ],
+  inst_empty: [],
+};
+
+describe("MonitoringPage", () => {
+  const createObjectURL = vi.fn();
+  const revokeObjectURL = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createObjectURL.mockReturnValue("blob:preview-1");
+    useAppStore.setState({
+      instances,
+      tabsChartData: [],
+      memoryChartData: [],
+      serverChartData: [],
+      currentTabs: tabsByInstance,
+      currentMemory: {},
+      settings: baseSettings,
+    });
+    vi.stubGlobal("URL", {
+      ...URL,
+      createObjectURL,
+      revokeObjectURL,
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("captures and shows a manual screenshot preview for the selected instance", async () => {
+    apiMock.fetchTabScreenshot.mockResolvedValue(
+      new Blob(["png"], { type: "image/png" }),
+    );
+
+    render(<MonitoringPage />);
+
+    const captureButton = screen.getByRole("button", {
+      name: "Capture Screenshot",
+    });
+    expect(captureButton).toBeEnabled();
+    expect(
+      screen.getByText("Capture a manual screenshot of the first open tab."),
+    ).toBeInTheDocument();
+
+    await userEvent.click(captureButton);
+
+    await waitFor(() =>
+      expect(apiMock.fetchTabScreenshot).toHaveBeenCalledWith("tab_primary"),
+    );
+
+    const preview = await screen.findByRole("img", {
+      name: "Screenshot preview for Headless worker",
+    });
+    expect(preview).toHaveAttribute("src", "blob:preview-1");
+    expect(
+      screen.getByText("Last captured from tab tab_primary"),
+    ).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: "Refresh Screenshot" }),
+    ).toBeVisible();
+  });
+
+  it("shows an error message when screenshot capture fails", async () => {
+    apiMock.fetchTabScreenshot.mockRejectedValue(
+      new Error("backend unavailable"),
+    );
+
+    render(<MonitoringPage />);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Capture Screenshot" }),
+    );
+
+    expect(
+      await screen.findByText("Screenshot failed: backend unavailable"),
+    ).toBeVisible();
+  });
+
+  it("disables screenshot capture when the selected instance has no open tabs", async () => {
+    render(<MonitoringPage />);
+
+    await userEvent.click(screen.getByRole("button", { name: "No tabs" }));
+
+    expect(
+      screen.getByRole("button", { name: "Capture Screenshot" }),
+    ).toBeDisabled();
+    expect(
+      screen.getByText("Open a tab to capture a screenshot."),
+    ).toBeInTheDocument();
+  });
+});

--- a/dashboard/src/pages/MonitoringPage.tsx
+++ b/dashboard/src/pages/MonitoringPage.tsx
@@ -15,6 +15,10 @@ export default function MonitoringPage() {
     settings,
   } = useAppStore();
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [screenshotUrl, setScreenshotUrl] = useState<string | null>(null);
+  const [screenshotTabId, setScreenshotTabId] = useState<string | null>(null);
+  const [screenshotLoading, setScreenshotLoading] = useState(false);
+  const [screenshotError, setScreenshotError] = useState<string | null>(null);
   const memoryEnabled = settings.monitoring?.memoryMetrics ?? false;
 
   // Auto-select first running instance
@@ -37,6 +41,51 @@ export default function MonitoringPage() {
   const selectedTabs = selectedId ? currentTabs?.[selectedId] || [] : [];
   const runningInstances =
     instances?.filter((i) => i?.status === "running") || [];
+  const screenshotTab = selectedTabs[0] ?? null;
+
+  useEffect(() => {
+    return () => {
+      if (screenshotUrl) {
+        URL.revokeObjectURL(screenshotUrl);
+      }
+    };
+  }, [screenshotUrl]);
+
+  useEffect(() => {
+    setScreenshotError(null);
+    setScreenshotLoading(false);
+    setScreenshotTabId(null);
+    setScreenshotUrl((currentUrl) => {
+      if (currentUrl) {
+        URL.revokeObjectURL(currentUrl);
+      }
+      return null;
+    });
+  }, [selectedId]);
+
+  const handleFetchScreenshot = async () => {
+    if (!screenshotTab) return;
+
+    setScreenshotLoading(true);
+    setScreenshotError(null);
+    try {
+      const blob = await api.fetchTabScreenshot(screenshotTab.id);
+      const nextUrl = URL.createObjectURL(blob);
+      setScreenshotTabId(screenshotTab.id);
+      setScreenshotUrl((currentUrl) => {
+        if (currentUrl) {
+          URL.revokeObjectURL(currentUrl);
+        }
+        return nextUrl;
+      });
+    } catch (e) {
+      setScreenshotError(
+        e instanceof Error ? e.message : "Failed to capture screenshot",
+      );
+    } finally {
+      setScreenshotLoading(false);
+    }
+  };
 
   return (
     <ErrorBoundary>
@@ -116,14 +165,70 @@ export default function MonitoringPage() {
                         {selectedInstance.headless ? "Headless" : "Headed"}
                       </div>
                     </div>
-                    {selectedInstance.status === "running" && (
+                    <div className="flex items-center gap-2">
                       <Button
                         size="sm"
-                        variant="danger"
-                        onClick={() => handleStop(selectedInstance.id)}
+                        variant="secondary"
+                        loading={screenshotLoading}
+                        disabled={!screenshotTab}
+                        onClick={() => void handleFetchScreenshot()}
                       >
-                        Stop
+                        {screenshotLoading
+                          ? "Capturing..."
+                          : screenshotUrl
+                            ? "Refresh Screenshot"
+                            : "Capture Screenshot"}
                       </Button>
+                      {selectedInstance.status === "running" && (
+                        <Button
+                          size="sm"
+                          variant="danger"
+                          onClick={() => handleStop(selectedInstance.id)}
+                        >
+                          Stop
+                        </Button>
+                      )}
+                    </div>
+                  </div>
+
+                  <div className="border-b border-border-subtle px-4 py-3">
+                    <div className="mb-2 flex items-center justify-between gap-3">
+                      <h4 className="text-xs font-semibold uppercase tracking-wide text-text-muted">
+                        Screenshot Preview
+                      </h4>
+                      {screenshotTab && (
+                        <div className="truncate text-xs text-text-muted">
+                          {screenshotTab.title || screenshotTab.url}
+                        </div>
+                      )}
+                    </div>
+                    {screenshotError ? (
+                      <div
+                        className="text-sm text-destructive"
+                        role="status"
+                        aria-live="polite"
+                      >
+                        Screenshot failed: {screenshotError}
+                      </div>
+                    ) : screenshotUrl ? (
+                      <div className="overflow-hidden rounded-md border border-border-subtle/80 bg-bg-elevated">
+                        <img
+                          src={screenshotUrl}
+                          alt={`Screenshot preview for ${selectedInstance.profileName}`}
+                          className="max-h-80 w-full object-contain"
+                        />
+                      </div>
+                    ) : (
+                      <div className="text-sm text-text-muted">
+                        {screenshotTab
+                          ? "Capture a manual screenshot of the first open tab."
+                          : "Open a tab to capture a screenshot."}
+                      </div>
+                    )}
+                    {screenshotUrl && screenshotTabId && (
+                      <div className="mt-2 text-xs text-text-muted">
+                        Last captured from tab {screenshotTabId}
+                      </div>
                     )}
                   </div>
 

--- a/dashboard/src/services/api.test.ts
+++ b/dashboard/src/services/api.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchTabScreenshot } from "./api";
+
+describe("fetchTabScreenshot", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", fetchMock);
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("requests the existing tab screenshot endpoint and returns a blob", async () => {
+    const responseBlob = new Blob(["image-bytes"], { type: "image/png" });
+    fetchMock.mockResolvedValue({
+      ok: true,
+      blob: vi.fn().mockResolvedValue(responseBlob),
+    });
+    window.localStorage.setItem("pinchtab.auth.token", "secret-token");
+
+    const result = await fetchTabScreenshot("tab_123");
+
+    expect(result).toBeInstanceOf(Blob);
+    expect(await result.text()).toBe("image-bytes");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("/tabs/tab_123/screenshot");
+    expect(
+      new Headers(fetchMock.mock.calls[0]?.[1]?.headers).get("Authorization"),
+    ).toBe("Bearer secret-token");
+  });
+});

--- a/dashboard/src/services/api.ts
+++ b/dashboard/src/services/api.ts
@@ -93,6 +93,36 @@ async function requestText(
   return res.text();
 }
 
+async function requestBlob(
+  url: string,
+  options?: RequestInit,
+  meta?: RequestMeta,
+): Promise<Blob> {
+  const headers = new Headers(options?.headers ?? {});
+  const token = meta?.authToken?.trim() || getStoredAuthToken();
+  if (token) {
+    headers.set("Authorization", `Bearer ${token}`);
+  }
+
+  const res = await fetch(BASE + url, {
+    ...options,
+    headers,
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ error: res.statusText }));
+    if (
+      res.status === 401 &&
+      !meta?.suppressAuthRedirect &&
+      typeof window !== "undefined"
+    ) {
+      window.localStorage.removeItem("pinchtab.auth.token");
+      dispatchAuthRequired(err.code || "unauthorized");
+    }
+    throw new Error(err.error || "Request failed");
+  }
+  return res.blob();
+}
+
 // Profiles — endpoint is /profiles (no /api prefix)
 export async function fetchProfiles(): Promise<Profile[]> {
   return request<Profile[]>("/profiles");
@@ -160,6 +190,10 @@ export async function stopInstance(id: string): Promise<void> {
 
 export async function fetchInstanceTabs(id: string): Promise<InstanceTab[]> {
   return request<InstanceTab[]>(`/instances/${encodeURIComponent(id)}/tabs`);
+}
+
+export async function fetchTabScreenshot(tabId: string): Promise<Blob> {
+  return requestBlob(`/tabs/${encodeURIComponent(tabId)}/screenshot`);
 }
 
 export async function fetchInstanceLogs(id: string): Promise<string> {


### PR DESCRIPTION
## Summary
- add a manual screenshot preview section to the dashboard monitoring view
- reuse the existing `GET /tabs/{id}/screenshot` backend capability instead of introducing streaming
- add focused dashboard tests for the screenshot API helper and the monitoring-page UX

Closes #238.

## Design
This keeps the first step intentionally small, matching the maintainer direction in the issue discussion:
- **manual screenshot first**: the dashboard now exposes a `Capture Screenshot` / `Refresh Screenshot` button instead of trying to ship a live browser stream
- **reused existing backend capability**: the frontend calls the already-available per-tab screenshot endpoint and renders the returned image blob as a preview
- **narrow scope**: no websocket transport, no polling loop, no live video/screencast embed, and no backend protocol changes

For the initial UX, the monitoring page captures the **first open tab** for the currently selected instance. That keeps the feature useful for both headed and headless sessions without expanding the interaction model yet.

## UX details
- loading state while capture is in progress
- disabled button when the selected instance has no open tabs
- inline error state when capture fails
- refreshed preview image after a successful capture
- object URL cleanup when the preview changes or the selected instance changes

## Testing
Ran real dashboard checks in this temp clone:
- `cd dashboard && npm install --legacy-peer-deps`
- `cd dashboard && npm install --no-save @testing-library/dom --legacy-peer-deps`
- `cd dashboard && npm run test:run`
- `cd dashboard && npm run build`
- `cd dashboard && npm run lint`
- `cd dashboard && npm run format:check`

All of the above passed.
