### PR TITLE
Add awaitPromise support to /evaluate endpoint

### DIFF
--- a/internal/handlers/evaluate.go
+++ b/internal/handlers/evaluate.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"net/http"
 
+	"github.com/chromedp/cdproto/runtime"
 	"github.com/chromedp/chromedp"
 	"github.com/pinchtab/pinchtab/internal/httpx"
 )
@@ -30,8 +31,9 @@ func (h *Handlers) HandleEvaluate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req struct {
-		TabID      string `json:"tabId"`
-		Expression string `json:"expression"`
+		TabID        string `json:"tabId"`
+		Expression   string `json:"expression"`
+		AwaitPromise bool   `json:"awaitPromise"`
 	}
 	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxBodySize)).Decode(&req); err != nil {
 		httpx.Error(w, 400, fmt.Errorf("decode: %w", err))
@@ -62,7 +64,13 @@ func (h *Handlers) HandleEvaluate(w http.ResponseWriter, r *http.Request) {
 	)
 
 	var result any
-	if err := chromedp.Run(tCtx, chromedp.Evaluate(req.Expression, &result)); err != nil {
+	opts := []chromedp.EvaluateOption{}
+	if req.AwaitPromise {
+		opts = append(opts, func(p *runtime.EvaluateParams) *runtime.EvaluateParams {
+			return p.WithAwaitPromise(true)
+		})
+	}
+	if err := chromedp.Run(tCtx, chromedp.Evaluate(req.Expression, &result, opts...)); err != nil {
 		httpx.Error(w, 500, fmt.Errorf("evaluate: %w", err))
 		return
 	}


### PR DESCRIPTION
Right now /evaluate returns {} for any expression that returns a Promise, since chromedp.Evaluate doesn't pass awaitPromise to CDP by default. This makes it impossible to use async/await or fetch() directly.

I ran into this building a proxy that does fetch() calls through the browser via /evaluate. Had to resort to writing results to window globals and polling, which sucks.

This just threads an optional awaitPromise bool through to Runtime.evaluate. False by default, nothing breaks.

```
POST /evaluate
{"expression": "(async () => await (await fetch('/x')).text())()", "awaitPromise": true}
```