### PR TITLE
feat: add focus CLI command (#294)

### DIFF
--- a/cmd/pinchtab/cmd_cli.go
+++ b/cmd/pinchtab/cmd_cli.go
@@ -218,6 +218,22 @@ var hoverCmd = &cobra.Command{
 	},
 }
 
+var focusCmd = &cobra.Command{
+	Use:   "focus <ref>",
+	Short: "Focus element",
+	Args:  cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		ref := ""
+		if len(args) > 0 {
+			ref = args[0]
+		}
+		cfg := config.Load()
+		runCLIWith(cfg, func(client *http.Client, base, token string) {
+			browseractions.Action(client, base, token, "focus", ref, cmd)
+		})
+	},
+}
+
 var scrollCmd = &cobra.Command{
 	Use:   "scroll <ref|pixels>",
 	Short: "Scroll to element or by pixels",
@@ -394,6 +410,7 @@ func init() {
 	pressCmd.GroupID = "browser"
 	fillCmd.GroupID = "browser"
 	hoverCmd.GroupID = "browser"
+	focusCmd.GroupID = "browser"
 	scrollCmd.GroupID = "browser"
 	evalCmd.GroupID = "browser"
 	pdfCmd.GroupID = "browser"
@@ -448,6 +465,7 @@ func init() {
 	hoverCmd.Flags().String("css", "", "CSS selector instead of ref")
 	hoverCmd.Flags().Float64("x", 0, "X coordinate for hover")
 	hoverCmd.Flags().Float64("y", 0, "Y coordinate for hover")
+	focusCmd.Flags().String("css", "", "CSS selector instead of ref")
 
 	snapCmd.Flags().BoolP("interactive", "i", false, "Filter interactive elements only")
 	snapCmd.Flags().BoolP("compact", "c", false, "Compact output format")
@@ -501,6 +519,7 @@ func init() {
 	clickCmd.Flags().String("tab", "", "Tab ID")
 	dblclickCmd.Flags().String("tab", "", "Tab ID")
 	hoverCmd.Flags().String("tab", "", "Tab ID")
+	focusCmd.Flags().String("tab", "", "Tab ID")
 	typeCmd.Flags().String("tab", "", "Tab ID")
 	pressCmd.Flags().String("tab", "", "Tab ID")
 	fillCmd.Flags().String("tab", "", "Tab ID")
@@ -526,6 +545,7 @@ func init() {
 	rootCmd.AddCommand(pressCmd)
 	rootCmd.AddCommand(fillCmd)
 	rootCmd.AddCommand(hoverCmd)
+	rootCmd.AddCommand(focusCmd)
 	rootCmd.AddCommand(scrollCmd)
 	rootCmd.AddCommand(evalCmd)
 	rootCmd.AddCommand(pdfCmd)

--- a/internal/cli/actions/actions_element_test.go
+++ b/internal/cli/actions/actions_element_test.go
@@ -142,6 +142,26 @@ func TestHoverWithCSS(t *testing.T) {
 	}
 }
 
+func TestFocus(t *testing.T) {
+	m := newMockServer()
+	defer m.close()
+	client := m.server.Client()
+
+	cmd := newActionCmd()
+	Action(client, m.base(), "", "focus", "e5", cmd)
+	if m.lastPath != "/action" {
+		t.Errorf("expected /action, got %s", m.lastPath)
+	}
+	var body map[string]any
+	_ = json.Unmarshal([]byte(m.lastBody), &body)
+	if body["kind"] != "focus" {
+		t.Errorf("expected kind=focus, got %v", body["kind"])
+	}
+	if body["ref"] != "e5" {
+		t.Errorf("expected ref=e5, got %v", body["ref"])
+	}
+}
+
 func TestFocusWithCSS(t *testing.T) {
 	m := newMockServer()
 	defer m.close()


### PR DESCRIPTION
## Summary

Expose the existing `focus` action kind as a top-level CLI command.

## Changes

- **cmd/pinchtab/cmd_cli.go**: Add `focusCmd` following the same pattern as click/hover commands. Registers `--tab` and `--css` flags. Uses `browseractions.Action()` with kind `"focus"`.
- **internal/cli/actions/actions_element_test.go**: Add `TestFocus` (ref selector) test verifying kind=focus and ref field.

## Verification

```
$ go vet ./...
(clean)

$ gofmt -l .
(clean)

$ go test ./... -count=1
ok  github.com/pinchtab/pinchtab/cmd/pinchtab
ok  github.com/pinchtab/pinchtab/internal/cli/actions
... (all packages pass)
```

Closes #294