### PR TITLE
ci: enforce SKILL.md version sync during release (#330)

### DIFF
--- a/.github/workflows/reusable-validate-release.yml
+++ b/.github/workflows/reusable-validate-release.yml
@@ -60,6 +60,12 @@ jobs:
             exit 1
           fi
 
+          if ! grep -q "$VERSION" skills/pinchtab/SKILL.md; then
+            echo "Error: skills/pinchtab/SKILL.md does not reference version $VERSION" >&2
+            echo "Please update the skill documentation before releasing." >&2
+            exit 1
+          fi
+
           if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
             echo "tag $TAG already exists on origin" >&2
             exit 1

--- a/skills/pinchtab/SKILL.md
+++ b/skills/pinchtab/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: pinchtab
+version: 0.8.4
 description: "Use this skill when a task needs browser automation through PinchTab: open a website, inspect interactive elements, click through flows, fill out forms, scrape page text, log into sites with a persistent profile, export screenshots or PDFs, manage multiple browser instances, or fall back to the HTTP API when the CLI is unavailable. Prefer this skill for token-efficient browser work driven by stable accessibility refs such as `e5` and `e12`."
 metadata:
   openclaw:


### PR DESCRIPTION
Rebased from #384 (TechWizard9999) — cherry-picked only the net-new commit onto current `main`.

Adds a gate to `reusable-validate-release.yml` that requires `skills/pinchtab/SKILL.md` to contain the release version string before tagging. Also adds `version: 0.8.4` to SKILL.md frontmatter.

Resolves #330. Supersedes #384.

Co-authored-by: Roopesh <roopesh1724989@gmail.com>