### PR TITLE
fix: bump picomatch to 4.0.4 (CVE-2026-33672)

### DIFF
--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -1380,9 +1380,9 @@
       }
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
Resolves [dependabot alert #8](https://github.com/pinchtab/pinchtab/security/dependabot/8).

**picomatch** 4.0.3 → 4.0.4 — fixes method injection in POSIX character classes (GHSA-3v7f-55p6-f55p).

Transitive dev dependency in `npm/package-lock.json`.