### PR TITLE
chore(dashboard): standardize sidebar panel layout and chrome

### DIFF
--- a/dashboard/src/activities/ActivityExplorer.tsx
+++ b/dashboard/src/activities/ActivityExplorer.tsx
@@ -1,10 +1,14 @@
 import { useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
 import { Select } from "../components/atoms";
+import { SidebarPanel, SidebarPanelHeader } from "../components/molecules";
 import { useAppStore } from "../stores/useAppStore";
 import * as api from "../services/api";
 import type { InstanceTab } from "../types";
 import { fetchActivity } from "./api";
-import ActivityFilterMenu from "./ActivityFilterMenu";
+import {
+  ActivityFilterActions,
+  ActivityFilterFields,
+} from "./ActivityFilterMenu";
 import ActivityTimeline from "./ActivityTimeline";
 import {
   applyLockedFilters,
@@ -253,31 +257,42 @@ export default function ActivityExplorer({
 
   const layoutClass = embedded
     ? "flex h-full min-h-0 flex-col overflow-hidden"
-    : "flex h-full min-h-0 flex-col gap-4 overflow-hidden p-4 xl:flex-row";
+    : "flex h-full min-h-0 flex-col gap-4 overflow-hidden p-4 lg:flex-row";
 
   return (
     <div className={layoutClass}>
       {showFilterMenu && (
-        <aside className="dashboard-panel flex w-full shrink-0 flex-col overflow-hidden xl:w-80">
-          <div className="border-b border-border-subtle px-4 py-4">
-            <div className="dashboard-section-label mb-1">{summaryLabel}</div>
-            <h1 className="text-lg font-semibold text-text-primary">{title}</h1>
-            <p className="mt-2 text-xs leading-5 text-text-muted">{summary}</p>
-          </div>
-          <ActivityFilterMenu
+        <SidebarPanel
+          as="aside"
+          surface="panel"
+          width="wide"
+          headerPadding="lg"
+          header={
+            <SidebarPanelHeader
+              eyebrow={summaryLabel}
+              title={title}
+              description={summary}
+            />
+          }
+          footer={
+            <ActivityFilterActions
+              loading={loading}
+              onClear={clearFilters}
+              onRefresh={() => setFilters((current) => ({ ...current }))}
+            />
+          }
+        >
+          <ActivityFilterFields
             filters={effectiveFilters}
             profileOptions={profiles}
             instanceOptions={filteredInstances}
             tabOptions={visibleTabs}
             agentOptions={agentOptions}
-            loading={loading}
-            onClear={clearFilters}
-            onRefresh={() => setFilters((current) => ({ ...current }))}
             onFilterChange={updateFilter}
             onProfileChange={handleProfileChange}
             onInstanceChange={handleInstanceChange}
           />
-        </aside>
+        </SidebarPanel>
       )}
 
       {embedded && agentOptions.length > 0 && (

--- a/dashboard/src/activities/ActivityFilterMenu.tsx
+++ b/dashboard/src/activities/ActivityFilterMenu.tsx
@@ -1,5 +1,6 @@
 import { useState, type ChangeEvent } from "react";
 import { Button, Input, Select } from "../components/atoms";
+import { SidebarPanelFooterActions } from "../components/molecules";
 import type { Profile, Instance, InstanceTab } from "../types";
 import type { ActivityFilters } from "./types";
 import { actionOptions } from "./helpers";
@@ -41,157 +42,193 @@ function FilterSelect({
   );
 }
 
-export default function ActivityFilterMenu({
+interface ActivityFilterFieldsProps {
+  filters: ActivityFilters;
+  profileOptions: Profile[];
+  instanceOptions: Instance[];
+  tabOptions: InstanceTab[];
+  agentOptions?: string[];
+  showAgentFilter?: boolean;
+  onFilterChange: (key: keyof ActivityFilters, value: string) => void;
+  onProfileChange: (value: string) => void;
+  onInstanceChange: (value: string) => void;
+}
+
+export function ActivityFilterFields({
   filters,
   profileOptions,
   instanceOptions,
   tabOptions,
   agentOptions = [],
-  loading,
   showAgentFilter = true,
-  onClear,
-  onRefresh,
   onFilterChange,
   onProfileChange,
   onInstanceChange,
-}: Props) {
+}: ActivityFilterFieldsProps) {
   const [showAdvanced, setShowAdvanced] = useState(false);
 
   return (
-    <>
-      <div className="flex-1 space-y-4 overflow-auto p-4">
-        <div className="space-y-3">
-          <FilterSelect
-            label="Profile"
-            value={filters.profileName}
-            options={[
-              { value: "", label: "Any profile" },
-              ...profileOptions.map((profile) => ({
-                value: profile.name,
-                label: profile.name,
-              })),
-            ]}
-            onChange={(event) => onProfileChange(event.target.value)}
-          />
-          <FilterSelect
-            label="Tab"
-            value={filters.tabId}
-            options={[
-              { value: "", label: "Any tab" },
-              ...tabOptions.map((tab) => ({
-                value: tab.id,
-                label: `${tab.title || tab.url || tab.id} · ${tab.id}`,
-              })),
-            ]}
-            onChange={(event) => onFilterChange("tabId", event.target.value)}
-          />
-        </div>
-
-        <div className="space-y-3 border-t border-border-subtle pt-4">
-          {showAgentFilter && (
-            <FilterSelect
-              label="Agent"
-              value={filters.agentId}
-              options={[
-                { value: "", label: "Any agent" },
-                ...agentOptions.map((id) => ({ value: id, label: id })),
-              ]}
-              onChange={(event) =>
-                onFilterChange("agentId", event.target.value)
-              }
-            />
-          )}
-          <FilterSelect
-            label="Action"
-            value={filters.action}
-            options={[
-              { value: "", label: "Any action" },
-              ...actionOptions
-                .filter(Boolean)
-                .map((option) => ({ value: option, label: option })),
-            ]}
-            onChange={(event) => onFilterChange("action", event.target.value)}
-          />
-        </div>
-
-        <div className="border-t border-border-subtle pt-4">
-          <button
-            type="button"
-            className="flex w-full items-center justify-between text-left"
-            onClick={() => setShowAdvanced((current) => !current)}
-            aria-expanded={showAdvanced}
-            aria-controls="activity-advanced-filters"
-          >
-            <span className="dashboard-section-title text-[0.68rem]">
-              Advanced filters
-            </span>
-            <span className="text-[0.68rem] uppercase tracking-[0.16em] text-text-muted">
-              {showAdvanced ? "Hide" : "Show"}
-            </span>
-          </button>
-
-          {showAdvanced && (
-            <div id="activity-advanced-filters" className="mt-3 space-y-3">
-              <FilterSelect
-                label="Instance"
-                value={filters.instanceId}
-                options={[
-                  { value: "", label: "Any instance" },
-                  ...instanceOptions.map((instance) => ({
-                    value: instance.id,
-                    label: `${instance.profileName} · ${instance.id}`,
-                  })),
-                ]}
-                onChange={(event) => onInstanceChange(event.target.value)}
-              />
-              <Input
-                label="Path prefix"
-                placeholder="/tabs/ or /instances/"
-                value={filters.pathPrefix}
-                onChange={(event) =>
-                  onFilterChange("pathPrefix", event.target.value)
-                }
-              />
-              <Input
-                label="Age (seconds)"
-                placeholder="3600"
-                value={filters.ageSec}
-                onChange={(event) =>
-                  onFilterChange("ageSec", event.target.value)
-                }
-              />
-              <Input
-                label="Limit"
-                placeholder="200"
-                value={filters.limit}
-                onChange={(event) =>
-                  onFilterChange("limit", event.target.value)
-                }
-              />
-            </div>
-          )}
-        </div>
+    <div className="space-y-4 p-4">
+      <div className="space-y-3">
+        <FilterSelect
+          label="Profile"
+          value={filters.profileName}
+          options={[
+            { value: "", label: "Any profile" },
+            ...profileOptions.map((profile) => ({
+              value: profile.name,
+              label: profile.name,
+            })),
+          ]}
+          onChange={(event) => onProfileChange(event.target.value)}
+        />
+        <FilterSelect
+          label="Tab"
+          value={filters.tabId}
+          options={[
+            { value: "", label: "Any tab" },
+            ...tabOptions.map((tab) => ({
+              value: tab.id,
+              label: `${tab.title || tab.url || tab.id} · ${tab.id}`,
+            })),
+          ]}
+          onChange={(event) => onFilterChange("tabId", event.target.value)}
+        />
       </div>
 
-      <div className="flex gap-2 border-t border-border-subtle p-4">
-        <Button
-          variant="secondary"
-          size="sm"
-          onClick={onClear}
-          disabled={loading}
-          className="flex-1"
+      <div className="space-y-3 border-t border-border-subtle pt-4">
+        {showAgentFilter && (
+          <FilterSelect
+            label="Agent"
+            value={filters.agentId}
+            options={[
+              { value: "", label: "Any agent" },
+              ...agentOptions.map((id) => ({ value: id, label: id })),
+            ]}
+            onChange={(event) => onFilterChange("agentId", event.target.value)}
+          />
+        )}
+        <FilterSelect
+          label="Action"
+          value={filters.action}
+          options={[
+            { value: "", label: "Any action" },
+            ...actionOptions
+              .filter(Boolean)
+              .map((option) => ({ value: option, label: option })),
+          ]}
+          onChange={(event) => onFilterChange("action", event.target.value)}
+        />
+      </div>
+
+      <div className="border-t border-border-subtle pt-4">
+        <button
+          type="button"
+          className="flex w-full items-center justify-between text-left"
+          onClick={() => setShowAdvanced((current) => !current)}
+          aria-expanded={showAdvanced}
+          aria-controls="activity-advanced-filters"
         >
-          Clear
-        </Button>
-        <Button
-          variant="primary"
-          size="sm"
-          onClick={onRefresh}
-          loading={loading}
-          className="flex-1"
-        >
-          Search
-        </Button>
+          <span className="dashboard-section-title text-[0.68rem]">
+            Advanced filters
+          </span>
+          <span className="text-[0.68rem] uppercase tracking-[0.16em] text-text-muted">
+            {showAdvanced ? "Hide" : "Show"}
+          </span>
+        </button>
+
+        {showAdvanced && (
+          <div id="activity-advanced-filters" className="mt-3 space-y-3">
+            <FilterSelect
+              label="Instance"
+              value={filters.instanceId}
+              options={[
+                { value: "", label: "Any instance" },
+                ...instanceOptions.map((instance) => ({
+                  value: instance.id,
+                  label: `${instance.profileName} · ${instance.id}`,
+                })),
+              ]}
+              onChange={(event) => onInstanceChange(event.target.value)}
+            />
+            <Input
+              label="Path prefix"
+              placeholder="/tabs/ or /instances/"
+              value={filters.pathPrefix}
+              onChange={(event) =>
+                onFilterChange("pathPrefix", event.target.value)
+              }
+            />
+            <Input
+              label="Age (seconds)"
+              placeholder="3600"
+              value={filters.ageSec}
+              onChange={(event) => onFilterChange("ageSec", event.target.value)}
+            />
+            <Input
+              label="Limit"
+              placeholder="200"
+              value={filters.limit}
+              onChange={(event) => onFilterChange("limit", event.target.value)}
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function ActivityFilterActions({
+  loading,
+  onClear,
+  onRefresh,
+}: Pick<Props, "loading" | "onClear" | "onRefresh">) {
+  return (
+    <SidebarPanelFooterActions>
+      <Button
+        variant="secondary"
+        size="sm"
+        onClick={onClear}
+        disabled={loading}
+        className="flex-1"
+      >
+        Clear
+      </Button>
+      <Button
+        variant="primary"
+        size="sm"
+        onClick={onRefresh}
+        loading={loading}
+        className="flex-1"
+      >
+        Search
+      </Button>
+    </SidebarPanelFooterActions>
+  );
+}
+
+export default function ActivityFilterMenu(props: Props) {
+  return (
+    <>
+      <div className="min-h-0 flex-1 overflow-auto">
+        <ActivityFilterFields
+          filters={props.filters}
+          profileOptions={props.profileOptions}
+          instanceOptions={props.instanceOptions}
+          tabOptions={props.tabOptions}
+          agentOptions={props.agentOptions}
+          showAgentFilter={props.showAgentFilter}
+          onFilterChange={props.onFilterChange}
+          onProfileChange={props.onProfileChange}
+          onInstanceChange={props.onInstanceChange}
+        />
+      </div>
+      <div className="border-t border-border-subtle">
+        <ActivityFilterActions
+          loading={props.loading}
+          onClear={props.onClear}
+          onRefresh={props.onRefresh}
+        />
       </div>
     </>
   );

--- a/dashboard/src/activities/AgentActivityWorkspace.tsx
+++ b/dashboard/src/activities/AgentActivityWorkspace.tsx
@@ -748,7 +748,7 @@ export default function AgentActivityWorkspace({
       : activityLoading || agentLoading;
 
   return (
-    <div className="flex h-full min-h-0 flex-col overflow-hidden xl:flex-row">
+    <div className="flex h-full min-h-0 flex-col overflow-hidden lg:flex-row">
       <AgentWorkspaceSidebar
         sidebarTab={sidebarTab}
         visibleAgents={visibleAgents}

--- a/dashboard/src/activities/AgentWorkspaceSidebar.tsx
+++ b/dashboard/src/activities/AgentWorkspaceSidebar.tsx
@@ -1,8 +1,11 @@
 import { useMemo } from "react";
-import { AgentItem } from "../components/molecules";
+import { AgentItem, SidebarPanel } from "../components/molecules";
 import type { Agent, Instance, InstanceTab, Profile } from "../types";
 import type { Session } from "../services/api";
-import ActivityFilterMenu from "./ActivityFilterMenu";
+import {
+  ActivityFilterActions,
+  ActivityFilterFields,
+} from "./ActivityFilterMenu";
 import type { ActivityFilters } from "./types";
 
 type WorkspaceTab = "agents" | "activities";
@@ -72,79 +75,90 @@ export default function AgentWorkspaceSidebar({
   }, [sessions]);
 
   return (
-    <aside className="flex w-full shrink-0 flex-col overflow-hidden border-b border-border-subtle bg-bg-surface xl:w-80 xl:border-b-0 xl:border-r">
-      <div className="flex border-b border-border-subtle">
-        {[
-          { id: "agents" as const, label: "Agents" },
-          { id: "activities" as const, label: "Activities" },
-        ].map((tab) => (
-          <button
-            key={tab.id}
-            type="button"
-            className={`flex-1 border-b px-4 py-3 text-sm font-semibold transition-colors ${
-              sidebarTab === tab.id
-                ? "border-primary bg-primary/8 text-text-primary"
-                : "border-transparent text-text-muted hover:bg-bg-elevated hover:text-text-primary"
-            }`}
-            onClick={() => onSidebarTabChange(tab.id)}
-          >
-            {tab.label}
-          </button>
-        ))}
-      </div>
-
-      {sidebarTab === "agents" ? (
-        <div className="min-h-0 flex-1 overflow-auto">
-          {visibleAgents.length === 0 ? (
-            <div className="py-8 text-center text-sm text-text-muted">
-              <div className="mb-2 text-2xl">🦀</div>
-              No agent activity observed yet
-            </div>
-          ) : (
-            <div className="flex flex-col">
-              {showAllAgentsOption && (
-                <button
-                  type="button"
-                  className={`px-3 py-2.5 text-left text-sm transition-colors ${
-                    activeAgentId === ""
-                      ? "bg-primary/8 text-primary"
-                      : "text-text-muted hover:bg-bg-elevated"
-                  }`}
-                  onClick={() => onSelectAgent("")}
-                >
-                  All Agents
-                </button>
-              )}
-              {visibleAgents.map((agent) => (
-                <AgentItem
-                  key={agent.id}
-                  agent={agent}
-                  selected={activeAgentId === agent.id}
-                  sessions={sessionsByAgent.get(agent.id) || []}
-                  activeSessionId={filters.sessionId}
-                  onClick={() => onSelectAgent(agent.id)}
-                  onSelectSession={onSelectSession}
-                />
-              ))}
-            </div>
-          )}
+    <SidebarPanel
+      as="aside"
+      chrome="sidebar"
+      surface="surface"
+      width="wide"
+      header={
+        <div className="flex">
+          {[
+            { id: "agents" as const, label: "Agents" },
+            { id: "activities" as const, label: "Activities" },
+          ].map((tab) => (
+            <button
+              key={tab.id}
+              type="button"
+              className={`flex-1 border-b px-4 py-3 text-sm font-semibold transition-colors ${
+                sidebarTab === tab.id
+                  ? "border-primary bg-primary/8 text-text-primary"
+                  : "border-transparent text-text-muted hover:bg-bg-elevated hover:text-text-primary"
+              }`}
+              onClick={() => onSidebarTabChange(tab.id)}
+            >
+              {tab.label}
+            </button>
+          ))}
         </div>
+      }
+      footer={
+        sidebarTab === "activities" ? (
+          <ActivityFilterActions
+            loading={loading}
+            onClear={onClearFilters}
+            onRefresh={onRefresh}
+          />
+        ) : undefined
+      }
+      headerPadding="none"
+    >
+      {sidebarTab === "agents" ? (
+        visibleAgents.length === 0 ? (
+          <div className="py-8 text-center text-sm text-text-muted">
+            <div className="mb-2 text-2xl">🦀</div>
+            No agent activity observed yet
+          </div>
+        ) : (
+          <div className="flex flex-col">
+            {showAllAgentsOption && (
+              <button
+                type="button"
+                className={`px-3 py-2.5 text-left text-sm transition-colors ${
+                  activeAgentId === ""
+                    ? "bg-primary/8 text-primary"
+                    : "text-text-muted hover:bg-bg-elevated"
+                }`}
+                onClick={() => onSelectAgent("")}
+              >
+                All Agents
+              </button>
+            )}
+            {visibleAgents.map((agent) => (
+              <AgentItem
+                key={agent.id}
+                agent={agent}
+                selected={activeAgentId === agent.id}
+                sessions={sessionsByAgent.get(agent.id) || []}
+                activeSessionId={filters.sessionId}
+                onClick={() => onSelectAgent(agent.id)}
+                onSelectSession={onSelectSession}
+              />
+            ))}
+          </div>
+        )
       ) : (
-        <ActivityFilterMenu
+        <ActivityFilterFields
           filters={filters}
           profileOptions={profiles}
           instanceOptions={filteredInstances}
           tabOptions={visibleTabs}
           agentOptions={agentOptions}
-          loading={loading}
           showAgentFilter={showAgentFilter}
-          onClear={onClearFilters}
-          onRefresh={onRefresh}
           onFilterChange={onFilterChange}
           onProfileChange={onProfileChange}
           onInstanceChange={onInstanceChange}
         />
       )}
-    </aside>
+    </SidebarPanel>
   );
 }

--- a/dashboard/src/components/molecules/SidebarPanel.tsx
+++ b/dashboard/src/components/molecules/SidebarPanel.tsx
@@ -1,0 +1,134 @@
+import React from "react";
+
+type SidebarSurface = "none" | "surface" | "panel";
+type SidebarWidth = "auto" | "narrow" | "wide";
+type SidebarChrome = "none" | "sidebar";
+type SidebarPadding = "none" | "sm" | "md" | "lg";
+
+interface SidebarPanelProps {
+  header?: React.ReactNode;
+  footer?: React.ReactNode;
+  children: React.ReactNode;
+  className?: string;
+  headerClassName?: string;
+  contentClassName?: string;
+  footerClassName?: string;
+  as?: "aside" | "div" | "section";
+  scrollContent?: boolean;
+  surface?: SidebarSurface;
+  width?: SidebarWidth;
+  chrome?: SidebarChrome;
+  headerPadding?: SidebarPadding;
+  contentPadding?: SidebarPadding;
+  footerPadding?: SidebarPadding;
+}
+
+function joinClasses(...classes: Array<string | undefined | false>) {
+  return classes.filter(Boolean).join(" ");
+}
+
+function paddingClass(size: SidebarPadding): string {
+  switch (size) {
+    case "sm":
+      return "p-3";
+    case "md":
+      return "px-4 py-3";
+    case "lg":
+      return "px-4 py-4";
+    default:
+      return "";
+  }
+}
+
+function surfaceClass(surface: SidebarSurface): string {
+  switch (surface) {
+    case "surface":
+      return "bg-bg-surface";
+    case "panel":
+      return "dashboard-panel";
+    default:
+      return "";
+  }
+}
+
+function widthClass(width: SidebarWidth): string {
+  switch (width) {
+    case "narrow":
+      return "w-full shrink-0 lg:w-72";
+    case "wide":
+      return "w-full shrink-0 lg:w-80";
+    default:
+      return "";
+  }
+}
+
+function chromeClass(chrome: SidebarChrome): string {
+  switch (chrome) {
+    case "sidebar":
+      return "border-b border-border-subtle lg:border-b-0 lg:border-r";
+    default:
+      return "";
+  }
+}
+
+export default function SidebarPanel({
+  header,
+  footer,
+  children,
+  className = "",
+  headerClassName = "",
+  contentClassName = "",
+  footerClassName = "",
+  as: Tag = "div",
+  scrollContent = true,
+  surface = "none",
+  width = "auto",
+  chrome = "none",
+  headerPadding = "none",
+  contentPadding = "none",
+  footerPadding = "none",
+}: SidebarPanelProps) {
+  return (
+    <Tag
+      className={joinClasses(
+        "flex min-h-0 flex-col overflow-hidden",
+        surfaceClass(surface),
+        widthClass(width),
+        chromeClass(chrome),
+        className,
+      )}
+    >
+      {header && (
+        <div
+          className={joinClasses(
+            "shrink-0 border-b border-border-subtle",
+            paddingClass(headerPadding),
+            headerClassName,
+          )}
+        >
+          {header}
+        </div>
+      )}
+      <div
+        className={joinClasses(
+          scrollContent ? "min-h-0 flex-1 overflow-auto" : "min-h-0 flex-1",
+          paddingClass(contentPadding),
+          contentClassName,
+        )}
+      >
+        {children}
+      </div>
+      {footer && (
+        <div
+          className={joinClasses(
+            "shrink-0 border-t border-border-subtle",
+            paddingClass(footerPadding),
+            footerClassName,
+          )}
+        >
+          {footer}
+        </div>
+      )}
+    </Tag>
+  );
+}

--- a/dashboard/src/components/molecules/SidebarPanelFooterActions.tsx
+++ b/dashboard/src/components/molecules/SidebarPanelFooterActions.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+
+interface SidebarPanelFooterActionsProps {
+  children: React.ReactNode;
+  className?: string;
+  align?: "start" | "end" | "between";
+}
+
+function joinClasses(...classes: Array<string | undefined | false>) {
+  return classes.filter(Boolean).join(" ");
+}
+
+function alignClass(align: SidebarPanelFooterActionsProps["align"]): string {
+  switch (align) {
+    case "end":
+      return "justify-end";
+    case "between":
+      return "justify-between";
+    default:
+      return "";
+  }
+}
+
+export default function SidebarPanelFooterActions({
+  children,
+  className = "",
+  align = "start",
+}: SidebarPanelFooterActionsProps) {
+  return (
+    <div
+      className={joinClasses("flex gap-2 p-4", alignClass(align), className)}
+    >
+      {children}
+    </div>
+  );
+}

--- a/dashboard/src/components/molecules/SidebarPanelHeader.tsx
+++ b/dashboard/src/components/molecules/SidebarPanelHeader.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+
+interface SidebarPanelHeaderProps {
+  eyebrow?: React.ReactNode;
+  title?: React.ReactNode;
+  description?: React.ReactNode;
+  actions?: React.ReactNode;
+  className?: string;
+  eyebrowClassName?: string;
+  titleClassName?: string;
+  descriptionClassName?: string;
+}
+
+function joinClasses(...classes: Array<string | undefined | false>) {
+  return classes.filter(Boolean).join(" ");
+}
+
+export default function SidebarPanelHeader({
+  eyebrow,
+  title,
+  description,
+  actions,
+  className = "",
+  eyebrowClassName = "",
+  titleClassName = "",
+  descriptionClassName = "",
+}: SidebarPanelHeaderProps) {
+  return (
+    <div className={joinClasses("flex items-start gap-3", className)}>
+      <div className="min-w-0 flex-1">
+        {eyebrow && (
+          <div
+            className={joinClasses(
+              "dashboard-section-label mb-1",
+              eyebrowClassName,
+            )}
+          >
+            {eyebrow}
+          </div>
+        )}
+        {title && (
+          <div
+            className={joinClasses(
+              "text-lg font-semibold text-text-primary",
+              titleClassName,
+            )}
+          >
+            {title}
+          </div>
+        )}
+        {description && (
+          <div
+            className={joinClasses(
+              "mt-2 text-xs leading-5 text-text-muted",
+              descriptionClassName,
+            )}
+          >
+            {description}
+          </div>
+        )}
+      </div>
+      {actions && <div className="shrink-0">{actions}</div>}
+    </div>
+  );
+}

--- a/dashboard/src/components/molecules/TabsLayout.tsx
+++ b/dashboard/src/components/molecules/TabsLayout.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import SidebarPanel from "./SidebarPanel";
 
 export interface TabItem<T extends string> {
   id: T;
@@ -13,6 +14,7 @@ interface Props<T extends string> {
   children: React.ReactNode;
   className?: string;
   rightSlot?: React.ReactNode;
+  footer?: React.ReactNode;
 }
 
 export default function TabsLayout<T extends string>({
@@ -22,10 +24,14 @@ export default function TabsLayout<T extends string>({
   children,
   className = "",
   rightSlot,
+  footer,
 }: Props<T>) {
   return (
-    <div className={`flex h-full flex-col overflow-hidden ${className}`}>
-      <div className="border-b border-border-subtle px-4 py-3">
+    <SidebarPanel
+      className={`h-full ${className}`}
+      footer={footer}
+      headerPadding="md"
+      header={
         <div className="flex items-center gap-1">
           {tabs.map((tab) => (
             <button
@@ -50,8 +56,9 @@ export default function TabsLayout<T extends string>({
             <div className="ml-auto min-w-0 shrink">{rightSlot}</div>
           )}
         </div>
-      </div>
-      <div className="min-h-0 flex-1 overflow-auto">{children}</div>
-    </div>
+      }
+    >
+      {children}
+    </SidebarPanel>
   );
 }

--- a/dashboard/src/components/molecules/index.ts
+++ b/dashboard/src/components/molecules/index.ts
@@ -1,4 +1,7 @@
 export { default as TabsLayout } from "./TabsLayout";
+export { default as SidebarPanel } from "./SidebarPanel";
+export { default as SidebarPanelHeader } from "./SidebarPanelHeader";
+export { default as SidebarPanelFooterActions } from "./SidebarPanelFooterActions";
 export { default as EmptyView } from "./EmptyView";
 export { default as NavBar } from "./NavBar";
 export { default as CreateProfileModal } from "./CreateProfileModal";

--- a/dashboard/src/pages/SettingsPage.tsx
+++ b/dashboard/src/pages/SettingsPage.tsx
@@ -1,6 +1,7 @@
 import type { Dispatch, FormEvent, SetStateAction } from "react";
 import { useEffect, useMemo, useState } from "react";
 import { Button, Card, Input, Modal } from "../components/atoms";
+import { SidebarPanel, SidebarPanelHeader } from "../components/molecules";
 import * as api from "../services/api";
 import { useAppStore } from "../stores/useAppStore";
 import type {
@@ -387,33 +388,41 @@ export default function SettingsPage() {
       </Modal>
 
       <div className="flex flex-1 flex-col overflow-hidden lg:flex-row">
-        <aside className="flex w-full shrink-0 flex-col overflow-y-auto border-b border-border-subtle lg:w-72 lg:border-b-0 lg:border-r">
-          <Card className="p-3">
-            <div className="dashboard-section-label">Settings</div>
-            <div className="mb-3 dashboard-mono text-xs text-text-muted">
-              Version: {serverInfo?.version || "dev"}
-            </div>
-            <div className="flex flex-col gap-1.5">
-              {sections.map((section) => (
-                <button
-                  key={section.id}
-                  type="button"
-                  className={`rounded-sm border px-3 py-2.5 text-left transition-all ${
-                    activeSection === section.id
-                      ? "border-primary/30 bg-primary/10 text-text-primary"
-                      : "border-transparent text-text-secondary hover:border-border-subtle hover:bg-bg-elevated hover:text-text-primary"
-                  }`}
-                  onClick={() => setActiveSection(section.id)}
-                >
-                  <div className="text-sm font-medium">{section.label}</div>
-                  <div className="mt-1 text-xs leading-5 text-text-muted">
-                    {section.description}
-                  </div>
-                </button>
-              ))}
-            </div>
-          </Card>
-        </aside>
+        <SidebarPanel
+          as="aside"
+          chrome="sidebar"
+          contentPadding="sm"
+          headerPadding="sm"
+          surface="panel"
+          width="narrow"
+          header={
+            <SidebarPanelHeader
+              eyebrow="Settings"
+              description={`Version: ${serverInfo?.version || "dev"}`}
+              descriptionClassName="dashboard-mono"
+            />
+          }
+        >
+          <div className="flex flex-col gap-1.5">
+            {sections.map((section) => (
+              <button
+                key={section.id}
+                type="button"
+                className={`rounded-sm border px-3 py-2.5 text-left transition-all ${
+                  activeSection === section.id
+                    ? "border-primary/30 bg-primary/10 text-text-primary"
+                    : "border-transparent text-text-secondary hover:border-border-subtle hover:bg-bg-elevated hover:text-text-primary"
+                }`}
+                onClick={() => setActiveSection(section.id)}
+              >
+                <div className="text-sm font-medium">{section.label}</div>
+                <div className="mt-1 text-xs leading-5 text-text-muted">
+                  {section.description}
+                </div>
+              </button>
+            ))}
+          </div>
+        </SidebarPanel>
 
         <div className="flex-1 overflow-y-auto pr-1">
           <div className="sticky top-0 z-10 flex flex-wrap items-center gap-2 border-b border-border-subtle bg-bg-surface/95 p-3 backdrop-blur">

--- a/dashboard/src/tabs/InstanceTabsPanel.tsx
+++ b/dashboard/src/tabs/InstanceTabsPanel.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { InstanceTab } from "../generated/types";
 import { useAppStore } from "../stores/useAppStore";
-import { TabsChart } from "../components/molecules";
+import { SidebarPanel, TabsChart } from "../components/molecules";
 import InstanceStats from "../components/molecules/InstanceStats";
 import { ErrorBoundary } from "../components/atoms";
 import TabBar from "./TabBar";
@@ -119,44 +119,49 @@ export default function InstanceTabsPanel({
   }, [currentTabIds, showTelemetry]);
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col">
-      <TabBar
-        tabs={tabs}
-        selectedTabId={selectedTabId}
-        pinnedTabId={selectionPinned ? selectedTabId : null}
-        telemetryActive={showTelemetry}
-        newTabsCount={newTabsCount}
-        onSelect={(id) => {
-          setAcknowledgedTabIds(currentTabIds);
-          setSelectedTabId(id);
-          setSelectionPinned(true);
-          if (showTelemetry) {
-            setShowTelemetry(false);
-          }
-        }}
-        onTogglePinned={(id) => {
-          if (selectionPinned && selectedTabId === id) {
-            setSelectionPinned(false);
-            setSelectedTabId(tabs[0]?.id ?? null);
-            return;
-          }
-          setAcknowledgedTabIds(currentTabIds);
-          setSelectedTabId(id);
-          setSelectionPinned(true);
-          if (showTelemetry) {
-            setShowTelemetry(false);
-          }
-        }}
-        onSetTelemetry={(active) => {
-          if (!active) {
+    <SidebarPanel
+      className="flex-1"
+      scrollContent={false}
+      contentClassName="flex min-h-0 flex-1 flex-col overflow-hidden"
+      header={
+        <TabBar
+          tabs={tabs}
+          selectedTabId={selectedTabId}
+          pinnedTabId={selectionPinned ? selectedTabId : null}
+          telemetryActive={showTelemetry}
+          newTabsCount={newTabsCount}
+          onSelect={(id) => {
             setAcknowledgedTabIds(currentTabIds);
-          }
-          if (active !== showTelemetry) {
-            setShowTelemetry(active);
-          }
-        }}
-      />
-
+            setSelectedTabId(id);
+            setSelectionPinned(true);
+            if (showTelemetry) {
+              setShowTelemetry(false);
+            }
+          }}
+          onTogglePinned={(id) => {
+            if (selectionPinned && selectedTabId === id) {
+              setSelectionPinned(false);
+              setSelectedTabId(tabs[0]?.id ?? null);
+              return;
+            }
+            setAcknowledgedTabIds(currentTabIds);
+            setSelectedTabId(id);
+            setSelectionPinned(true);
+            if (showTelemetry) {
+              setShowTelemetry(false);
+            }
+          }}
+          onSetTelemetry={(active) => {
+            if (!active) {
+              setAcknowledgedTabIds(currentTabIds);
+            }
+            if (active !== showTelemetry) {
+              setShowTelemetry(active);
+            }
+          }}
+        />
+      }
+    >
       {tabs.length === 0 && !showTelemetry ? (
         <div className="flex flex-1 items-center justify-center py-8 text-sm text-text-muted">
           {emptyMessage}
@@ -188,6 +193,6 @@ export default function InstanceTabsPanel({
       ) : (
         <SelectedTabPanel selectedTab={selectedTab} instanceId={instanceId} />
       )}
-    </div>
+    </SidebarPanel>
   );
 }


### PR DESCRIPTION
## Summary
- add shared sidebar layout primitives for consistent header/content/footer structure
- refactor activity, agent workspace, settings, and instance tabs side panels to use the shared sidebar chrome
- simplify duplicated sidebar action/footer patterns in activity filters and related dashboard views

## Why
The dashboard had multiple sidebar-like layouts with slightly different chrome, spacing, and footer behavior. This refactor standardizes that structure so future dashboard work can reuse the same panel model instead of re-implementing sidebar layout each time.

## Validation
- `go test ./...`
