### PR TITLE
fix(runtime): retry direct-launch fallback on headless Chrome startup cancellation

### DIFF
--- a/.github/workflows/reusable-docker-smoke.yml
+++ b/.github/workflows/reusable-docker-smoke.yml
@@ -29,5 +29,10 @@ jobs:
       - name: Verify bootstrap path in container
         run: bash scripts/docker-smoke.sh pinchtab-release-smoke:${{ github.run_id }}
 
+      - name: Verify headless Ubuntu Chrome for Testing startup
+        run: bash scripts/docker-chrome-cft-smoke.sh pinchtab-chrome-cft-smoke:${{ github.run_id }}
+        env:
+          DOCKER_BUILDKIT: 1
+
       - name: Verify MCP stdio in container
         run: bash scripts/docker-mcp-smoke.sh pinchtab-release-smoke:${{ github.run_id }}

--- a/dashboard/tsconfig.json
+++ b/dashboard/tsconfig.json
@@ -2,6 +2,7 @@
   "files": [],
   "references": [
     { "path": "./tsconfig.app.json" },
-    { "path": "./tsconfig.node.json" }
+    { "path": "./tsconfig.node.json" },
+    { "path": "./tsconfig.test.json" }
   ]
 }

--- a/dashboard/tsconfig.test.json
+++ b/dashboard/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.app.json",
+  "compilerOptions": {
+    "types": ["vite/client", "@testing-library/jest-dom"]
+  },
+  "include": ["src"]
+}

--- a/internal/bridge/runtime/init.go
+++ b/internal/bridge/runtime/init.go
@@ -230,8 +230,8 @@ func startChromeWithRecovery(parentCtx context.Context, cfg *config.RuntimeConfi
 			}
 		}
 
-		if isStartupTimeout(err) && debugPort > 0 {
-			slog.Warn("chrome startup timeout (Chrome 145+ regression), trying direct-launch fallback", "port", debugPort)
+		if shouldRetryChromeStartupWithDirectLaunch(parentCtx, err) && debugPort > 0 {
+			slog.Warn("chrome startup failed via allocator, trying direct-launch fallback", "port", debugPort, "error", errMsg)
 			time.Sleep(500 * time.Millisecond)
 			return startChromeWithRemoteAllocator(parentCtx, cfg, bundle, debugPort, bundle.Script)
 		}
@@ -262,6 +262,19 @@ func isStartupTimeout(err error) bool {
 	}
 	msg := err.Error()
 	return strings.Contains(msg, "deadline exceeded") || strings.Contains(msg, "context deadline exceeded")
+}
+
+func shouldRetryChromeStartupWithDirectLaunch(parentCtx context.Context, err error) bool {
+	if isStartupTimeout(err) {
+		return true
+	}
+	if parentCtx != nil && parentCtx.Err() != nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) {
+		return true
+	}
+	return strings.Contains(err.Error(), "context canceled")
 }
 
 func startChromeWithRemoteAllocator(parentCtx context.Context, cfg *config.RuntimeConfig, bundle *stealth.Bundle, debugPort int, injectedStealthScript string) (context.Context, context.CancelFunc, stealth.LaunchMode, error) {

--- a/internal/bridge/runtime/init_test.go
+++ b/internal/bridge/runtime/init_test.go
@@ -1,6 +1,9 @@
 package runtime
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"os"
 	"testing"
 )
