### PR TITLE
Add multiInstance.disableLocalLaunch

### DIFF
--- a/internal/config/config_file.go
+++ b/internal/config/config_file.go
@@ -175,11 +175,12 @@ type idpiConfigJSON struct {
 }
 
 type multiInstanceConfigJSON struct {
-	Strategy          string                   `json:"strategy"`
-	AllocationPolicy  string                   `json:"allocationPolicy"`
-	InstancePortStart *int                     `json:"instancePortStart"`
-	InstancePortEnd   *int                     `json:"instancePortEnd"`
-	Restart           multiInstanceRestartJSON `json:"restart"`
+	Strategy           string                   `json:"strategy"`
+	AllocationPolicy   string                   `json:"allocationPolicy"`
+	DisableLocalLaunch *bool                    `json:"disableLocalLaunch,omitempty"`
+	InstancePortStart  *int                     `json:"instancePortStart"`
+	InstancePortEnd    *int                     `json:"instancePortEnd"`
+	Restart            multiInstanceRestartJSON `json:"restart"`
 }
 
 type multiInstanceRestartJSON struct {
@@ -285,10 +286,11 @@ func (fc FileConfig) MarshalJSON() ([]byte, error) {
 			DefaultProfile: fc.Profiles.DefaultProfile,
 		},
 		MultiInstance: multiInstanceConfigJSON{
-			Strategy:          fc.MultiInstance.Strategy,
-			AllocationPolicy:  fc.MultiInstance.AllocationPolicy,
-			InstancePortStart: fc.MultiInstance.InstancePortStart,
-			InstancePortEnd:   fc.MultiInstance.InstancePortEnd,
+			Strategy:           fc.MultiInstance.Strategy,
+			AllocationPolicy:   fc.MultiInstance.AllocationPolicy,
+			DisableLocalLaunch: fc.MultiInstance.DisableLocalLaunch,
+			InstancePortStart:  fc.MultiInstance.InstancePortStart,
+			InstancePortEnd:    fc.MultiInstance.InstancePortEnd,
 			Restart: multiInstanceRestartJSON{
 				MaxRestarts:    fc.MultiInstance.Restart.MaxRestarts,
 				InitBackoffSec: fc.MultiInstance.Restart.InitBackoffSec,
@@ -349,6 +351,7 @@ func FileConfigFromRuntime(cfg *RuntimeConfig) FileConfig {
 	restartInitBackoffSec := int(cfg.RestartInitBackoff / time.Second)
 	restartMaxBackoffSec := int(cfg.RestartMaxBackoff / time.Second)
 	restartStableAfterSec := int(cfg.RestartStableAfter / time.Second)
+	disableLocalLaunch := cfg.DisableLocalLaunch
 	activityEnabled := cfg.Observability.Activity.Enabled
 	activitySessionIdleSec := cfg.Observability.Activity.SessionIdleSec
 	activityRetentionDays := cfg.Observability.Activity.RetentionDays
@@ -412,10 +415,11 @@ func FileConfigFromRuntime(cfg *RuntimeConfig) FileConfig {
 			DefaultProfile: cfg.DefaultProfile,
 		},
 		MultiInstance: MultiInstanceConfig{
-			Strategy:          cfg.Strategy,
-			AllocationPolicy:  cfg.AllocationPolicy,
-			InstancePortStart: &start,
-			InstancePortEnd:   &end,
+			Strategy:           cfg.Strategy,
+			AllocationPolicy:   cfg.AllocationPolicy,
+			DisableLocalLaunch: &disableLocalLaunch,
+			InstancePortStart:  &start,
+			InstancePortEnd:    &end,
 			Restart: MultiInstanceRestartConfig{
 				MaxRestarts:    &restartMaxRestarts,
 				InitBackoffSec: &restartInitBackoffSec,

--- a/internal/config/config_load.go
+++ b/internal/config/config_load.go
@@ -290,6 +290,9 @@ func applyFileConfig(cfg *RuntimeConfig, fc *FileConfig) {
 	if fc.MultiInstance.AllocationPolicy != "" {
 		cfg.AllocationPolicy = fc.MultiInstance.AllocationPolicy
 	}
+	if fc.MultiInstance.DisableLocalLaunch != nil {
+		cfg.DisableLocalLaunch = *fc.MultiInstance.DisableLocalLaunch
+	}
 	if fc.MultiInstance.InstancePortStart != nil {
 		cfg.InstancePortStart = *fc.MultiInstance.InstancePortStart
 	}

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -49,8 +49,9 @@ type RuntimeConfig struct {
 	WaitNavDelay    time.Duration
 
 	// Orchestrator settings (dashboard mode only)
-	Strategy           string        // "always-on" (default), "simple", "explicit", or "simple-autorestart"
-	AllocationPolicy   string        // "fcfs" (default), "round_robin", "random"
+	Strategy           string // "always-on" (default), "simple", "explicit", or "simple-autorestart"
+	AllocationPolicy   string // "fcfs" (default), "round_robin", "random"
+	DisableLocalLaunch bool
 	RestartMaxRestarts int           // Max restart attempts for restart-managed strategies (-1 = unlimited, 0 = strategy default)
 	RestartInitBackoff time.Duration // Initial restart backoff (0 = strategy default)
 	RestartMaxBackoff  time.Duration // Maximum restart backoff cap (0 = strategy default)
@@ -177,11 +178,12 @@ type SecurityConfig struct {
 }
 
 type MultiInstanceConfig struct {
-	Strategy          string                     `json:"strategy,omitempty"`
-	AllocationPolicy  string                     `json:"allocationPolicy,omitempty"`
-	InstancePortStart *int                       `json:"instancePortStart,omitempty"`
-	InstancePortEnd   *int                       `json:"instancePortEnd,omitempty"`
-	Restart           MultiInstanceRestartConfig `json:"restart,omitempty"`
+	Strategy           string                     `json:"strategy,omitempty"`
+	AllocationPolicy   string                     `json:"allocationPolicy,omitempty"`
+	DisableLocalLaunch *bool                      `json:"disableLocalLaunch,omitempty"`
+	InstancePortStart  *int                       `json:"instancePortStart,omitempty"`
+	InstancePortEnd    *int                       `json:"instancePortEnd,omitempty"`
+	Restart            MultiInstanceRestartConfig `json:"restart,omitempty"`
 }
 
 // MultiInstanceRestartConfig controls restart-managed strategy recovery behavior.

--- a/internal/config/editor.go
+++ b/internal/config/editor.go
@@ -181,6 +181,12 @@ func setMultiInstanceField(o *MultiInstanceConfig, field, value string) error {
 		o.Strategy = value
 	case "allocationPolicy":
 		o.AllocationPolicy = value
+	case "disableLocalLaunch":
+		b, err := parseBool(value)
+		if err != nil {
+			return fmt.Errorf("multiInstance.disableLocalLaunch must be true or false: %w", err)
+		}
+		o.DisableLocalLaunch = &b
 	case "instancePortStart":
 		n, err := strconv.Atoi(value)
 		if err != nil {
@@ -395,6 +401,8 @@ func getMultiInstanceField(o *MultiInstanceConfig, field string) (string, error)
 		return o.Strategy, nil
 	case "allocationPolicy":
 		return o.AllocationPolicy, nil
+	case "disableLocalLaunch":
+		return formatBoolPtr(o.DisableLocalLaunch), nil
 	case "instancePortStart":
 		return formatIntPtr(o.InstancePortStart), nil
 	case "instancePortEnd":

--- a/internal/config/editor_test.go
+++ b/internal/config/editor_test.go
@@ -110,6 +110,9 @@ func TestSetConfigValue_MultiInstanceFields(t *testing.T) {
 	}{
 		{"multiInstance.strategy", "explicit", func(fc *FileConfig) bool { return fc.MultiInstance.Strategy == "explicit" }, false},
 		{"multiInstance.allocationPolicy", "round_robin", func(fc *FileConfig) bool { return fc.MultiInstance.AllocationPolicy == "round_robin" }, false},
+		{"multiInstance.disableLocalLaunch", "true", func(fc *FileConfig) bool {
+			return fc.MultiInstance.DisableLocalLaunch != nil && *fc.MultiInstance.DisableLocalLaunch
+		}, false},
 		{"multiInstance.instancePortStart", "9900", func(fc *FileConfig) bool { return *fc.MultiInstance.InstancePortStart == 9900 }, false},
 		{"multiInstance.restart.maxRestarts", "12", func(fc *FileConfig) bool {
 			return fc.MultiInstance.Restart.MaxRestarts != nil && *fc.MultiInstance.Restart.MaxRestarts == 12

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -246,6 +246,9 @@ func installStableBinary(src, dst string) error {
 }
 
 func (o *Orchestrator) Launch(name, port string, headless bool, extensionPaths []string) (*bridge.Instance, error) {
+	if o != nil && o.runtimeCfg != nil && o.runtimeCfg.DisableLocalLaunch {
+		return nil, fmt.Errorf("local instance launch is disabled")
+	}
 	// Validate profile name to prevent path traversal attacks
 	if err := profiles.ValidateProfileName(name); err != nil {
 		return nil, err

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -39,6 +39,17 @@ func TestOrchestrator_Launch_Lifecycle(t *testing.T) {
 	}
 }
 
+func TestOrchestrator_Launch_DisabledByRuntimeConfig(t *testing.T) {
+	runner := &mockRunner{portAvail: true}
+	o := NewOrchestratorWithRunner(t.TempDir(), runner)
+	o.ApplyRuntimeConfig(&config.RuntimeConfig{DisableLocalLaunch: true})
+
+	_, err := o.Launch("profile1", "9001", true, nil)
+	if err == nil || !strings.Contains(err.Error(), "local instance launch is disabled") {
+		t.Fatalf("Launch() error = %v, want local launch disabled error", err)
+	}
+}
+
 func TestOrchestrator_ListAndStop(t *testing.T) {
 	alive := true
 	old := processAliveFunc


### PR DESCRIPTION
Adds `multiInstance.disableLocalLaunch` to block local browser creation on the orchestrator.
Closes #320 

What it does:
- returns an error from `Orchestrator.Launch()` when enabled
- wires the flag through config load/save
- supports `pinchtab config set multiInstance.disableLocalLaunch true`
- adds focused tests

This keeps the change small while covering the main local-launch paths (`/instances/start`, `/instances/launch`, `/profiles/{id}/start`, and strategy-driven launch attempts).