### PR TITLE
feat: add security.trustedProxyCIDRs for proxy on private networks

### DIFF
--- a/internal/config/config_file.go
+++ b/internal/config/config_file.go
@@ -176,6 +176,7 @@ type securityConfigJSON struct {
 	UploadMaxFileBytes     *int           `json:"uploadMaxFileBytes"`
 	UploadMaxTotalBytes    *int           `json:"uploadMaxTotalBytes"`
 	MaxRedirects           *int           `json:"maxRedirects"`
+	TrustedProxyCIDRs      []string       `json:"trustedProxyCIDRs"`
 	Attach                 attachJSON     `json:"attach"`
 	IDPI                   idpiConfigJSON `json:"idpi"`
 }
@@ -296,6 +297,7 @@ func (fc FileConfig) MarshalJSON() ([]byte, error) {
 			UploadMaxFileBytes:     fc.Security.UploadMaxFileBytes,
 			UploadMaxTotalBytes:    fc.Security.UploadMaxTotalBytes,
 			MaxRedirects:           fc.Security.MaxRedirects,
+			TrustedProxyCIDRs:      copyStringSlice(fc.Security.TrustedProxyCIDRs),
 			Attach: attachJSON{
 				Enabled:      fc.Security.Attach.Enabled,
 				AllowHosts:   copyStringSlice(fc.Security.Attach.AllowHosts),
@@ -447,6 +449,7 @@ func FileConfigFromRuntime(cfg *RuntimeConfig) FileConfig {
 			UploadMaxFileBytes:     &uploadMaxFileBytes,
 			UploadMaxTotalBytes:    &uploadMaxTotalBytes,
 			MaxRedirects:           &maxRedirects,
+			TrustedProxyCIDRs:      append([]string(nil), cfg.TrustedProxyCIDRs...),
 			Attach: AttachConfig{
 				Enabled:      &attachEnabled,
 				AllowHosts:   append([]string(nil), cfg.AttachAllowHosts...),

--- a/internal/config/config_load.go
+++ b/internal/config/config_load.go
@@ -240,6 +240,7 @@ func applyFileConfig(cfg *RuntimeConfig, fc *FileConfig) {
 	}
 	cfg.AttachAllowHosts = append([]string(nil), fc.Security.Attach.AllowHosts...)
 	cfg.AttachAllowSchemes = append([]string(nil), fc.Security.Attach.AllowSchemes...)
+	cfg.TrustedProxyCIDRs = append([]string(nil), fc.Security.TrustedProxyCIDRs...)
 	// IDPI – copy the whole struct; individual fields have safe zero-value defaults.
 	cfg.IDPI = fc.Security.IDPI
 	if fc.Observability.Activity.Enabled != nil {

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -27,7 +27,8 @@ type RuntimeConfig struct {
 	UploadMaxFiles         int
 	UploadMaxFileBytes     int
 	UploadMaxTotalBytes    int
-	MaxRedirects           int // Max HTTP redirects (-1=unlimited, 0=none, default=-1)
+	MaxRedirects           int      // Max HTTP redirects (-1=unlimited, 0=none, default=-1)
+	TrustedProxyCIDRs      []string // CIDRs/IPs whose RemoteIPAddress is trusted in navigation responses (e.g. internal proxy)
 
 	// Browser/instance settings
 	Headless          bool
@@ -190,6 +191,7 @@ type SecurityConfig struct {
 	UploadMaxFileBytes     *int         `json:"uploadMaxFileBytes,omitempty"`
 	UploadMaxTotalBytes    *int         `json:"uploadMaxTotalBytes,omitempty"`
 	MaxRedirects           *int         `json:"maxRedirects,omitempty"`
+	TrustedProxyCIDRs      []string     `json:"trustedProxyCIDRs,omitempty"`
 	Attach                 AttachConfig `json:"attach,omitempty"`
 	IDPI                   IDPIConfig   `json:"idpi,omitempty"`
 }

--- a/internal/config/editor_get.go
+++ b/internal/config/editor_get.go
@@ -130,6 +130,8 @@ func getSecurityField(s *SecurityConfig, field string) (string, error) {
 		return formatIntPtr(s.UploadMaxTotalBytes), nil
 	case "maxRedirects":
 		return formatIntPtr(s.MaxRedirects), nil
+	case "trustedProxyCIDRs":
+		return strings.Join(s.TrustedProxyCIDRs, ","), nil
 	default:
 		return "", fmt.Errorf("unknown field security.%s", field)
 	}

--- a/internal/config/editor_set.go
+++ b/internal/config/editor_set.go
@@ -142,6 +142,10 @@ func setSecurityField(s *SecurityConfig, field, value string) error {
 		s.DownloadAllowedDomains = parseCSVList(value)
 		return nil
 	}
+	if field == "trustedProxyCIDRs" {
+		s.TrustedProxyCIDRs = parseCSVList(value)
+		return nil
+	}
 	switch field {
 	case "downloadMaxBytes":
 		n, err := strconv.Atoi(value)

--- a/internal/handlers/navigation.go
+++ b/internal/handlers/navigation.go
@@ -107,6 +107,7 @@ func (h *Handlers) HandleNavigate(w http.ResponseWriter, r *http.Request) {
 		httpx.Error(w, http.StatusForbidden, err)
 		return
 	}
+	trustedCIDRs := parseCIDRs(h.Config.TrustedProxyCIDRs)
 	h.recordNavigateRequest(r, req.TabID, req.URL)
 
 	// --- Lite engine fast path ---
@@ -185,7 +186,7 @@ func (h *Handlers) HandleNavigate(w http.ResponseWriter, r *http.Request) {
 		tCtx, tCancel := context.WithTimeout(newCtx, navTimeout)
 		defer tCancel()
 		go httpx.CancelOnClientDone(r.Context(), tCancel)
-		navGuard, err := installNavigateRuntimeGuard(tCtx, tCancel, target)
+		navGuard, err := installNavigateRuntimeGuard(tCtx, tCancel, target, trustedCIDRs)
 		if err != nil {
 			httpx.Error(w, 500, fmt.Errorf("navigation guard: %w", err))
 			return
@@ -237,7 +238,7 @@ func (h *Handlers) HandleNavigate(w http.ResponseWriter, r *http.Request) {
 	tCtx, tCancel := context.WithTimeout(ctx, navTimeout)
 	defer tCancel()
 	go httpx.CancelOnClientDone(r.Context(), tCancel)
-	navGuard, err := installNavigateRuntimeGuard(tCtx, tCancel, target)
+	navGuard, err := installNavigateRuntimeGuard(tCtx, tCancel, target, trustedCIDRs)
 	if err != nil {
 		httpx.Error(w, 500, fmt.Errorf("navigation guard: %w", err))
 		return

--- a/internal/handlers/navigation_policy.go
+++ b/internal/handlers/navigation_policy.go
@@ -155,15 +155,39 @@ func extractNavigateHost(raw string) (string, bool) {
 	return "", false
 }
 
-func validateNavigateRemoteIPAddress(raw string) error {
+func validateNavigateRemoteIPAddress(raw string, trustedCIDRs []*net.IPNet) error {
 	normalized := netguard.NormalizeRemoteIP(raw)
 	if err := netguard.ValidateRemoteIPAddress(raw); err != nil {
+		if ip := net.ParseIP(normalized); ip != nil {
+			for _, cidr := range trustedCIDRs {
+				if cidr.Contains(ip) {
+					return nil
+				}
+			}
+		}
 		return fmt.Errorf("navigation connected to blocked remote IP %s", normalized)
 	}
 	return nil
 }
 
-func installNavigateRuntimeGuard(tCtx context.Context, tCancel context.CancelFunc, target *validatedNavigateTarget) (*navigateRuntimeGuard, error) {
+func parseCIDRs(raw []string) []*net.IPNet {
+	var nets []*net.IPNet
+	for _, s := range raw {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+		if !strings.Contains(s, "/") {
+			s += "/32"
+		}
+		if _, cidr, err := net.ParseCIDR(s); err == nil {
+			nets = append(nets, cidr)
+		}
+	}
+	return nets
+}
+
+func installNavigateRuntimeGuard(tCtx context.Context, tCancel context.CancelFunc, target *validatedNavigateTarget, trustedCIDRs []*net.IPNet) (*navigateRuntimeGuard, error) {
 	if target == nil || target.allowInternal {
 		return nil, nil
 	}
@@ -185,7 +209,7 @@ func installNavigateRuntimeGuard(tCtx context.Context, tCancel context.CancelFun
 			if !guard.isMainDocumentResponse(string(e.RequestID)) {
 				return
 			}
-			if err := validateNavigateRemoteIPAddress(e.Response.RemoteIPAddress); err != nil {
+			if err := validateNavigateRemoteIPAddress(e.Response.RemoteIPAddress, trustedCIDRs); err != nil {
 				guard.setBlocked(err)
 				tCancel()
 			}


### PR DESCRIPTION
Closes #365

## Summary

- Adds `security.trustedProxyCIDRs` config option — a list of CIDR ranges whose RemoteIPAddress is trusted in navigation responses
- When Chrome navigates through an HTTP proxy on a private/Docker network, the runtime SSRF guard blocks the response because RemoteIPAddress is the proxy's private IP, not the target site
- This change whitelists specific CIDRs so the guard lets them through while remaining active for all other IPs

## Problem

In containerized deployments where Chrome uses `--proxy-server=http://internal-proxy:3128`, all TCP connections go to the proxy's private IP (e.g. `172.18.0.3`). The runtime SSRF guard in `installNavigateRuntimeGuard` sees this private IP in `Response.RemoteIPAddress` and blocks the navigation with `"navigation connected to blocked remote IP"`, even though the actual target is a public domain.

There is no existing config to bypass this — `allowExplicitInternal` in `validateNavigateTarget` only affects the DNS pre-check path (when the target itself resolves to a private IP), not the post-connection remote IP guard.

## Solution

Instead of a blanket `allowInternal` bool that would disable the guard entirely, this adds a targeted CIDR allowlist:

- New config field `security.trustedProxyCIDRs` (e.g. `["172.16.0.0/12", "10.0.0.0/8"]`)
- The SSRF guard remains active — only IPs matching a trusted CIDR are exempted
- Full config integration: load, save, round-trip, `pinchtab config set/get`

## Changes

7 files, +43/-6 lines:

- `config_types.go` — field in RuntimeConfig + SecurityConfig
- `config_file.go` — JSON serialization (both directions, full round-trip)
- `config_load.go` — FileConfig → RuntimeConfig mapping
- `editor_set.go` / `editor_get.go` — CLI support
- `navigation_policy.go` — `parseCIDRs()`, pass trusted list to guard, check before blocking
- `navigation.go` — parse CIDRs from config, pass to both guard call sites

## Example config

```json
"security": {
  "trustedProxyCIDRs": ["172.16.0.0/12", "10.0.0.0/8"]
}
```

## Test plan

- [x] `go vet ./...` — clean
- [x] `go test ./internal/config/... ./internal/handlers/... ./internal/idpi/... ./internal/netguard/...` — all pass
- [x] `gofmt -l` — no formatting issues
- [x] Manual E2E: sandbox container with `--proxy-server=http://gost-router:3128` (Docker IP 172.18.0.x) navigates to public sites successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)