### PR TITLE
fix(auth): respect forwarded scheme/host for dashboard sessions

### DIFF
--- a/internal/config/config_file.go
+++ b/internal/config/config_file.go
@@ -129,6 +129,7 @@ type serverConfigJSON struct {
 	StateDir          string `json:"stateDir"`
 	Engine            string `json:"engine"`
 	NetworkBufferSize *int   `json:"networkBufferSize,omitempty"`
+	TrustProxyHeaders *bool  `json:"trustProxyHeaders,omitempty"`
 }
 
 type browserConfigJSON struct {
@@ -254,6 +255,7 @@ func (fc FileConfig) MarshalJSON() ([]byte, error) {
 			StateDir:          fc.Server.StateDir,
 			Engine:            fc.Server.Engine,
 			NetworkBufferSize: fc.Server.NetworkBufferSize,
+			TrustProxyHeaders: fc.Server.TrustProxyHeaders,
 		},
 		Browser: browserConfigJSON{
 			ChromeVersion:    fc.Browser.ChromeVersion,
@@ -401,6 +403,7 @@ func FileConfigFromRuntime(cfg *RuntimeConfig) FileConfig {
 			StateDir:          cfg.StateDir,
 			Engine:            cfg.Engine,
 			NetworkBufferSize: netBufSize,
+			TrustProxyHeaders: &cfg.TrustProxyHeaders,
 		},
 		Browser: BrowserConfig{
 			ChromeVersion:    cfg.ChromeVersion,

--- a/internal/config/config_load.go
+++ b/internal/config/config_load.go
@@ -194,6 +194,9 @@ func applyFileConfig(cfg *RuntimeConfig, fc *FileConfig) {
 	if fc.Server.NetworkBufferSize != nil && *fc.Server.NetworkBufferSize > 0 {
 		cfg.NetworkBufferSize = ClampNetworkBufferSize(*fc.Server.NetworkBufferSize)
 	}
+	if fc.Server.TrustProxyHeaders != nil {
+		cfg.TrustProxyHeaders = *fc.Server.TrustProxyHeaders
+	}
 	// Security
 	if fc.Security.AllowEvaluate != nil {
 		cfg.AllowEvaluate = *fc.Security.AllowEvaluate

--- a/internal/config/config_load_test.go
+++ b/internal/config/config_load_test.go
@@ -59,6 +59,9 @@ func TestLoadConfigDefaults(t *testing.T) {
 	if cfg.AllowEvaluate {
 		t.Errorf("default AllowEvaluate = %v, want false", cfg.AllowEvaluate)
 	}
+	if cfg.TrustProxyHeaders {
+		t.Errorf("default TrustProxyHeaders = %v, want false", cfg.TrustProxyHeaders)
+	}
 	if len(cfg.DownloadAllowedDomains) != 0 {
 		t.Errorf("default DownloadAllowedDomains = %v, want empty list", cfg.DownloadAllowedDomains)
 	}
@@ -387,6 +390,27 @@ func TestApplyFileConfigToRuntime_ClampsTransferLimits(t *testing.T) {
 	}
 	if cfg.UploadMaxTotalBytes != MaxUploadMaxTotalBytes {
 		t.Fatalf("UploadMaxTotalBytes = %d, want %d", cfg.UploadMaxTotalBytes, MaxUploadMaxTotalBytes)
+	}
+}
+
+func TestApplyFileConfigToRuntime_TrustProxyHeaders(t *testing.T) {
+	cfg := &RuntimeConfig{}
+	if cfg.TrustProxyHeaders {
+		t.Fatal("expected default TrustProxyHeaders to be false")
+	}
+
+	enabled := true
+	fc := &FileConfig{Server: ServerConfig{TrustProxyHeaders: &enabled}}
+	applyFileConfig(cfg, fc)
+	if !cfg.TrustProxyHeaders {
+		t.Fatal("expected TrustProxyHeaders to be true after apply")
+	}
+
+	disabled := false
+	fc2 := &FileConfig{Server: ServerConfig{TrustProxyHeaders: &disabled}}
+	applyFileConfig(cfg, fc2)
+	if cfg.TrustProxyHeaders {
+		t.Fatal("expected TrustProxyHeaders to be false after apply with false")
 	}
 }
 

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -12,6 +12,7 @@ type RuntimeConfig struct {
 	InstancePortEnd   int // Ending port for instances (default 9968)
 	Token             string
 	StateDir          string
+	TrustProxyHeaders bool // Only trust X-Forwarded-*/Forwarded headers when behind a trusted reverse proxy
 
 	// Security settings
 	AllowEvaluate          bool
@@ -141,6 +142,7 @@ type ServerConfig struct {
 	StateDir          string `json:"stateDir,omitempty"`
 	Engine            string `json:"engine,omitempty"`
 	NetworkBufferSize *int   `json:"networkBufferSize,omitempty"`
+	TrustProxyHeaders *bool  `json:"trustProxyHeaders,omitempty"`
 }
 
 type BrowserConfig struct {

--- a/internal/config/editor_get.go
+++ b/internal/config/editor_get.go
@@ -46,6 +46,8 @@ func getServerField(s *ServerConfig, field string) (string, error) {
 		return s.Token, nil
 	case "stateDir":
 		return s.StateDir, nil
+	case "trustProxyHeaders":
+		return formatBoolPtr(s.TrustProxyHeaders), nil
 	default:
 		return "", fmt.Errorf("unknown field server.%s", field)
 	}

--- a/internal/config/editor_set.go
+++ b/internal/config/editor_set.go
@@ -45,6 +45,12 @@ func setServerField(s *ServerConfig, field, value string) error {
 		s.Token = value
 	case "stateDir":
 		s.StateDir = value
+	case "trustProxyHeaders":
+		b, err := parseBool(value)
+		if err != nil {
+			return fmt.Errorf("server.trustProxyHeaders must be true or false: %w", err)
+		}
+		s.TrustProxyHeaders = &b
 	default:
 		return fmt.Errorf("unknown field server.%s", field)
 	}

--- a/internal/handlers/middleware.go
+++ b/internal/handlers/middleware.go
@@ -87,7 +87,7 @@ func AuthMiddlewareWithSessions(cfg *config.RuntimeConfig, sessions *authn.Sessi
 				return
 			}
 		case authn.MethodCookie:
-			if !cookieOriginAllowed(r) {
+			if !cookieOriginAllowed(r, cfg.TrustProxyHeaders) {
 				httpx.ErrorCode(w, http.StatusForbidden, "origin_forbidden", "same-origin browser request required for session authentication", false, map[string]any{
 					"sameOriginRequired": true,
 				})
@@ -226,31 +226,32 @@ func corsAllowedOrigin(cfg *config.RuntimeConfig, r *http.Request) string {
 	if strings.TrimSpace(cfg.Token) == "" {
 		return "*"
 	}
-	if sameOriginRequest(origin, r) {
+	if sameOriginRequest(origin, r, cfg.TrustProxyHeaders) {
 		return origin
 	}
 	return ""
 }
 
-func sameOriginRequest(origin string, r *http.Request) bool {
+func sameOriginRequest(origin string, r *http.Request, trustProxy ...bool) bool {
 	parsed, err := url.Parse(origin)
 	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
 		return false
 	}
-	return strings.EqualFold(parsed.Scheme, requestScheme(r)) && strings.EqualFold(parsed.Host, requestHost(r))
+	trust := len(trustProxy) > 0 && trustProxy[0]
+	return strings.EqualFold(parsed.Scheme, requestScheme(r, trust)) && strings.EqualFold(parsed.Host, requestHost(r, trust))
 }
 
-func cookieOriginAllowed(r *http.Request) bool {
+func cookieOriginAllowed(r *http.Request, trustProxy bool) bool {
 	if isWebSocketUpgrade(r) {
 		origin := strings.TrimSpace(r.Header.Get("Origin"))
-		return origin != "" && sameOriginRequest(origin, r)
+		return origin != "" && sameOriginRequest(origin, r, trustProxy)
 	}
 
 	if origin := strings.TrimSpace(r.Header.Get("Origin")); origin != "" {
-		return sameOriginRequest(origin, r)
+		return sameOriginRequest(origin, r, trustProxy)
 	}
 	if referer := strings.TrimSpace(r.Header.Get("Referer")); referer != "" {
-		return sameOriginRequest(referer, r)
+		return sameOriginRequest(referer, r, trustProxy)
 	}
 	return false
 }
@@ -265,42 +266,46 @@ func isWebSocketUpgrade(r *http.Request) bool {
 	return strings.Contains(strings.ToLower(r.Header.Get("Connection")), "upgrade")
 }
 
-func requestScheme(r *http.Request) string {
+func requestScheme(r *http.Request, trustProxy bool) string {
 	if r == nil {
 		return "http"
 	}
-	if forwarded := strings.TrimSpace(r.Header.Get("X-Forwarded-Proto")); forwarded != "" {
-		return strings.ToLower(strings.TrimSpace(strings.Split(forwarded, ",")[0]))
-	}
-	if forwarded := strings.TrimSpace(r.Header.Get("Forwarded")); forwarded != "" {
-		for _, part := range strings.Split(forwarded, ";") {
-			key, value, ok := strings.Cut(strings.TrimSpace(part), "=")
-			if !ok || !strings.EqualFold(key, "proto") {
-				continue
+	if trustProxy {
+		if forwarded := strings.TrimSpace(r.Header.Get("X-Forwarded-Proto")); forwarded != "" {
+			return strings.ToLower(strings.TrimSpace(strings.Split(forwarded, ",")[0]))
+		}
+		if forwarded := strings.TrimSpace(r.Header.Get("Forwarded")); forwarded != "" {
+			for _, part := range strings.Split(forwarded, ";") {
+				key, value, ok := strings.Cut(strings.TrimSpace(part), "=")
+				if !ok || !strings.EqualFold(key, "proto") {
+					continue
+				}
+				return strings.ToLower(strings.Trim(value, `"`))
 			}
-			return strings.ToLower(strings.Trim(value, `"`))
 		}
 	}
-	if r != nil && r.TLS != nil {
+	if r.TLS != nil {
 		return "https"
 	}
 	return "http"
 }
 
-func requestHost(r *http.Request) string {
+func requestHost(r *http.Request, trustProxy bool) string {
 	if r == nil {
 		return ""
 	}
-	if forwarded := strings.TrimSpace(r.Header.Get("X-Forwarded-Host")); forwarded != "" {
-		return strings.TrimSpace(strings.Split(forwarded, ",")[0])
-	}
-	if forwarded := strings.TrimSpace(r.Header.Get("Forwarded")); forwarded != "" {
-		for _, part := range strings.Split(forwarded, ";") {
-			key, value, ok := strings.Cut(strings.TrimSpace(part), "=")
-			if !ok || !strings.EqualFold(key, "host") {
-				continue
+	if trustProxy {
+		if forwarded := strings.TrimSpace(r.Header.Get("X-Forwarded-Host")); forwarded != "" {
+			return strings.TrimSpace(strings.Split(forwarded, ",")[0])
+		}
+		if forwarded := strings.TrimSpace(r.Header.Get("Forwarded")); forwarded != "" {
+			for _, part := range strings.Split(forwarded, ";") {
+				key, value, ok := strings.Cut(strings.TrimSpace(part), "=")
+				if !ok || !strings.EqualFold(key, "host") {
+					continue
+				}
+				return strings.Trim(value, `"`)
 			}
-			return strings.Trim(value, `"`)
 		}
 	}
 	return strings.TrimSpace(r.Host)

--- a/internal/handlers/middleware_action_auth_test.go
+++ b/internal/handlers/middleware_action_auth_test.go
@@ -1,8 +1,9 @@
 package handlers
 
-import "net/http/httptest"
-
-import "testing"
+import (
+	"net/http/httptest"
+	"testing"
+)
 
 func TestCookieAuthAllowed_ActionPost(t *testing.T) {
 	req := httptest.NewRequest("POST", "/action", nil)
@@ -10,4 +11,3 @@ func TestCookieAuthAllowed_ActionPost(t *testing.T) {
 		t.Fatal("expected cookie auth to allow POST /action for dashboard same-origin sessions")
 	}
 }
-

--- a/internal/handlers/middleware_proxy_test.go
+++ b/internal/handlers/middleware_proxy_test.go
@@ -11,8 +11,8 @@ func TestSameOriginRequest_UsesForwardedProtoAndHost(t *testing.T) {
 	req.Header.Set("X-Forwarded-Proto", "https")
 	req.Header.Set("X-Forwarded-Host", "browser.example.com")
 
-	if !sameOriginRequest("https://browser.example.com/dashboard", req) {
-		t.Fatal("expected same-origin request when forwarded proto/host match browser origin")
+	if !sameOriginRequest("https://browser.example.com/dashboard", req, true) {
+		t.Fatal("expected same-origin when trustProxy=true and forwarded proto/host match")
 	}
 }
 
@@ -21,8 +21,30 @@ func TestSameOriginRequest_UsesForwardedHeader(t *testing.T) {
 	req.Host = "pinchtab:9867"
 	req.Header.Set("Forwarded", `for=127.0.0.1;proto=https;host=browser.example.com`)
 
-	if !sameOriginRequest("https://browser.example.com/dashboard", req) {
-		t.Fatal("expected same-origin request when RFC 7239 Forwarded header matches browser origin")
+	if !sameOriginRequest("https://browser.example.com/dashboard", req, true) {
+		t.Fatal("expected same-origin when trustProxy=true and RFC 7239 Forwarded header matches")
 	}
 }
 
+func TestSameOriginRequest_IgnoresForwardedWhenTrustDisabled(t *testing.T) {
+	req := httptest.NewRequest("GET", "http://pinchtab/health", nil)
+	req.Host = "pinchtab:9867"
+	req.Header.Set("X-Forwarded-Proto", "https")
+	req.Header.Set("X-Forwarded-Host", "browser.example.com")
+
+	if sameOriginRequest("https://browser.example.com/dashboard", req, false) {
+		t.Fatal("expected NOT same-origin when trustProxy=false even with forwarded headers")
+	}
+}
+
+func TestSameOriginRequest_DefaultIgnoresForwarded(t *testing.T) {
+	req := httptest.NewRequest("GET", "http://pinchtab/health", nil)
+	req.Host = "pinchtab:9867"
+	req.Header.Set("X-Forwarded-Proto", "https")
+	req.Header.Set("X-Forwarded-Host", "browser.example.com")
+
+	// No trustProxy argument — defaults to false
+	if sameOriginRequest("https://browser.example.com/dashboard", req) {
+		t.Fatal("expected NOT same-origin when trustProxy not specified")
+	}
+}


### PR DESCRIPTION
## Summary\n- trust X-Forwarded-Proto/X-Forwarded-Host and Forwarded when validating same-origin dashboard session requests\n- fix /health returning 403 behind Caddy after session-auth refactor\n- add middleware tests covering forwarded proxy headers\n\n## Verification\n- go test ./internal/handlers -run 'TestSameOriginRequest_UsesForwarded'\n- login via https://browser.spru.dev/api/auth/login then GET /health with session cookie now returns 200 instead of 403\n