### PR TITLE
feat: support wildcard (*) in attach allowHosts

### DIFF
--- a/internal/orchestrator/handlers_instances.go
+++ b/internal/orchestrator/handlers_instances.go
@@ -451,7 +451,7 @@ func (o *Orchestrator) validateAttachURL(rawURL string) error {
 	host := parsed.Hostname()
 	hostAllowed := false
 	for _, allowed := range o.runtimeCfg.AttachAllowHosts {
-		if host == allowed {
+		if allowed == "*" || host == allowed {
 			hostAllowed = true
 			break
 		}

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -436,6 +436,22 @@ func TestValidateAttachURL_RejectsBridgeBaseURLWithPath(t *testing.T) {
 	}
 }
 
+func TestValidateAttachURL_WildcardHost(t *testing.T) {
+	o := NewOrchestratorWithRunner(t.TempDir(), &mockRunner{portAvail: true})
+	o.ApplyRuntimeConfig(&config.RuntimeConfig{
+		AttachEnabled:      true,
+		AttachAllowHosts:   []string{"*"},
+		AttachAllowSchemes: []string{"http", "ws"},
+	})
+
+	if err := o.validateAttachURL("http://192.168.1.100:9868"); err != nil {
+		t.Fatalf("wildcard host should allow any host, got: %v", err)
+	}
+	if err := o.validateAttachURL("http://bridge-container:9868"); err != nil {
+		t.Fatalf("wildcard host should allow hostname, got: %v", err)
+	}
+}
+
 func TestOrchestrator_RegisterHandlers_LocksSensitiveRoutes(t *testing.T) {
 	o := NewOrchestratorWithRunner(t.TempDir(), &mockRunner{portAvail: true})
 	o.ApplyRuntimeConfig(&config.RuntimeConfig{})


### PR DESCRIPTION
## Summary
- Allow `"*"` as a value in `security.attach.allowHosts` to permit any host in `validateAttachURL`
- Enables orchestrator + bridge setups across Docker networks or separate machines without enumerating every host
- Adds test coverage for wildcard host matching

## Test plan
- [x] `TestValidateAttachURL_WildcardHost` — verifies `*` allows arbitrary IPs and hostnames
- [x] Existing `TestValidateAttachURL_AllowsBridgeHTTP` and `RejectsBridgeBaseURLWithPath` still pass
- [x] Full `go test ./...` passes
- [x] `go vet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)