### PR TITLE
fix(profiles): normalize and validate import source paths

### DIFF
--- a/internal/profiles/profiles.go
+++ b/internal/profiles/profiles.go
@@ -235,13 +235,18 @@ func (pm *ProfileManager) Import(name, sourcePath string) error {
 		return fmt.Errorf("profile %q already exists", name)
 	}
 
-	if _, err := os.Stat(filepath.Join(sourcePath, "Default")); err != nil {
-		if _, err2 := os.Stat(filepath.Join(sourcePath, "Preferences")); err2 != nil {
+	resolvedSourcePath, err := resolveImportSourcePath(sourcePath)
+	if err != nil {
+		return err
+	}
+
+	if _, err := os.Stat(filepath.Join(resolvedSourcePath, "Default")); err != nil {
+		if _, err2 := os.Stat(filepath.Join(resolvedSourcePath, "Preferences")); err2 != nil {
 			return fmt.Errorf("source doesn't look like a Chrome user data dir (no Default/ or Preferences found)")
 		}
 	}
 
-	srcInfo, err := os.Lstat(sourcePath)
+	srcInfo, err := os.Lstat(resolvedSourcePath)
 	if err != nil {
 		return fmt.Errorf("source path invalid: %w", err)
 	}
@@ -252,12 +257,12 @@ func (pm *ProfileManager) Import(name, sourcePath string) error {
 		return fmt.Errorf("source path must be a directory")
 	}
 
-	slog.Info("importing profile", "name", name, "source", sourcePath)
-	if err := copyDir(sourcePath, dest); err != nil {
+	slog.Info("importing profile", "name", name, "source", resolvedSourcePath)
+	if err := copyDir(resolvedSourcePath, dest); err != nil {
 		return fmt.Errorf("copy failed: %w", err)
 	}
 
-	if err := os.WriteFile(filepath.Join(dest, ".pinchtab-imported"), []byte(sourcePath), 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(dest, ".pinchtab-imported"), []byte(resolvedSourcePath), 0600); err != nil {
 		slog.Warn("failed to write import marker", "err", err)
 	}
 	return writeProfileMeta(dest, ProfileMeta{
@@ -301,6 +306,51 @@ func (pm *ProfileManager) Create(name string) error {
 		ID:   profileID(name),
 		Name: name,
 	})
+}
+
+func resolveImportSourcePath(sourcePath string) (string, error) {
+	if sourcePath == "" {
+		return "", fmt.Errorf("source path required")
+	}
+
+	cleaned := filepath.Clean(sourcePath)
+	if !filepath.IsAbs(cleaned) {
+		abs, err := filepath.Abs(cleaned)
+		if err != nil {
+			return "", fmt.Errorf("source path invalid: %w", err)
+		}
+		cleaned = abs
+	}
+
+	roots, err := allowedImportRoots()
+	if err != nil {
+		return "", err
+	}
+	for _, root := range roots {
+		if pathWithinRoot(cleaned, root) {
+			return cleaned, nil
+		}
+	}
+	return "", fmt.Errorf("source path must be within %s", strings.Join(roots, " or "))
+}
+
+func allowedImportRoots() ([]string, error) {
+	roots := []string{filepath.Clean(os.TempDir())}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("resolve home dir: %w", err)
+	}
+	roots = append(roots, filepath.Clean(homeDir))
+	return roots, nil
+}
+
+func pathWithinRoot(path, root string) bool {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (!strings.HasPrefix(rel, ".."+string(os.PathSeparator)) && rel != "..")
 }
 
 func (pm *ProfileManager) CreateWithMeta(name string, meta ProfileMeta) error {

--- a/internal/profiles/profiles_test.go
+++ b/internal/profiles/profiles_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -85,6 +86,37 @@ func TestProfileManagerImport(t *testing.T) {
 	}
 }
 
+func TestProfileManagerImportNormalizesSourcePath(t *testing.T) {
+	dir := t.TempDir()
+	pm := NewProfileManager(dir)
+
+	srcRoot := t.TempDir()
+	src := filepath.Join(srcRoot, "chrome-src")
+	_ = os.MkdirAll(filepath.Join(src, "Default"), 0755)
+	_ = os.WriteFile(filepath.Join(src, "Default", "Preferences"), []byte(`{}`), 0644)
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	relSource, err := filepath.Rel(cwd, src)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := pm.Import("normalized-import", relSource); err != nil {
+		t.Fatal(err)
+	}
+
+	importMarker, err := os.ReadFile(filepath.Join(dir, profileID("normalized-import"), ".pinchtab-imported"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := string(importMarker), filepath.Clean(src); got != want {
+		t.Fatalf("expected normalized source %q, got %q", want, got)
+	}
+}
+
 func TestProfileManagerImportBadSource(t *testing.T) {
 	dir := t.TempDir()
 	pm := NewProfileManager(dir)
@@ -92,6 +124,28 @@ func TestProfileManagerImportBadSource(t *testing.T) {
 	err := pm.Import("bad", "/nonexistent/path")
 	if err == nil {
 		t.Fatal("expected error on bad source")
+	}
+}
+
+func TestProfileManagerImportRejectsSourceOutsideAllowedRoots(t *testing.T) {
+	dir := t.TempDir()
+	pm := NewProfileManager(dir)
+
+	var outside string
+	switch runtime.GOOS {
+	case "windows":
+		systemRoot := os.Getenv("SystemRoot")
+		if systemRoot == "" {
+			t.Skip("SystemRoot not set")
+		}
+		outside = systemRoot
+	default:
+		outside = string(os.PathSeparator) + "etc"
+	}
+
+	err := pm.Import("outside-root", outside)
+	if err == nil || !strings.Contains(err.Error(), "must be within") {
+		t.Fatalf("expected allowed root error, got %v", err)
 	}
 }
 


### PR DESCRIPTION
Hardens the profile import path to prevent directory traversal and restrict source directories to safe locations.

## Changes

- **Path normalization**: Cleans and resolves relative paths to absolute before any filesystem operations
- **Allowed roots check**: Import source must be within `$HOME` or `$TMPDIR` — rejects paths like `/etc`, `/var`, system directories
- **Import marker uses resolved path**: The `.pinchtab-imported` file stores the normalized absolute path

## Tests

- `TestProfileManagerImportNormalizesSourcePath` — relative path resolved to absolute, marker stores clean path
- `TestProfileManagerImportRejectsSourceOutsideAllowedRoots` — `/etc` (Unix) or `%SystemRoot%` (Windows) rejected
- Existing symlink, path traversal, and bad source tests continue to pass