### PR TITLE
fix: save/restore browser tabs and hide transient tabs from API

### DIFF
--- a/internal/bridge/bridge.go
+++ b/internal/bridge/bridge.go
@@ -243,6 +243,11 @@ func (b *Bridge) EnsureChrome(cfg *config.RuntimeConfig) error {
 		b.InitActionRegistry()
 	}
 
+	// Restore tabs from previous session (if any saved state exists)
+	if b.tempProfileDir == "" {
+		b.RestoreState()
+	}
+
 	// Start crash monitoring
 	b.MonitorCrashes(nil)
 
@@ -252,6 +257,16 @@ func (b *Bridge) EnsureChrome(cfg *config.RuntimeConfig) error {
 // Cleanup releases browser resources and removes temporary profile directories.
 // Must be called on shutdown to prevent Chrome process and disk leaks.
 func (b *Bridge) Cleanup() {
+	// Persist open tabs so next startup can restore them
+	if b.TabManager != nil && b.tempProfileDir == "" {
+		b.SaveState()
+	}
+
+	// Mark a clean exit so Chrome doesn't show a crash recovery bar
+	if b.Config != nil && b.tempProfileDir == "" {
+		MarkCleanExit(b.Config.ProfileDir)
+	}
+
 	// Cancel chromedp contexts (kills main Chrome process)
 	if b.BrowserCancel != nil {
 		b.BrowserCancel()

--- a/internal/bridge/state.go
+++ b/internal/bridge/state.go
@@ -32,7 +32,9 @@ type SessionState struct {
 	SavedAt string     `json:"savedAt"`
 }
 
-func isTransientURL(url string) bool {
+// IsTransientURL returns true for URLs that should not be shown in the UI
+// or persisted to session state (about:blank, chrome://, etc.).
+func IsTransientURL(url string) bool {
 	switch url {
 	case "about:blank", "chrome://newtab/", "chrome://new-tab-page/":
 		return true
@@ -133,7 +135,7 @@ func (b *Bridge) SaveState() {
 	tabs := make([]TabState, 0, len(targets))
 	seen := make(map[string]bool, len(targets))
 	for _, t := range targets {
-		if t.URL == "" || isTransientURL(t.URL) {
+		if t.URL == "" || IsTransientURL(t.URL) {
 			continue
 		}
 		if seen[t.URL] {
@@ -222,6 +224,7 @@ func (b *Bridge) RestoreState() {
 		b.tabSetup(ctx)
 		b.mu.Lock()
 		b.tabs[newID] = &TabEntry{Ctx: ctx, Cancel: cancel}
+		b.accessed[newID] = true
 		b.mu.Unlock()
 		restored++
 

--- a/internal/bridge/state_test.go
+++ b/internal/bridge/state_test.go
@@ -139,7 +139,7 @@ func TestIsTransientURL(t *testing.T) {
 		"http://localhost:3000/dashboard",
 	}
 	for _, u := range transient {
-		if !isTransientURL(u) {
+		if !IsTransientURL(u) {
 			t.Errorf("expected transient: %s", u)
 		}
 	}
@@ -151,7 +151,7 @@ func TestIsTransientURL(t *testing.T) {
 		"https://httpbin.org/get",
 	}
 	for _, u := range persistent {
-		if isTransientURL(u) {
+		if IsTransientURL(u) {
 			t.Errorf("expected persistent: %s", u)
 		}
 	}

--- a/internal/handlers/health_tabs.go
+++ b/internal/handlers/health_tabs.go
@@ -124,6 +124,10 @@ func (h *Handlers) HandleTabs(w http.ResponseWriter, r *http.Request) {
 
 	tabs := make([]map[string]any, 0, len(targets))
 	for _, t := range targets {
+		// Skip the initial about:blank tab that Chrome creates on launch
+		if bridge.IsTransientURL(t.URL) {
+			continue
+		}
 		tabID := string(t.TargetID)
 		entry := map[string]any{
 			"id":    tabID,


### PR DESCRIPTION
## Summary
- Call `SaveState()` and `MarkCleanExit()` during `Cleanup()` so open tabs are persisted to `sessions.json` before Chrome is killed
- Call `RestoreState()` in `EnsureChrome()` so tabs are reopened on next startup
- Mark restored tabs as accessed (`b.accessed[newID] = true`) so they survive the next `SaveState()` cycle instead of being silently dropped
- Export `IsTransientURL` and use it in `HandleTabs` to filter `about:blank`, `chrome://`, and other internal URLs from the `/tabs` API response

## Context
The `SaveState`/`RestoreState`/`MarkCleanExit` functions were fully implemented but never wired into the bridge lifecycle — three one-line calls were missing. This meant browser tabs were lost on every bridge restart.

The `about:blank` default tab that Chrome creates on launch was always visible in the dashboard UI and API responses, even though `isTransientURL` already existed to identify such URLs.

## Test plan
- [x] `go test ./internal/bridge/ ./internal/handlers/` — all pass
- [x] `go vet ./...` — clean
- [x] `gofmt` — no changes needed
- [x] Verified end-to-end: sandbox bridge saves tabs on stop, restores on restart, `about:blank` no longer appears in dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)