### PR TITLE
docs(skill): add commands, agent-optimization, and mcp reference files

### DIFF
--- a/skill/pinchtab/references/agent-optimization.md
+++ b/skill/pinchtab/references/agent-optimization.md
@@ -1,0 +1,99 @@
+# Agent Optimization Reference
+
+Practical playbook for token-efficient, reliable browser automation with Pinchtab.
+
+## Cheapest-Path Decision Table
+
+Pick the cheapest method that gives you what you need:
+
+| Need | Method | Typical Tokens | When to Use |
+|------|--------|---------------|-------------|
+| Read page content | `text` | ~800 | Extracting articles, checking text on page |
+| Find interactive elements | `snap -i -c` | ~1,800 | Locating buttons, links, inputs to act on |
+| See what changed | `snap -d` | varies | Multi-step workflows (only diffs returned) |
+| Full page understanding | `snap` | ~10,500 | First visit, complex layouts |
+| Visual verification | `screenshot` | ~2K (vision) | Confirming visual state, debugging |
+| Export page | `pdf` | 0 (binary) | Saving page — no token cost |
+
+**Strategy:** Start with `snap -i -c`. Use `snap -d` on subsequent snapshots. Use `text` when you only need readable content. Full `snap` only when the cheaper options don't give you enough context.
+
+## The 3-Second Wait Pattern
+
+**Critical:** Always wait 3+ seconds after `nav` before taking a snapshot.
+
+```bash
+pinchtab nav https://example.com
+sleep 3
+pinchtab snap -i -c
+```
+
+**Why:** Chrome's accessibility tree lags behind DOM rendering. Without the wait, you get only 1 node (`RootWebArea`) instead of 2,000+.
+
+**Dynamic/SPA sites:** Increase to 5–10 seconds, or take multiple snapshots with waits between state changes.
+
+## Diff Snapshots for Multi-Step Workflows
+
+After the first full snapshot, use `-d` (diff) to see only what changed:
+
+```bash
+pinchtab snap -i -c          # Full snapshot (first time)
+pinchtab click e5             # Act on an element
+sleep 1
+pinchtab snap -d              # Only changes since last snapshot
+```
+
+This reduces token usage dramatically in multi-step flows (login → navigate → fill form → submit).
+
+## Recovery Patterns
+
+| Error | Meaning | Recovery |
+|-------|---------|----------|
+| **Connection refused** | Pinchtab server not running | Start with `pinchtab &` or check `PINCHTAB_URL` |
+| **403 Forbidden** | Auth token required or invalid | Set `PINCHTAB_TOKEN` or check `BRIDGE_TOKEN` |
+| **401 Unauthorized** | Token mismatch | Verify token matches the server's `BRIDGE_TOKEN` |
+| **Stale refs** | Page changed since last snapshot | Take a new snapshot before acting |
+| **Bot detection** | Site blocked automated browser | Try `BRIDGE_STEALTH=full`, rotate fingerprint, add waits |
+| **Only 1 node** | Snapshot taken too early | Wait 3+ seconds after navigation |
+| **Timeout** | Action or navigation took too long | Increase `BRIDGE_TIMEOUT` or `BRIDGE_NAV_TIMEOUT` |
+
+## Token Savings: Real Numbers
+
+| Approach | Tokens | Notes |
+|----------|--------|-------|
+| Exploratory (agent discovers pattern) | ~3,842 | Multiple retries, full tree parsing |
+| Pattern-driven (prescriptive instructions) | ~272 | **14× better** — direct execution |
+
+**Key insight:** Give agents exact commands. Exploratory agent loops waste 93% of tokens on reasoning, failed filters, and narration.
+
+## Prescriptive Scraping Template
+
+For agents extracting headlines/data:
+
+```bash
+pinchtab nav TARGET_URL
+sleep 3
+pinchtab snap -i -c | jq '.nodes[] | select(.name | length > 15) | .name' | head -30
+```
+
+Replace `TARGET_URL`. Limit output with `head -N`. Filter threshold (`length > 15`) skips buttons and labels.
+
+## Lite Engine Boundaries
+
+`--engine lite` uses a minimal rendering pipeline:
+
+| ✅ Works | ❌ Doesn't work |
+|----------|-----------------|
+| Page navigation | Complex JS-heavy SPAs |
+| Text extraction | Sites requiring full JS execution |
+| Simple form fills | Dynamic content after initial load |
+| Screenshot capture | Sites with anti-bot JS challenges |
+
+Use lite engine for read-heavy, simple pages. Switch to default engine for anything interactive or JS-dependent.
+
+## Tips
+
+- **Block images** for read-heavy tasks: `pinchtab nav URL --block-images` or `BRIDGE_BLOCK_IMAGES=true`
+- **Scope snapshots** to reduce tokens: `snap -s main` limits to `<main>` element
+- **Cap output**: `snap --max-tokens 2000` truncates to ~2K tokens
+- **Batch actions**: Use `pinchtab action -f actions.json` to send multiple steps in one call
+- **Always pass `--instance`** explicitly in multi-instance setups

