### PR TITLE
docs(trust): add CVE-2026-30834 reference and Security History section

### DIFF
--- a/skills/pinchtab/TRUST.md
+++ b/skills/pinchtab/TRUST.md
@@ -36,7 +36,7 @@ Binaries are built automatically from tagged commits via GitHub Actions (publicl
 
 - **Source**: https://github.com/pinchtab/pinchtab (MIT)
 - **Releases**: https://github.com/pinchtab/pinchtab/releases
-- **Latest**: v0.8.0 (March 2026)
+- **Latest**: v0.8.4 (Mar 2026)
 
 If you're concerned, audit the source—it's 12MB, zero external dependencies, mostly Go stdlib.
 
@@ -63,6 +63,18 @@ Pinchtab runs a separate Chrome process with:
 - Standard Chrome security model (site isolation, CSP, etc.)
 
 Use `profiles.baseDir`, `profiles.defaultProfile`, or `PINCHTAB_CONFIG` if you need to control where PinchTab stores browser state.
+
+## Security History
+
+| CVE | Severity | Affected | Fixed In | Endpoint |
+| --- | --- | --- | --- | --- |
+| [CVE-2026-30834](https://github.com/advisories/GHSA-rw8p-c6hf-q3pg) | High (7.5) | < 0.7.7 | 0.7.7 | `/download` |
+
+**Type:** Server-Side Request Forgery (SSRF) — allowed exfiltration of internal files and network probing via crafted download URLs.
+
+**Fix PRs:** [#135](https://github.com/pinchtab/pinchtab/pull/135) (SafePath validation), [#288](https://github.com/pinchtab/pinchtab/pull/288) (expanded URL validation).
+
+**Minimum recommended version:** 0.8.3+ (includes full SSRF hardening).
 
 ## Questions?
 


### PR DESCRIPTION
## Summary

Adds a **Security History** section to `skills/pinchtab/TRUST.md` referencing [CVE-2026-30834](https://github.com/advisories/GHSA-rw8p-c6hf-q3pg) (SSRF in `/download`, CVSS 7.5) as requested in #333.

## Changes

- **Security History table** — CVE ID, severity, affected versions (\< 0.7.7), fix version, endpoint
- **Fix PR references** — [#135](https://github.com/pinchtab/pinchtab/pull/135) (SafePath validation), [#288](https://github.com/pinchtab/pinchtab/pull/288) (expanded URL validation)
- **Minimum recommended version** — 0.8.3+ (full SSRF hardening)
- **Version update** — Latest version updated from v0.7.0 to v0.8.4

## Why

Operators and agents evaluating Pinchtab's security posture read TRUST.md first. Without the CVE reference, they can't determine whether their version is affected, what the minimum safe version is, or what endpoint was vulnerable. The fix PRs are already public — this just surfaces them where people look.

Closes #333

cc @luigi-agosti @pinchtabdev