### PR TITLE
Add Codespaces devcontainer config for browser-based development

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,15 @@
+{
+  "name": "PinchTab",
+  "image": "mcr.microsoft.com/devcontainers/go:1.23",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+  },
+  "postCreateCommand": "docker compose up -d && go build -o pinchtab ./cmd/pinchtab && echo 'Done! Run: ./pinchtab health'",
+  "forwardPorts": [9867],
+  "portsAttributes": {
+    "9867": {
+      "label": "PinchTab",
+      "onAutoForward": "notify"
+    }
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     build: .
     container_name: pinchtab
     ports:
-      - "127.0.0.1:9867:9867"
+      - "9867:9867"
     volumes:
       - pinchtab-data:/data
     environment:


### PR DESCRIPTION
Adds .devcontainer/devcontainer.json to enable GitHub Codespaces with Go + Docker-in-Docker, auto-builds the CLI binary on creation, and forwards port 9867. Updates docker-compose.yml to bind on all interfaces so Codespaces port forwarding works correctly.

https://claude.ai/code/session_01Gj7Duue8M3aBTQjTFD8wEm

## What Changed?
<!-- Brief description of the change -->

## Why?
<!-- Motivation, issue being fixed, or feature request -->

## Testing
<!-- How did you test this? Include command examples if applicable -->

- [ ] Unit and/or Docker E2E tests added or updated
- [ ] Manual testing completed (describe below)

## Checklist
See [DEFINITION_OF_DONE.md](./DEFINITION_OF_DONE.md) for the full checklist.

**Automated (CI enforces):**
- [ ] gofmt + golangci-lint passes
- [ ] All tests pass
- [ ] Build succeeds

**Manual:**
- [ ] Error handling explicit (wrapped with `%w`)
- [ ] No regressions in stealth/performance/persistence
- [ ] README/CHANGELOG updated (if user-facing)
- [ ] npm install works (if npm changes)

## Impact
<!-- Any performance, compatibility, or breaking changes? -->

---