--- a/skill/pinchtab/references/commands.md
+++ b/skill/pinchtab/references/commands.md
@@ -1,0 +1,84 @@
+# CLI Commands Reference
+
+> **Canonical names only.** Aliases like `ss` (for `screenshot`) work but use full names in automation.
+
+## Instance Management
+
+| Command | Description |
+|---------|-------------|
+| `pinchtab instances` | List running instances |
+| `pinchtab instance launch [--mode headed] [--port N]` | Launch a new instance |
+| `pinchtab instance <id> logs` | View instance logs |
+| `pinchtab instance <id> stop` | Stop an instance |
+
+## Browser Control
+
+All browser commands accept `--instance <id>` (or set `PINCHTAB_INSTANCE` env var).
+
+| Command | Description |
+|---------|-------------|
+| `pinchtab nav <url> [--new-tab] [--block-images]` | Navigate to URL |
+| `pinchtab snap [-i] [-c] [-d] [-s <selector>] [--max-tokens N]` | Snapshot accessibility tree |
+| `pinchtab click <ref>` | Click element by ref |
+| `pinchtab type <ref> "text"` | Type into element |
+| `pinchtab fill <ref> "value"` | Set value directly (no keystrokes) |
+| `pinchtab press <key>` | Press key (Enter, Tab, Escape, etc.) |
+| `pinchtab scroll <down\|up\|N>` | Scroll page |
+| `pinchtab text [--raw]` | Extract readable page text |
+| `pinchtab screenshot [-o file] [-q 0-100]` | Take screenshot |
+| `pinchtab pdf [-o file] [--landscape] [--page-ranges "1-3"]` | Export page as PDF |
+| `pinchtab eval "<expression>"` | Run JavaScript |
+| `pinchtab cookies` | Get cookies for current page |
+| `pinchtab console [--clear] [--limit N]` | View browser console logs |
+| `pinchtab errors [--clear] [--limit N]` | View uncaught JS errors |
+| `pinchtab health` | Server health check |
+
+## Tab Management
+
+| Command | Description |
+|---------|-------------|
+| `pinchtab tabs` | List tabs |
+| `pinchtab tab create <url>` | Create new tab |
+| `pinchtab tab <id> navigate <url>` | Navigate specific tab |
+| `pinchtab tab <id> close` | Close tab |
+| `pinchtab tab <id> lock --owner <name> --ttl <sec>` | Lock tab (multi-agent) |
+| `pinchtab tab <id> unlock --owner <name>` | Unlock tab |
+
+## Snapshot Flags
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--interactive` | `-i` | Interactive elements only (buttons, links, inputs) |
+| `--compact` | `-c` | One-line-per-node format (56–64% fewer tokens) |
+| `--diff` | `-d` | Only changes since last snapshot |
+| `--selector` | `-s` | Scope to CSS selector (e.g. `main`) |
+| `--max-tokens` | — | Truncate output to ~N tokens |
+| `--depth` | — | Max tree depth |
+
+## Common Pitfalls
+
+| ❌ Wrong | ✅ Correct | Notes |
+|----------|-----------|-------|
+| `ss` | `screenshot` | `ss` is a shortcut alias — use full name |
+| `--profileId` | `--profile` | Flag is `--profile` |
+| `tabs` (for single) | `tab <id> <action>` | `tabs` lists; `tab` manages |
+| `find` | `snap -i` | `find` doesn't exist; use filtered snapshot |
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PINCHTAB_URL` | `http://localhost:9867` | Server URL |
+| `PINCHTAB_INSTANCE` | (auto) | Default instance ID |
+| `PINCHTAB_TOKEN` | (none) | Auth token |
+| `PINCHTAB_TIMEOUT` | `30` | Request timeout (seconds) |
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Success |
+| `1` | User error (bad args, missing file) |
+| `2` | Server error (500, connection refused) |
+| `3` | Timeout |
+| `4` | Resource not found |