@@ -35,5 +38,62 @@ func TestChromeNeedsNoSandbox(t *testing.T) {
 	}
 	if !chromeNeedsNoSandbox() {
 		t.Fatal("expected container marker to enable no-sandbox compatibility")
+	}
+}
+
+func TestShouldRetryChromeStartupWithDirectLaunch(t *testing.T) {
+	canceledParent, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	tests := []struct {
+		name      string
+		parentCtx context.Context
+		err       error
+		want      bool
+	}{
+		{
+			name:      "startup timeout retries",
+			parentCtx: context.Background(),
+			err:       context.DeadlineExceeded,
+			want:      true,
+		},
+		{
+			name:      "allocator context canceled retries",
+			parentCtx: context.Background(),
+			err:       context.Canceled,
+			want:      true,
+		},
+		{
+			name:      "wrapped context canceled retries",
+			parentCtx: context.Background(),
+			err:       fmt.Errorf("failed to start: %w", context.Canceled),
+			want:      true,
+		},
+		{
+			name:      "string matched context canceled retries",
+			parentCtx: context.Background(),
+			err:       errors.New("failed to connect to chrome: context canceled"),
+			want:      true,
+		},
+		{
+			name:      "parent cancellation does not retry",
+			parentCtx: canceledParent,
+			err:       context.Canceled,
+			want:      false,
+		},
+		{
+			name:      "other errors do not retry",
+			parentCtx: context.Background(),
+			err:       errors.New("exec format error"),
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldRetryChromeStartupWithDirectLaunch(tt.parentCtx, tt.err); got != tt.want {
+				t.Fatalf("shouldRetryChromeStartupWithDirectLaunch() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/scripts/docker-chrome-cft-smoke.sh
+++ b/scripts/docker-chrome-cft-smoke.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMAGE="${1:-pinchtab-chrome-cft-smoke:${RANDOM}${RANDOM}}"
+NAME="pinchtab-chrome-cft-smoke-${RANDOM}${RANDOM}"
+TOKEN="chrome-cft-smoke-token"
+FAILED=0
+
+cleanup() {
+  if docker ps -a --format '{{.Names}}' | grep -Fxq "$NAME"; then
+    if [ "$FAILED" -ne 0 ]; then
+      echo ""
+      echo "Container logs:"
+      docker logs "$NAME" || true
+      echo ""
+      echo "Chrome processes:"
+      docker exec "$NAME" ps -eo pid,args || true
+    fi
+    docker rm -f "$NAME" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+echo "Building Ubuntu + Chrome for Testing smoke image..."
+docker build \
+  --platform linux/amd64 \
+  -f tests/docker/chrome-cft-smoke.Dockerfile \
+  -t "$IMAGE" \
+  .
+
+docker run -d \
+  --platform linux/amd64 \
+  --name "$NAME" \
+  --shm-size=1g \
+  -p 127.0.0.1::9867 \
+  "$IMAGE" >/dev/null
+
+HOST_PORT="$(docker port "$NAME" 9867/tcp | head -1 | awk -F: '{print $NF}')"
+if [ -z "$HOST_PORT" ]; then
+  FAILED=1
+  echo "failed to determine published host port"
+  exit 1
+fi
+
+if docker exec "$NAME" sh -lc 'test -z "${DISPLAY:-}"'; then
+  echo "Confirmed DISPLAY is unset inside the container."
+else
+  FAILED=1
+  echo "expected DISPLAY to be unset inside the container"
+  exit 1
+fi
+
+HEALTH_BODY=""
+HEALTH_CODE=""
+
+fetch_health() {
+  HEALTH_BODY="$(mktemp)"
+  HEALTH_CODE="$(curl -sS -o "$HEALTH_BODY" -w '%{http_code}' -H "Authorization: Bearer ${TOKEN}" "http://127.0.0.1:${HOST_PORT}/health" || true)"
+}
+
+echo "Waiting for PinchTab to report healthy with Chrome for Testing on port $HOST_PORT..."
+for _ in $(seq 1 90); do
+  fetch_health
+  if [ "$HEALTH_CODE" = "200" ] && grep -q '"status":"ok"' "$HEALTH_BODY"; then
+    break
+  fi
+  rm -f "$HEALTH_BODY"
+  sleep 1
+done
+
+fetch_health
+if [ "$HEALTH_CODE" != "200" ] || ! grep -q '"status":"ok"' "$HEALTH_BODY"; then
+  FAILED=1
+  echo "health check did not pass"
+  echo "HTTP $HEALTH_CODE"
+  cat "$HEALTH_BODY" || true
+  rm -f "$HEALTH_BODY"
+  exit 1
+fi
+rm -f "$HEALTH_BODY"
+
+echo "Ubuntu Chrome for Testing smoke test passed."

--- a/tests/docker/chrome-cft-smoke.Dockerfile
+++ b/tests/docker/chrome-cft-smoke.Dockerfile
@@ -1,0 +1,93 @@
+FROM golang:1.26 AS builder
+
+WORKDIR /src
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o /out/pinchtab ./cmd/pinchtab
+
+FROM ubuntu:22.04
+
+ARG CHROME_FOR_TESTING_VERSION=145.0.7632.6
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    HOME=/data \
+    XDG_CONFIG_HOME=/data/.config \
+    PINCHTAB_CONFIG=/etc/pinchtab/smoke-config.json
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    dumb-init \
+    fonts-liberation \
+    libasound2 \
+    libatk-bridge2.0-0 \
+    libatk1.0-0 \
+    libc6 \
+    libcairo2 \
+    libcups2 \
+    libdbus-1-3 \
+    libexpat1 \
+    libfontconfig1 \
+    libgbm1 \
+    libgcc-s1 \
+    libglib2.0-0 \
+    libgtk-3-0 \
+    libnspr4 \
+    libnss3 \
+    libpango-1.0-0 \
+    libpangocairo-1.0-0 \
+    libstdc++6 \
+    libx11-6 \
+    libx11-xcb1 \
+    libxcb1 \
+    libxcomposite1 \
+    libxcursor1 \
+    libxdamage1 \
+    libxext6 \
+    libxfixes3 \
+    libxi6 \
+    libxrandr2 \
+    libxrender1 \
+    libxshmfence1 \
+    libxss1 \
+    libxtst6 \
+    procps \
+    unzip \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL "https://storage.googleapis.com/chrome-for-testing-public/${CHROME_FOR_TESTING_VERSION}/linux64/chrome-linux64.zip" -o /tmp/chrome-linux64.zip \
+ && mkdir -p /opt/chrome \
+ && unzip -q /tmp/chrome-linux64.zip -d /opt/chrome \
+ && ln -s /opt/chrome/chrome-linux64/chrome /usr/bin/google-chrome \
+ && rm -f /tmp/chrome-linux64.zip
+
+RUN useradd -m -d /data -s /bin/bash pinchtab \
+ && mkdir -p /data /etc/pinchtab \
+ && chown -R pinchtab:pinchtab /data
+
+COPY --from=builder /out/pinchtab /usr/local/bin/pinchtab
+RUN printf '%s\n' \
+  '{' \
+  '  "server": {' \
+  '    "bind": "0.0.0.0",' \
+  '    "port": "9867",' \
+  '    "token": "chrome-cft-smoke-token"' \
+  '  },' \
+  '  "browser": {' \
+    '    "binary": "/opt/chrome/chrome-linux64/chrome"' \
+  '  },' \
+  '  "instanceDefaults": {' \
+  '    "mode": "headless"' \
+  '  }' \
+  '}' > /etc/pinchtab/smoke-config.json
+
+USER pinchtab
+WORKDIR /data
+
+EXPOSE 9867
+
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+CMD ["pinchtab", "server"]


### PR DESCRIPTION
## Summary
- retry a direct-launch + remote-allocator fallback when headless Chrome startup fails with timeout/context-canceled style errors
- keep the fallback narrow so unrelated startup failures do not trigger an extra launch path
- add unit coverage for the retry decision logic
- add a Docker smoke test for Ubuntu + Chrome for Testing in a no-DISPLAY headless environment
- include the small dashboard test-config adjustment needed to keep CI/dashboard test setup aligned in this branch

## Why
Some headless Linux environments appear to launch Chrome successfully but still fail the initial startup/connection path with context-canceled style errors. This branch adds a targeted fallback path and a realistic container smoke test for that scenario.

Related to #437.

## Validation
- `go test ./...`
