### PR TITLE
fix: pre-release process (health check, lite mode, docker smoke)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ ENV HOME=/data \
 EXPOSE 9867
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-  CMD wget -q -O /dev/null http://localhost:9867/health || exit 1
+  CMD /bin/sh -lc 'pinchtab health >/dev/null' || exit 1
 
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["/usr/local/bin/docker-entrypoint.sh", "pinchtab"]

--- a/internal/handlers/health_tabs.go
+++ b/internal/handlers/health_tabs.go
@@ -6,10 +6,26 @@ import (
 	"time"
 
 	"github.com/pinchtab/pinchtab/internal/bridge"
+	"github.com/pinchtab/pinchtab/internal/engine"
 	"github.com/pinchtab/pinchtab/internal/httpx"
 )
 
 func (h *Handlers) HandleHealth(w http.ResponseWriter, r *http.Request) {
+	if h.Router != nil && h.Router.Mode() == engine.ModeLite {
+		resp := map[string]any{
+			"status": "ok",
+			"engine": "lite",
+		}
+		if hasFailureDiagnostics() {
+			resp["failures"] = FailureSnapshot()
+		}
+		if bridge.HasCrashDiagnostics() {
+			resp["crashes"] = bridge.CrashSnapshot()
+		}
+		httpx.JSON(w, http.StatusOK, resp)
+		return
+	}
+
 	// Guard against nil Bridge
 	if h.Bridge == nil {
 		httpx.JSON(w, 503, map[string]any{"status": "error", "reason": "bridge not initialized"})

--- a/internal/handlers/health_tabs_test.go
+++ b/internal/handlers/health_tabs_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/chromedp/cdproto/target"
 	"github.com/pinchtab/pinchtab/internal/bridge"
 	"github.com/pinchtab/pinchtab/internal/config"
+	"github.com/pinchtab/pinchtab/internal/engine"
 )
 
 // TestHandleHealth_NilBridge verifies health endpoint returns 503 when bridge is nil
@@ -252,6 +253,43 @@ func TestHandleHealth_EnsureChromeSuccess(t *testing.T) {
 
 	if status, ok := resp["status"]; !ok || status != "ok" {
 		t.Errorf("expected status=ok, got %v", status)
+	}
+}
+
+func TestHandleHealth_LiteModeSkipsChrome(t *testing.T) {
+	mockBridge := &MockBridge{
+		ensureChromeErr: "should not be called",
+	}
+
+	h := &Handlers{
+		Bridge: mockBridge,
+		Config: &config.RuntimeConfig{},
+		Router: engine.NewRouter(engine.ModeLite, engine.NewLiteEngine()),
+	}
+
+	req := httptest.NewRequest("GET", "/health", nil)
+	w := httptest.NewRecorder()
+
+	h.HandleHealth(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+
+	if mockBridge.ensureChromeCalled {
+		t.Error("expected lite health to skip ensureChrome")
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+
+	if status, ok := resp["status"]; !ok || status != "ok" {
+		t.Errorf("expected status=ok, got %v", status)
+	}
+	if engineName, ok := resp["engine"]; !ok || engineName != "lite" {
+		t.Errorf("expected engine=lite, got %v", engineName)
 	}
 }
 

--- a/scripts/docker-smoke.sh
+++ b/scripts/docker-smoke.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 IMAGE="${1:-pinchtab-local:test}"
+SMOKE_TOKEN="pinchtab-smoke-token-${RANDOM}${RANDOM}"
 
 NAME="pinchtab-smoke-${RANDOM}${RANDOM}"
 FAILED=0
@@ -18,7 +19,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-docker run -d --name "$NAME" -p 127.0.0.1::9867 "$IMAGE" >/dev/null
+docker run -d --name "$NAME" -e PINCHTAB_TOKEN="$SMOKE_TOKEN" -p 127.0.0.1::9867 "$IMAGE" >/dev/null
 
 HOST_PORT="$(docker port "$NAME" 9867/tcp | head -1 | awk -F: '{print $NF}')"
 if [ -z "$HOST_PORT" ]; then
@@ -27,21 +28,20 @@ if [ -z "$HOST_PORT" ]; then
   exit 1
 fi
 
-AUTH_HEADER=()
-TOKEN="$(docker exec "$NAME" pinchtab config get server.token | tr -d '\r')"
-if [ -n "$TOKEN" ]; then
-  AUTH_HEADER=(-H "Authorization: Bearer ${TOKEN}")
-fi
+health_check() {
+  printf 'fail\nsilent\nshow-error\nheader = "Authorization: Bearer %s"\nurl = "http://127.0.0.1:%s/health"\n' "$SMOKE_TOKEN" "$HOST_PORT" \
+    | curl --config - >/dev/null 2>&1
+}
 
 echo "Waiting for PinchTab to become healthy on port $HOST_PORT..."
 for _ in $(seq 1 60); do
-  if curl -fsS "${AUTH_HEADER[@]}" "http://127.0.0.1:${HOST_PORT}/health" >/dev/null 2>&1; then
+  if health_check; then
     break
   fi
   sleep 1
 done
 
-if ! curl -fsS "${AUTH_HEADER[@]}" "http://127.0.0.1:${HOST_PORT}/health" >/dev/null 2>&1; then
+if ! health_check; then
   FAILED=1
   echo "health check did not pass"
   exit 1


### PR DESCRIPTION
- Docker healthcheck uses `pinchtab health` CLI instead of raw wget
- Health endpoint returns early for lite engine mode (skips Chrome checks)
- Docker smoke script uses explicit token via env var, curl config file
- Unit test for lite mode health path