--- a/skill/pinchtab/references/mcp.md
+++ b/skill/pinchtab/references/mcp.md
@@ -1,0 +1,90 @@
+# MCP / SMCP Reference
+
+Pinchtab exposes browser control tools via an [SMCP](https://github.com/sanctumos/smcp) plugin. Agents using MCP-compatible clients can call Pinchtab tools directly.
+
+## Available Tools
+
+Tool names follow the `pinchtab__<command>` convention (double underscore):
+
+| Tool | Description |
+|------|-------------|
+| `pinchtab__health` | Health check |
+| `pinchtab__instances` | List running instances |
+| `pinchtab__instance-start` | Start an instance (optional: profile-id, mode, port) |
+| `pinchtab__instance-stop` | Stop an instance |
+| `pinchtab__tabs` | List tabs |
+| `pinchtab__navigate` | Navigate to URL |
+| `pinchtab__snapshot` | Get accessibility tree (filter, format, selector, max-tokens, diff) |
+| `pinchtab__action` | Single action: click, type, press, focus, fill, hover, select, scroll |
+| `pinchtab__actions` | Batch actions (JSON array) |
+| `pinchtab__text` | Extract page text |
+| `pinchtab__screenshot` | Take screenshot |
+| `pinchtab__pdf` | Export tab to PDF |
+| `pinchtab__evaluate` | Run JavaScript |
+| `pinchtab__cookies-get` | Get cookies |
+| `pinchtab__stealth-status` | Stealth/fingerprint status |
+
+## Configuration
+
+| Setting | Description |
+|---------|-------------|
+| `MCP_PLUGINS_DIR` | Set to the `plugins/` directory containing the `pinchtab` folder |
+| `--base-url` | Pinchtab server URL (default: `http://localhost:9867`) |
+| `--token` | Auth token (if `BRIDGE_TOKEN` is set on the server) |
+| `--instance-id` | Target instance ID (required for instance-scoped calls via orchestrator) |
+
+### Setup
+
+```bash
+# 1. Point SMCP at the plugins directory
+export MCP_PLUGINS_DIR=/path/to/pinchtab/plugins
+
+# 2. Ensure cli.py is executable
+chmod +x plugins/pinchtab/cli.py
+
+# 3. Restart SMCP — no pip install required (stdlib only)
+```
+
+## Example Tool Call
+
+Agent calls `pinchtab__navigate`:
+
+```json
+{
+  "base_url": "http://localhost:9867",
+  "instance_id": "inst_0a89a5bb",
+  "url": "https://example.com"
+}
+```
+
+SMCP invokes:
+
+```bash
+python cli.py navigate --base-url http://localhost:9867 --instance-id inst_0a89a5bb --url https://example.com
+```
+
+Returns JSON to stdout:
+
+```json
+{ "status": "success", "data": { ... } }
+```
+
+## What MCP CAN'T Do
+
+The SMCP plugin covers browser control only. These features are **not available** via MCP:
+
+| Not Available | Alternative |
+|---------------|-------------|
+| Profile CRUD (create, update, delete) | Use `curl` against `/profiles` endpoints |
+| Scheduler / cron jobs | External scheduler + MCP tool calls |
+| Stealth configuration changes | Set `BRIDGE_STEALTH` env var before launch |
+| Dashboard UI control | Use the web dashboard directly |
+| Download / upload files | Use `curl` against `/download` and `/upload` endpoints |
+| Cookie setting | Use `curl` against `POST /cookies` |
+| Fingerprint rotation | Use `curl` against `POST /fingerprint/rotate` |
+
+## Requirements
+
+- Python 3.9+
+- A running Pinchtab server
+- No extra Python dependencies (stdlib only)


### PR DESCRIPTION
## Summary

Adds three missing reference files to `skills/pinchtab/references/` as requested in #331.

## New Files

### 1. `commands.md` — CLI Commands Reference
- All command groups: instance management, browser control, tab management
- Key flags (snapshot, screenshot, PDF, navigation)
- **Common pitfalls** table (`screenshot` not `ss`, `--profile` not `--profileId`, etc.)
- Environment variables and exit codes

### 2. `agent-optimization.md` — Agent Optimization Playbook
- **Cheapest-path decision table** — when to use `text` vs `snap -i -c` vs `screenshot`
- The 3-second wait pattern with explanation
- Diff snapshots (`snap -d`) for multi-step workflows
- **Recovery patterns** for 403, 401, connection refused, stale refs, bot detection
- Lite engine boundaries
- Real token savings data (93% reduction with prescriptive instructions)

### 3. `mcp.md` — MCP / SMCP Reference
- All 15 available SMCP tools with descriptions
- Configuration (`MCP_PLUGINS_DIR`, `--base-url`, `--token`, `--instance-id`)
- Example tool call walkthrough
- **What MCP CAN'T do** — no profile CRUD, no scheduler, no stealth config, etc.

## Why

The skill is designed to be the agent's primary reference. When references are missing, agents fall back to general web searches or halluculate flags/commands. These three files cover the most frequently needed reference areas that agents currently lack.

Each file is 80–120 lines, covering the practical surface without unnecessary verbosity.

Closes #331

cc @luigi-agosti @pinchtabdev