### PR TITLE
chore(dashboard): unify dropdowns with shared Select atom

### DIFF
--- a/dashboard/src/activities/ActivityExplorer.tsx
+++ b/dashboard/src/activities/ActivityExplorer.tsx
@@ -1,4 +1,5 @@
 import { useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
+import { Select } from "../components/atoms";
 import { useAppStore } from "../stores/useAppStore";
 import * as api from "../services/api";
 import type { InstanceTab } from "../types";
@@ -283,13 +284,13 @@ export default function ActivityExplorer({
         <div className="flex items-center gap-2 border-b border-border-subtle px-4 py-1.5">
           <label className="flex items-center gap-1.5 text-xs text-text-muted">
             Agent
-            <select
+            <Select
               value={effectiveFilters.agentId}
               onChange={(e) => {
                 updateFilter("agentId", e.target.value);
                 if (!e.target.value) updateFilter("sessionId", "");
               }}
-              className="rounded border border-border-subtle bg-bg-surface px-2 py-1 text-xs text-text-primary"
+              variant="compact"
             >
               <option value="">All</option>
               {agentOptions.map((id) => (
@@ -297,15 +298,15 @@ export default function ActivityExplorer({
                   {id}
                 </option>
               ))}
-            </select>
+            </Select>
           </label>
           <label className="flex items-center gap-1.5 text-xs text-text-muted">
             Session
-            <select
+            <Select
               value={effectiveFilters.sessionId}
               onChange={(e) => updateFilter("sessionId", e.target.value)}
               disabled={!effectiveFilters.agentId}
-              className="rounded border border-border-subtle bg-bg-surface px-2 py-1 text-xs text-text-primary disabled:opacity-40"
+              variant="compact"
             >
               <option value="">All</option>
               {sessionOptions.map((s) => (
@@ -313,7 +314,7 @@ export default function ActivityExplorer({
                   {s.label || s.id}
                 </option>
               ))}
-            </select>
+            </Select>
           </label>
           <span className="ml-auto text-[0.68rem] text-text-muted">
             {summary}

--- a/dashboard/src/activities/ActivityFilterMenu.tsx
+++ b/dashboard/src/activities/ActivityFilterMenu.tsx
@@ -1,5 +1,5 @@
 import { useState, type ChangeEvent } from "react";
-import { Button, Input } from "../components/atoms";
+import { Button, Input, Select } from "../components/atoms";
 import type { Profile, Instance, InstanceTab } from "../types";
 import type { ActivityFilters } from "./types";
 import { actionOptions } from "./helpers";
@@ -31,21 +31,13 @@ function FilterSelect({
   onChange: (event: ChangeEvent<HTMLSelectElement>) => void;
 }) {
   return (
-    <label className="flex flex-col gap-1.5">
-      <span className="dashboard-section-title text-[0.68rem]">{label}</span>
-      <select
-        aria-label={label}
-        value={value}
-        onChange={onChange}
-        className="appearance-none rounded-sm border border-border-subtle bg-[rgb(var(--brand-surface-code-rgb)/0.72)] bg-[url('data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2020%2020%22%20fill%3D%22%236b7280%22%3E%3Cpath%20fill-rule%3D%22evenodd%22%20d%3D%22M5.23%207.21a.75.75%200%20011.06.02L10%2011.168l3.71-3.938a.75.75%200%20111.08%201.04l-4.25%204.5a.75.75%200%2001-1.08%200l-4.25-4.5a.75.75%200%2001.02-1.06z%22%20clip-rule%3D%22evenodd%22%2F%3E%3C%2Fsvg%3E')] bg-[length:1.25rem_1.25rem] bg-[position:right_0.5rem_center] bg-no-repeat pl-3 pr-8 py-2 text-sm text-text-primary transition-all duration-150 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
-      >
-        {options.map((option) => (
-          <option key={option.value || "all"} value={option.value}>
-            {option.label}
-          </option>
-        ))}
-      </select>
-    </label>
+    <Select aria-label={label} label={label} value={value} onChange={onChange}>
+      {options.map((option) => (
+        <option key={option.value || "all"} value={option.value}>
+          {option.label}
+        </option>
+      ))}
+    </Select>
   );
 }
 

--- a/dashboard/src/components/atoms/Select.tsx
+++ b/dashboard/src/components/atoms/Select.tsx
@@ -1,0 +1,55 @@
+import type { ReactNode, SelectHTMLAttributes } from "react";
+import { forwardRef, useId } from "react";
+
+interface Props extends SelectHTMLAttributes<HTMLSelectElement> {
+  children?: ReactNode;
+  label?: string;
+  hint?: string;
+  variant?: "default" | "compact";
+}
+
+const baseClassName =
+  "appearance-none rounded-sm border border-border-subtle bg-[rgb(var(--brand-surface-code-rgb)/0.72)] bg-[url('data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2020%2020%22%20fill%3D%22%236b7280%22%3E%3Cpath%20fill-rule%3D%22evenodd%22%20d%3D%22M5.23%207.21a.75.75%200%20011.06.02L10%2011.168l3.71-3.938a.75.75%200%20111.08%201.04l-4.25%204.5a.75.75%200%2001-1.08%200l-4.25-4.5a.75.75%200%2001.02-1.06z%22%20clip-rule%3D%22evenodd%22%2F%3E%3C%2Fsvg%3E')] bg-[length:1.25rem_1.25rem] bg-[position:right_0.5rem_center] bg-no-repeat text-text-primary transition-all duration-150 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20 disabled:cursor-not-allowed disabled:opacity-40";
+
+const variantClassName: Record<NonNullable<Props["variant"]>, string> = {
+  default: "w-full px-3 py-2 pr-8 text-sm",
+  compact: "px-2 py-1 pr-7 text-xs",
+};
+
+const Select = forwardRef<HTMLSelectElement, Props>(
+  ({ label, hint, variant = "default", className = "", ...props }, ref) => {
+    const generatedId = useId();
+    const selectId = props.id || generatedId;
+    const select = (
+      <select
+        id={selectId}
+        ref={ref}
+        className={`${baseClassName} ${variantClassName[variant]} ${className}`}
+        {...props}
+      />
+    );
+
+    if (!label && !hint) {
+      return select;
+    }
+
+    return (
+      <div className="flex flex-col gap-1.5">
+        {label && (
+          <label
+            htmlFor={selectId}
+            className="dashboard-section-title text-[0.68rem]"
+          >
+            {label}
+          </label>
+        )}
+        {select}
+        {hint && <span className="text-xs text-text-muted">{hint}</span>}
+      </div>
+    );
+  },
+);
+
+Select.displayName = "Select";
+
+export default Select;

--- a/dashboard/src/components/atoms/index.ts
+++ b/dashboard/src/components/atoms/index.ts
@@ -1,5 +1,6 @@
 export { default as Button } from "./Button";
 export { default as Input } from "./Input";
+export { default as Select } from "./Select";
 export { default as Card } from "./Card";
 export { default as Badge } from "./Badge";
 export { default as StatusDot } from "./StatusDot";

--- a/dashboard/src/pages/settings/DashboardSettingsSection.tsx
+++ b/dashboard/src/pages/settings/DashboardSettingsSection.tsx
@@ -1,6 +1,6 @@
 import type { Dispatch, SetStateAction } from "react";
+import { Select } from "../../components/atoms";
 import type { LocalDashboardSettings } from "../../types";
-import { selectClass } from "./settingsShared";
 import { SectionCard, SettingRow } from "./SettingsSharedComponents";
 
 interface DashboardSettingsSectionProps {
@@ -73,7 +73,7 @@ export function DashboardSettingsSection({
         label="Screencast width"
         description="Maximum preview width for live tiles."
       >
-        <select
+        <Select
           value={localSettings.screencast.maxWidth}
           onChange={(e) =>
             setLocalSettings((current) => ({
@@ -84,14 +84,13 @@ export function DashboardSettingsSection({
               },
             }))
           }
-          className={selectClass}
         >
           {[400, 600, 800, 1024, 1280].map((width) => (
             <option key={width} value={width}>
               {width}px
             </option>
           ))}
-        </select>
+        </Select>
       </SettingRow>
       <SettingRow
         label="Memory metrics"
@@ -146,7 +145,7 @@ export function DashboardSettingsSection({
         label="Reasoning output"
         description="Choose whether the live agent feed shows tool calls, progress updates, or both."
       >
-        <select
+        <Select
           value={localSettings.agents.reasoningMode}
           onChange={(e) =>
             setLocalSettings((current) => ({
@@ -160,12 +159,11 @@ export function DashboardSettingsSection({
               },
             }))
           }
-          className={selectClass}
         >
           <option value="tool_calls">Tool calls only</option>
           <option value="progress">Progress only</option>
           <option value="both">Both</option>
-        </select>
+        </Select>
       </SettingRow>
     </SectionCard>
   );

--- a/dashboard/src/pages/settings/DefaultsSettingsSection.tsx
+++ b/dashboard/src/pages/settings/DefaultsSettingsSection.tsx
@@ -1,10 +1,7 @@
+import { Select } from "../../components/atoms";
 import type { BackendConfig } from "../../types";
 import type { UpdateBackendSection } from "./settingsShared";
-import {
-  fieldClass,
-  instanceDefaultsBooleanRows,
-  selectClass,
-} from "./settingsShared";
+import { fieldClass, instanceDefaultsBooleanRows } from "./settingsShared";
 import { SectionCard, SettingRow } from "./SettingsSharedComponents";
 
 interface DefaultsSettingsSectionProps {
@@ -25,25 +22,24 @@ export function DefaultsSettingsSection({
         label="Mode"
         description="Default browser mode for new launches."
       >
-        <select
+        <Select
           value={backendConfig.instanceDefaults.mode}
           onChange={(e) =>
             updateBackendSection("instanceDefaults", {
               mode: e.target.value as BackendConfig["instanceDefaults"]["mode"],
             })
           }
-          className={selectClass}
         >
           <option value="headless">Headless</option>
           <option value="headed">Headed</option>
-        </select>
+        </Select>
       </SettingRow>
       <SettingRow
         label="Stealth level"
         description="Bot detection evasion profile. Higher levels may affect error monitoring and certain browser features."
       >
         <div className="space-y-2">
-          <select
+          <Select
             value={backendConfig.instanceDefaults.stealthLevel}
             onChange={(e) =>
               updateBackendSection("instanceDefaults", {
@@ -51,12 +47,11 @@ export function DefaultsSettingsSection({
                   .value as BackendConfig["instanceDefaults"]["stealthLevel"],
               })
             }
-            className={selectClass}
           >
             <option value="light">Light</option>
             <option value="medium">Medium</option>
             <option value="full">Full</option>
-          </select>
+          </Select>
           <div className="rounded-sm border border-border-subtle bg-black/10 px-3 py-2 text-xs leading-5 text-text-muted">
             {backendConfig.instanceDefaults.stealthLevel === "light" && (
               <div className="space-y-2">
@@ -131,7 +126,7 @@ export function DefaultsSettingsSection({
         label="Tab eviction policy"
         description="How PinchTab behaves when a managed instance reaches its tab limit."
       >
-        <select
+        <Select
           value={backendConfig.instanceDefaults.tabEvictionPolicy}
           onChange={(e) =>
             updateBackendSection("instanceDefaults", {
@@ -139,12 +134,11 @@ export function DefaultsSettingsSection({
                 .value as BackendConfig["instanceDefaults"]["tabEvictionPolicy"],
             })
           }
-          className={selectClass}
         >
           <option value="reject">Reject new tabs</option>
           <option value="close_oldest">Close oldest</option>
           <option value="close_lru">Close least recently used</option>
-        </select>
+        </Select>
       </SettingRow>
       <SettingRow
         label="Max tabs"

--- a/dashboard/src/pages/settings/NetworkSettingsSection.tsx
+++ b/dashboard/src/pages/settings/NetworkSettingsSection.tsx
@@ -1,3 +1,4 @@
+import { Select } from "../../components/atoms";
 import type { BackendConfig, BackendConfigState } from "../../types";
 import type { UpdateBackendSection } from "./settingsShared";
 import { csvToList, fieldClass, listToCsv } from "./settingsShared";
@@ -134,7 +135,7 @@ export function NetworkSettingsSection({
         description="Controls whether dashboard session cookies require HTTPS. Auto enables Secure only on HTTPS. Force Secure is appropriate when TLS is in front of PinchTab."
       >
         <div className="space-y-2">
-          <select
+          <Select
             value={
               backendConfig.server.cookieSecure === true
                 ? "true"
@@ -150,12 +151,11 @@ export function NetworkSettingsSection({
                     : e.target.value === "true",
               })
             }
-            className={fieldClass}
           >
             <option value="auto">Auto</option>
             <option value="true">Force Secure</option>
             <option value="false">Force Insecure</option>
-          </select>
+          </Select>
           <div className="rounded-sm border border-warning/25 bg-warning/10 px-3 py-2 text-xs leading-5 text-warning">
             Force Secure blocks dashboard login on plain HTTP. Use it when
             PinchTab is served through HTTPS directly or behind a trusted proxy.

--- a/dashboard/src/pages/settings/OrchestrationSettingsSection.tsx
+++ b/dashboard/src/pages/settings/OrchestrationSettingsSection.tsx
@@ -1,6 +1,7 @@
+import { Select } from "../../components/atoms";
 import type { BackendConfig } from "../../types";
 import type { UpdateBackendSection } from "./settingsShared";
-import { fieldClass, selectClass } from "./settingsShared";
+import { fieldClass } from "./settingsShared";
 import { SectionCard, SettingRow } from "./SettingsSharedComponents";
 
 interface OrchestrationSettingsSectionProps {
@@ -21,7 +22,7 @@ export function OrchestrationSettingsSection({
         label="Strategy"
         description="Controls instance lifecycle and how shorthand routes are routed."
       >
-        <select
+        <Select
           value={backendConfig.multiInstance.strategy}
           onChange={(e) =>
             updateBackendSection("multiInstance", {
@@ -29,14 +30,13 @@ export function OrchestrationSettingsSection({
                 .value as BackendConfig["multiInstance"]["strategy"],
             })
           }
-          className={selectClass}
         >
           <option value="always-on">Always on</option>
           <option value="simple">Simple</option>
           <option value="explicit">Explicit</option>
           <option value="simple-autorestart">Simple autorestart</option>
           <option value="no-instance">No instance (hub)</option>
-        </select>
+        </Select>
         <div className="mt-2 text-[11px] leading-relaxed text-text-muted">
           {backendConfig.multiInstance.strategy === "always-on" &&
             "Launches a default instance at boot and relaunches on crash."}
@@ -54,7 +54,7 @@ export function OrchestrationSettingsSection({
         label="Allocation policy"
         description="Determines how running instances are chosen for shorthand requests."
       >
-        <select
+        <Select
           value={backendConfig.multiInstance.allocationPolicy}
           onChange={(e) =>
             updateBackendSection("multiInstance", {
@@ -62,12 +62,11 @@ export function OrchestrationSettingsSection({
                 .value as BackendConfig["multiInstance"]["allocationPolicy"],
             })
           }
-          className={selectClass}
         >
           <option value="fcfs">First available</option>
           <option value="round_robin">Round robin</option>
           <option value="random">Random</option>
-        </select>
+        </Select>
       </SettingRow>
       <SettingRow
         label="Instance port start"

--- a/dashboard/src/pages/settings/settingsShared.ts
+++ b/dashboard/src/pages/settings/settingsShared.ts
@@ -77,9 +77,6 @@ export const sections: Array<{
 export const fieldClass =
   "w-full rounded-sm border border-border-subtle bg-[rgb(var(--brand-surface-code-rgb)/0.72)] px-3 py-2 text-sm text-text-primary placeholder:text-text-muted transition-all duration-150 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20";
 
-export const selectClass =
-  "rounded-sm border border-border-subtle bg-[rgb(var(--brand-surface-code-rgb)/0.72)] px-3 py-2 text-sm text-text-primary transition-all duration-150 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20";
-
 export type UpdateBackendSection = <K extends keyof BackendConfig>(
   section: K,
   patch: Partial<BackendConfig[K]>,


### PR DESCRIPTION
## Summary
- add a shared dashboard `Select` atom for consistent select styling and labeling
- migrate activity filters and settings dropdowns to the shared component
- remove duplicated select-specific styling from settings helpers

## Why
This keeps dropdown behavior and styling consistent across the dashboard and reduces repeated select markup in settings/activity views.

## Validation
- `go test ./...`
