### PR TITLE
Allow re-attaching a bridge by name

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -418,12 +418,28 @@ func intPtr(v int) *int {
 	return &n
 }
 
-func (o *Orchestrator) attachExternalInstance(name string, inst bridge.Instance, authToken string) (*bridge.Instance, error) {
+// attachExternalInstance registers an external instance or updates an existing
+// bridge in place (upsert). Non-bridge duplicates still return an error.
+func (o *Orchestrator) attachExternalInstance(name string, inst bridge.Instance, authToken string) (*bridge.Instance, bool, error) {
 	o.mu.Lock()
-	for _, inst := range o.instances {
-		if inst.ProfileName == name && instanceIsActive(inst) {
+	for _, existing := range o.instances {
+		if existing.ProfileName == name && instanceIsActive(existing) {
+			// Allow upsert for bridge re-attach Other attach types still conflict.
+			if existing.Attached && inst.AttachType == "bridge" && existing.AttachType == "bridge" {
+				existing.URL = inst.URL
+				existing.Instance.URL = inst.URL
+				existing.authToken = authToken
+				existing.Status = "running"
+				existing.Error = ""
+				existing.StartTime = time.Now()
+				result := existing.Instance
+				o.mu.Unlock()
+
+				o.syncInstanceToManager(&result)
+				return &result, false, nil
+			}
 			o.mu.Unlock()
-			return nil, fmt.Errorf("instance with name %q already exists", name)
+			return nil, false, fmt.Errorf("instance with name %q already exists", name)
 		}
 	}
 	o.mu.Unlock()
@@ -446,14 +462,14 @@ func (o *Orchestrator) attachExternalInstance(name string, inst bridge.Instance,
 	o.mu.Unlock()
 
 	o.syncInstanceToManager(&internal.Instance)
-	return &internal.Instance, nil
+	return &internal.Instance, true, nil
 }
 
 // Attach connects to an externally managed Chrome instance via CDP URL.
 // Unlike Launch, this does not start a Chrome process - it only registers
 // the external instance for tracking and proxying.
 func (o *Orchestrator) Attach(name, cdpURL string) (*bridge.Instance, error) {
-	inst, err := o.attachExternalInstance(name, bridge.Instance{
+	inst, _, err := o.attachExternalInstance(name, bridge.Instance{
 		Attached:   true,
 		AttachType: "cdp",
 		CdpURL:     cdpURL,
@@ -471,13 +487,14 @@ func (o *Orchestrator) Attach(name, cdpURL string) (*bridge.Instance, error) {
 }
 
 // AttachBridge registers an already-running bridge server as an attached instance.
+// If a bridge with the same name is already attached, it is updated in place (upsert).
 func (o *Orchestrator) AttachBridge(name, baseURL, token string) (*bridge.Instance, error) {
 	normalizedBaseURL := strings.TrimRight(baseURL, "/")
 	if parsed, err := url.Parse(normalizedBaseURL); err == nil && parsed.Scheme != "" && parsed.Host != "" {
 		normalizedBaseURL = parsed.Scheme + "://" + parsed.Host
 	}
 
-	inst, err := o.attachExternalInstance(name, bridge.Instance{
+	inst, created, err := o.attachExternalInstance(name, bridge.Instance{
 		Attached:   true,
 		AttachType: "bridge",
 		URL:        normalizedBaseURL,
@@ -488,11 +505,13 @@ func (o *Orchestrator) AttachBridge(name, baseURL, token string) (*bridge.Instan
 
 	slog.Info("attached to external bridge", "id", inst.ID, "name", name, "url", internalurls.RedactForLog(inst.URL))
 	o.emitEvent("instance.attached", inst)
-	o.mu.RLock()
-	internal := o.instances[inst.ID]
-	o.mu.RUnlock()
-	if internal != nil {
-		go o.monitorAttachedBridge(internal)
+	if created {
+		o.mu.RLock()
+		internal := o.instances[inst.ID]
+		o.mu.RUnlock()
+		if internal != nil {
+			go o.monitorAttachedBridge(internal)
+		}
 	}
 	return inst, nil
 }

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -409,6 +409,43 @@ func TestOrchestrator_AttachBridge(t *testing.T) {
 	}
 }
 
+func TestOrchestrator_AttachBridge_UpsertsExistingBridge(t *testing.T) {
+	runner := &mockRunner{portAvail: true}
+	o := NewOrchestratorWithRunner(t.TempDir(), runner)
+
+	first, err := o.AttachBridge("bridge1", "http://10.0.0.8:9868", "bridge-token-1")
+	if err != nil {
+		t.Fatalf("first AttachBridge failed: %v", err)
+	}
+
+	second, err := o.AttachBridge("bridge1", "http://10.0.0.9:9868", "bridge-token-2")
+	if err != nil {
+		t.Fatalf("second AttachBridge failed: %v", err)
+	}
+
+	if second.ID != first.ID {
+		t.Fatalf("ID = %q, want %q", second.ID, first.ID)
+	}
+	if second.URL != "http://10.0.0.9:9868" {
+		t.Fatalf("URL = %q, want %q", second.URL, "http://10.0.0.9:9868")
+	}
+
+	o.mu.RLock()
+	internal := o.instances[first.ID]
+	o.mu.RUnlock()
+	if internal == nil {
+		t.Fatalf("attached instance %q missing from orchestrator", first.ID)
+	}
+	if internal.authToken != "bridge-token-2" {
+		t.Fatalf("authToken = %q, want %q", internal.authToken, "bridge-token-2")
+	}
+
+	list := o.List()
+	if len(list) != 1 {
+		t.Fatalf("expected 1 instance in list, got %d", len(list))
+	}
+}
+
 func TestOrchestrator_AttachBridge_RemovesUnhealthyBridge(t *testing.T) {
 	unhealthy := false
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Sometimes attach-bridge gets called again for the same bridge after reconnects or restarts. Having to clean up the old entry first is unnecessary friction, so this just updates the existing attached bridge in place instead.