### PR TITLE
feat: support PINCHTAB_CHROME_PROXY env var

### DIFF
--- a/internal/bridge/runtime/init.go
+++ b/internal/bridge/runtime/init.go
@@ -144,6 +144,9 @@ func setupAllocator(cfg *config.RuntimeConfig, hooks Hooks) (context.Context, co
 		opts = append(opts, chromedp.Flag("tz", cfg.Timezone))
 	}
 
+	if proxyURL := os.Getenv("PINCHTAB_CHROME_PROXY"); proxyURL != "" {
+		opts = append(opts, chromedp.ProxyServer(proxyURL))
+	}
 	if cfg.ChromeExtraFlags != "" {
 		for _, f := range strings.Fields(cfg.ChromeExtraFlags) {
 			opts = appendExecAllocatorFlag(opts, f)


### PR DESCRIPTION
## Summary

- Reads `PINCHTAB_CHROME_PROXY` env var at Chrome launch and adds `--proxy-server` flag
- Allows configuring the proxy URL without touching config files — useful when the same image/config is shared across environments

## Use case

In containerized deployments, the proxy endpoint may differ per environment (internal Docker DNS vs external HTTPS proxy). An env var is the standard way to vary this without rebuilding images or runtime config hacking.

## Changes

1 file, +3 lines: `internal/bridge/runtime/init.go`

## Test plan

- [x] `go vet ./...` — clean
- [x] `go build ./cmd/pinchtab/` — compiles
- [x] Manual E2E: `PINCHTAB_CHROME_PROXY=http://gost-router:3128` — Chrome navigates through proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)