### PR TITLE
fix: release process — auto-set npm version in CI

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -48,12 +48,6 @@ jobs:
           fi
 
           TAG="v$VERSION"
-          PKG_VERSION="$(jq -r .version npm/package.json)"
-          if [ "$PKG_VERSION" != "$VERSION" ]; then
-            echo "npm/package.json version is $PKG_VERSION, expected $VERSION" >&2
-            exit 1
-          fi
-
           if git rev-parse "$TAG" >/dev/null 2>&1; then
             echo "tag $TAG already exists locally" >&2
             exit 1
@@ -103,6 +97,7 @@ jobs:
     uses: ./.github/workflows/reusable-npm-verify.yml
     with:
       ref: ${{ needs.validate.outputs.sha }}
+      version: ${{ needs.validate.outputs.version }}
 
   e2e-release:
     needs: validate
@@ -159,6 +154,14 @@ jobs:
       - name: Dry-run npm publish
         working-directory: npm
         run: |
+          CURRENT="$(jq -r .version package.json)"
+          DESIRED="${{ needs.validate.outputs.version }}"
+          if [ "$CURRENT" != "$DESIRED" ]; then
+            npm version "$DESIRED" --no-git-tag-version
+          else
+            echo "Version already correct: $CURRENT"
+          fi
+
           npm ci --ignore-scripts
           npm run build
           npm publish --dry-run

--- a/.github/workflows/reusable-npm-verify.yml
+++ b/.github/workflows/reusable-npm-verify.yml
@@ -6,6 +6,9 @@ on:
       ref:
         required: true
         type: string
+      version:
+        required: false
+        type: string
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -27,7 +30,7 @@ jobs:
           node-version: '22'
 
       - name: Verify npm package
-        run: bash scripts/check-npm.sh
+        run: bash scripts/check-npm.sh "${{ inputs.version }}"
 
       - name: List package contents
         working-directory: npm

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -72,8 +72,8 @@ grep -A 2 "^release:" .goreleaser.yml
 
 ## Manual Release Flow
 
-1. Bump release-facing versions on the branch first.
-   The hard gate today is `npm/package.json`, and `Prepare Release` will fail if the input version does not match it.
+1. Choose the branch, tag, or SHA you want to release.
+   `Prepare Release` now validates the requested version format and tag availability, then rewrites the npm package version inside the CI workspace for the dry-run steps.
 2. Open **Actions → Prepare Release**.
 3. Run it with:
    - `version`: the release version, for example `0.8.0`

--- a/scripts/check-npm.sh
+++ b/scripts/check-npm.sh
@@ -5,6 +5,16 @@ cd "$(dirname "$0")/../npm"
 
 echo "Verifying npm package..."
 
+DESIRED_VERSION="${1:-}"
+if [ -n "$DESIRED_VERSION" ]; then
+  CURRENT_VERSION="$(jq -r .version package.json)"
+  if [ "$CURRENT_VERSION" != "$DESIRED_VERSION" ]; then
+    npm version "$DESIRED_VERSION" --no-git-tag-version
+  else
+    echo "Version already correct: $CURRENT_VERSION"
+  fi
+fi
+
 npm ci
 npm run lint
 npm run format:check


### PR DESCRIPTION
Removes the pre-flight npm version check from `Prepare Release` and instead sets the version automatically during CI.

- Remove early `npm/package.json` version gate from validate step
- Auto-rewrite npm version via `npm version --no-git-tag-version` in dry-run and verify steps
- Pass `version` input to `reusable-npm-verify.yml`
- Update `check-npm.sh` to accept optional version argument
- Update RELEASE.md docs