### PR TITLE
chore(benchmark): tighten optimization loop follow-ups

### DIFF
--- a/cmd/pinchtab/cmd_security.go
+++ b/cmd/pinchtab/cmd_security.go
@@ -254,7 +254,7 @@ func editSecurityCheck(cfg *config.RuntimeConfig, check cli.SecurityPostureCheck
 		}
 		return workflow.UpdateValue("security.attach.allowHosts", value)
 	case "idpi_whitelist_scoped":
-		value, err := promptInput("Set security.allowedDomains (comma-separated):", strings.Join(cfg.IDPI.AllowedDomains, ","))
+		value, err := promptInput("Set security.allowedDomains (comma-separated):", strings.Join(cfg.AllowedDomains, ","))
 		if err != nil {
 			return nil, false, err
 		}

--- a/cmd/pinchtab/cmd_security_test.go
+++ b/cmd/pinchtab/cmd_security_test.go
@@ -127,12 +127,12 @@ func testRuntimeConfig() *config.RuntimeConfig {
 		AttachEnabled:      false,
 		AttachAllowHosts:   []string{"127.0.0.1", "localhost", "::1"},
 		AttachAllowSchemes: []string{"ws", "wss"},
+		AllowedDomains:     []string{"127.0.0.1", "localhost", "::1"},
 		IDPI: config.IDPIConfig{
-			Enabled:        true,
-			AllowedDomains: []string{"127.0.0.1", "localhost", "::1"},
-			StrictMode:     true,
-			ScanContent:    true,
-			WrapContent:    true,
+			Enabled:     true,
+			StrictMode:  true,
+			ScanContent: true,
+			WrapContent: true,
 		},
 	}
 }

--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -161,6 +161,8 @@ Text query parameters:
 - `mode=raw`
 - `format`
 
+`/text` default mode picks the first **visible** `<article>` / `[role="main"]` / `<main>` (skips `display:none`) and strips nav/footer/ads. Use `mode=raw` for full `innerText`, or `/snapshot` for structured UI text like prices and button labels.
+
 Find body fields:
 
 - `query`

--- a/internal/assets/readability.js
+++ b/internal/assets/readability.js
@@ -7,9 +7,30 @@
     '#Lb4nn', '.language-selector', '.locale-selector',
     '[data-language-picker]', '#langsec-button'];
 
-  let root = document.querySelector('article') ||
-             document.querySelector('[role="main"]') ||
-             document.querySelector('main');
+  // Pick the first VISIBLE candidate root. Pages may contain multiple
+  // <main> or [role="main"] elements and toggle between them with
+  // display:none (common SPA pattern). querySelector() returns the first
+  // in document order regardless of visibility, which produces stale
+  // content after in-place DOM updates.
+  const isVisible = (el) => {
+    if (!el || !el.isConnected) return false;
+    const style = window.getComputedStyle(el);
+    if (style.display === 'none' || style.visibility === 'hidden') return false;
+    const rect = el.getBoundingClientRect();
+    return rect.width > 0 || rect.height > 0;
+  };
+
+  const firstVisible = (selector) => {
+    const nodes = document.querySelectorAll(selector);
+    for (const n of nodes) {
+      if (isVisible(n)) return n;
+    }
+    return null;
+  };
+
+  let root = firstVisible('article') ||
+             firstVisible('[role="main"]') ||
+             firstVisible('main');
 
   if (!root) {
     root = document.body.cloneNode(true);

--- a/internal/bridge/action_pointer.go
+++ b/internal/bridge/action_pointer.go
@@ -145,6 +145,13 @@ func (b *Bridge) actionScroll(ctx context.Context, req ActionRequest) (map[strin
 	if req.NodeID > 0 {
 		return map[string]any{"scrolled": true}, ScrollByNodeID(ctx, req.NodeID)
 	}
+	if req.Selector != "" {
+		node, err := firstNodeBySelector(ctx, req.Selector)
+		if err != nil {
+			return nil, err
+		}
+		return map[string]any{"scrolled": true}, ScrollByNodeID(ctx, int64(node.BackendNodeID))
+	}
 
 	scrollX := req.ScrollX
 	scrollY := req.ScrollY

--- a/internal/bridge/tab_policy.go
+++ b/internal/bridge/tab_policy.go
@@ -34,7 +34,7 @@ func (tm *TabManager) idpiDomainPolicyActive() bool {
 	return tm != nil &&
 		tm.config != nil &&
 		tm.config.IDPI.Enabled &&
-		len(tm.config.IDPI.AllowedDomains) > 0
+		len(tm.config.AllowedDomains) > 0
 }
 
 func (tm *TabManager) startTabPolicyWatcher(tabID string, ctx context.Context) {

--- a/internal/cli/report/security.go
+++ b/internal/cli/report/security.go
@@ -61,7 +61,7 @@ func AssessSecurityPosture(cfg *config.RuntimeConfig) SecurityPosture {
 		{
 			ID:     "idpi_whitelist_scoped",
 			Label:  "website whitelist",
-			Passed: cfg.IDPI.Enabled && len(cfg.IDPI.AllowedDomains) > 0 && !allowsAllDomains(cfg.IDPI.AllowedDomains),
+			Passed: cfg.IDPI.Enabled && len(cfg.AllowedDomains) > 0 && !allowsAllDomains(cfg.AllowedDomains),
 			Detail: formatWhitelistStatus(cfg),
 		},
 		{
@@ -159,13 +159,13 @@ func AssessSecurityWarnings(cfg *config.RuntimeConfig) []SecurityWarning {
 			Attrs:   []any{"setting", "security.idpi.enabled", "hint", "enable IDPI and keep security.allowedDomains scoped to approved websites"},
 		})
 	} else {
-		if len(cfg.IDPI.AllowedDomains) == 0 {
+		if len(cfg.AllowedDomains) == 0 {
 			warnings = append(warnings, SecurityWarning{
 				ID:      "idpi_whitelist_not_set",
 				Message: "website whitelist is not set for IDPI",
 				Attrs:   []any{"setting", "security.allowedDomains", "hint", "configure allowedDomains to restrict which websites navigation may reach"},
 			})
-		} else if allowsAllDomains(cfg.IDPI.AllowedDomains) {
+		} else if allowsAllDomains(cfg.AllowedDomains) {
 			warnings = append(warnings, SecurityWarning{
 				ID:      "idpi_whitelist_allows_all",
 				Message: "website whitelist allows all domains",
@@ -299,13 +299,13 @@ func formatWhitelistStatus(cfg *config.RuntimeConfig) string {
 	if !cfg.IDPI.Enabled {
 		return "disabled"
 	}
-	if len(cfg.IDPI.AllowedDomains) == 0 {
+	if len(cfg.AllowedDomains) == 0 {
 		return "not set"
 	}
-	if allowsAllDomains(cfg.IDPI.AllowedDomains) {
+	if allowsAllDomains(cfg.AllowedDomains) {
 		return "wildcard"
 	}
-	return strings.Join(cfg.IDPI.AllowedDomains, ", ")
+	return strings.Join(cfg.AllowedDomains, ", ")
 }
 
 func formatStrictModeStatus(cfg *config.RuntimeConfig) string {

--- a/internal/cli/report/security_test.go
+++ b/internal/cli/report/security_test.go
@@ -15,12 +15,12 @@ func TestAssessSecurityWarnings(t *testing.T) {
 			Token:              "secret",
 			AttachAllowHosts:   []string{"127.0.0.1", "localhost", "::1"},
 			AttachAllowSchemes: []string{"ws", "wss"},
+			AllowedDomains:     []string{"127.0.0.1", "localhost", "::1"},
 			IDPI: config.IDPIConfig{
-				Enabled:        true,
-				AllowedDomains: []string{"127.0.0.1", "localhost", "::1"},
-				StrictMode:     true,
-				ScanContent:    true,
-				WrapContent:    true,
+				Enabled:     true,
+				StrictMode:  true,
+				ScanContent: true,
+				WrapContent: true,
 			},
 		}
 
@@ -76,13 +76,13 @@ func TestAssessSecurityWarnings(t *testing.T) {
 
 	t.Run("wildcard whitelist is warned", func(t *testing.T) {
 		cfg := &config.RuntimeConfig{
-			Bind:  "127.0.0.1",
-			Token: "secret",
+			Bind:           "127.0.0.1",
+			Token:          "secret",
+			AllowedDomains: []string{"*"},
 			IDPI: config.IDPIConfig{
-				Enabled:        true,
-				AllowedDomains: []string{"*"},
-				StrictMode:     true,
-				ScanContent:    true,
+				Enabled:     true,
+				StrictMode:  true,
+				ScanContent: true,
 			},
 		}
 
@@ -157,12 +157,12 @@ func TestAssessSecurityPosture(t *testing.T) {
 			Token:              "secret",
 			AttachAllowHosts:   []string{"127.0.0.1", "localhost", "::1"},
 			AttachAllowSchemes: []string{"ws", "wss"},
+			AllowedDomains:     []string{"127.0.0.1", "localhost", "::1"},
 			IDPI: config.IDPIConfig{
-				Enabled:        true,
-				AllowedDomains: []string{"127.0.0.1", "localhost", "::1"},
-				StrictMode:     true,
-				ScanContent:    true,
-				WrapContent:    true,
+				Enabled:     true,
+				StrictMode:  true,
+				ScanContent: true,
+				WrapContent: true,
 			},
 		}
 
@@ -181,12 +181,12 @@ func TestAssessSecurityPosture(t *testing.T) {
 			Token:              "secret",
 			AttachAllowHosts:   []string{"*"},
 			AttachAllowSchemes: []string{"http", "https"},
+			AllowedDomains:     []string{"example.com"},
 			IDPI: config.IDPIConfig{
-				Enabled:        true,
-				AllowedDomains: []string{"example.com"},
-				StrictMode:     true,
-				ScanContent:    true,
-				WrapContent:    true,
+				Enabled:     true,
+				StrictMode:  true,
+				ScanContent: true,
+				WrapContent: true,
 			},
 		}
 

--- a/internal/config/config_load.go
+++ b/internal/config/config_load.go
@@ -278,7 +278,11 @@ func applyFileConfig(cfg *RuntimeConfig, fc *FileConfig) {
 	cfg.TrustedResolveCIDRs = append([]string(nil), fc.Security.TrustedResolveCIDRs...)
 	// IDPI – copy the whole struct; individual fields have safe zero-value defaults.
 	cfg.IDPI = fc.Security.IDPI
-	cfg.IDPI.AllowedDomains = effectiveSecurityAllowedDomains(fc.Security)
+	// Unified allowlist: security.allowedDomains is the canonical source,
+	// with a legacy fallback to security.idpi.allowedDomains.
+	cfg.AllowedDomains = effectiveSecurityAllowedDomains(fc.Security)
+	// Mirror onto IDPI for existing consumers that still read the deprecated field.
+	cfg.IDPI.AllowedDomains = append([]string(nil), cfg.AllowedDomains...)
 	if fc.Observability.Activity.Enabled != nil {
 		cfg.Observability.Activity.Enabled = *fc.Observability.Activity.Enabled
 	}

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -18,10 +18,15 @@ type RuntimeConfig struct {
 	CookieSecure      *bool // Nil = auto-detect based on request scheme/host for backward compatibility
 
 	// Security settings
-	AllowEvaluate          bool
-	AllowMacro             bool
-	AllowScreencast        bool
-	AllowDownload          bool
+	AllowEvaluate   bool
+	AllowMacro      bool
+	AllowScreencast bool
+	AllowDownload   bool
+	// AllowedDomains is the unified per-instance allowlist sourced from
+	// security.allowedDomains in the file config. Consumers (IDPI guard,
+	// download handler, tab policy) should prefer this list over the
+	// deprecated IDPI.AllowedDomains duplicate.
+	AllowedDomains         []string
 	DownloadAllowedDomains []string
 	DownloadMaxBytes       int
 	AllowUpload            bool

--- a/internal/handlers/download.go
+++ b/internal/handlers/download.go
@@ -254,7 +254,15 @@ func (h *Handlers) HandleDownload(w http.ResponseWriter, r *http.Request) {
 	}
 	maxDownloadBytes := h.Config.EffectiveDownloadMaxBytes()
 
-	validator := newDownloadURLGuard(h.Config.DownloadAllowedDomains)
+	// Download allowlist: prefer the explicit per-feature list, but fall
+	// back to the unified security.allowedDomains (surfaced on the runtime
+	// config as IDPI.AllowedDomains). This way operators only need to
+	// configure trusted domains once.
+	allowed := h.Config.DownloadAllowedDomains
+	if len(allowed) == 0 {
+		allowed = h.Config.IDPI.AllowedDomains
+	}
+	validator := newDownloadURLGuard(allowed)
 	if err := validator.Validate(dlURL); err != nil {
 		httpx.Error(w, 400, fmt.Errorf("unsafe URL: %w", err))
 		return

--- a/internal/handlers/download.go
+++ b/internal/handlers/download.go
@@ -255,12 +255,11 @@ func (h *Handlers) HandleDownload(w http.ResponseWriter, r *http.Request) {
 	maxDownloadBytes := h.Config.EffectiveDownloadMaxBytes()
 
 	// Download allowlist: prefer the explicit per-feature list, but fall
-	// back to the unified security.allowedDomains (surfaced on the runtime
-	// config as IDPI.AllowedDomains). This way operators only need to
-	// configure trusted domains once.
+	// back to the unified security.allowedDomains. This way operators only
+	// need to configure trusted domains once.
 	allowed := h.Config.DownloadAllowedDomains
 	if len(allowed) == 0 {
-		allowed = h.Config.IDPI.AllowedDomains
+		allowed = h.Config.AllowedDomains
 	}
 	validator := newDownloadURLGuard(allowed)
 	if err := validator.Validate(dlURL); err != nil {

--- a/internal/handlers/download_test.go
+++ b/internal/handlers/download_test.go
@@ -321,10 +321,10 @@ func TestHandleDownload_TabScopedCrossOriginBlockedForCookieAuth(t *testing.T) {
 		},
 	}
 	h := New(b, &config.RuntimeConfig{
-		AllowDownload: true,
+		AllowDownload:  true,
+		AllowedDomains: []string{"pinchtab.com", "example.com"},
 		IDPI: config.IDPIConfig{
-			Enabled:        true,
-			AllowedDomains: []string{"pinchtab.com"},
+			Enabled: true,
 		},
 	}, nil, nil, nil)
 	req := httptest.NewRequest("GET", "/download?tabId=tab1&url=https://example.com/file.txt", nil)
@@ -354,10 +354,10 @@ func TestHandleDownload_TabScopedCrossOriginAllowedForHeaderAuth(t *testing.T) {
 		},
 	}
 	h := New(b, &config.RuntimeConfig{
-		AllowDownload: true,
+		AllowDownload:  true,
+		AllowedDomains: []string{"pinchtab.com", "example.com"},
 		IDPI: config.IDPIConfig{
-			Enabled:        true,
-			AllowedDomains: []string{"pinchtab.com"},
+			Enabled: true,
 		},
 	}, nil, nil, nil)
 	req := httptest.NewRequest("GET", "/download?tabId=tab1&url=https://example.com/file.txt", nil)

--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -354,10 +354,10 @@ func TestHandleGetConsoleLogs_BlocksWhenCachedTabPolicyIsBlocked(t *testing.T) {
 		hasState: true,
 	}
 	h := New(b, &config.RuntimeConfig{
+		AllowedDomains: []string{"example.com"},
 		IDPI: config.IDPIConfig{
-			Enabled:        true,
-			AllowedDomains: []string{"example.com"},
-			StrictMode:     true,
+			Enabled:    true,
+			StrictMode: true,
 		},
 	}, nil, nil, nil)
 
@@ -382,10 +382,10 @@ func TestHandleGetErrorLogs_BlocksWhenCachedTabPolicyIsBlocked(t *testing.T) {
 		hasState: true,
 	}
 	h := New(b, &config.RuntimeConfig{
+		AllowedDomains: []string{"example.com"},
 		IDPI: config.IDPIConfig{
-			Enabled:        true,
-			AllowedDomains: []string{"example.com"},
-			StrictMode:     true,
+			Enabled:    true,
+			StrictMode: true,
 		},
 	}, nil, nil, nil)
 

--- a/internal/handlers/tab_policy.go
+++ b/internal/handlers/tab_policy.go
@@ -25,7 +25,7 @@ func (h *Handlers) currentTabDomainPolicyEnabled() bool {
 	return h != nil &&
 		h.Config != nil &&
 		h.Config.IDPI.Enabled &&
-		len(h.Config.IDPI.AllowedDomains) > 0
+		len(h.Config.AllowedDomains) > 0
 }
 
 func (h *Handlers) enforceCurrentTabDomainPolicy(w http.ResponseWriter, r *http.Request, ctx context.Context, tabID string) (string, bool) {

--- a/internal/handlers/tab_policy_test.go
+++ b/internal/handlers/tab_policy_test.go
@@ -45,11 +45,11 @@ func TestHandleActionBlocksWhenCachedTabPolicyIsBlocked(t *testing.T) {
 		hasState: true,
 	}
 	h := New(b, &config.RuntimeConfig{
-		ActionTimeout: time.Second,
+		ActionTimeout:  time.Second,
+		AllowedDomains: []string{"example.com"},
 		IDPI: config.IDPIConfig{
-			Enabled:        true,
-			AllowedDomains: []string{"example.com"},
-			StrictMode:     true,
+			Enabled:    true,
+			StrictMode: true,
 		},
 	}, nil, nil, nil)
 
@@ -85,11 +85,11 @@ func TestHandleActionWarnsWhenCachedTabPolicyIsThreatOnly(t *testing.T) {
 		hasState: true,
 	}
 	h := New(b, &config.RuntimeConfig{
-		ActionTimeout: time.Second,
+		ActionTimeout:  time.Second,
+		AllowedDomains: []string{"example.com"},
 		IDPI: config.IDPIConfig{
-			Enabled:        true,
-			AllowedDomains: []string{"example.com"},
-			StrictMode:     false,
+			Enabled:    true,
+			StrictMode: false,
 		},
 	}, nil, nil, nil)
 
@@ -120,11 +120,11 @@ func TestHandleBackIgnoresCachedTabPolicyBlock(t *testing.T) {
 		hasState: true,
 	}
 	h := New(b, &config.RuntimeConfig{
-		ActionTimeout: time.Second,
+		ActionTimeout:  time.Second,
+		AllowedDomains: []string{"example.com"},
 		IDPI: config.IDPIConfig{
-			Enabled:        true,
-			AllowedDomains: []string{"example.com"},
-			StrictMode:     true,
+			Enabled:    true,
+			StrictMode: true,
 		},
 	}, nil, nil, nil)
 

--- a/skills/pinchtab/SKILL.md
+++ b/skills/pinchtab/SKILL.md
@@ -224,6 +224,8 @@ Rules:
 - Re-snapshot immediately after `click`, `press Enter`, `select`, or `scroll` if the UI can change.
 - To discover valid dropdown values, snapshot with `filter=interactive` first — the output shows `<option>` elements with their `value` attributes. Then use `select` with the exact value.
 - If a click opens a JS dialog (`alert`, `confirm`, `prompt`), pass `"dialogAction": "accept"` or `"dialogAction": "dismiss"` on the click action body. The dialog is auto-handled in a single call. Without this, the click hangs until `/tabs/TAB_ID/dialog` is called from a parallel request, and a pending dialog wedges subsequent `/snapshot` and `/text` calls.
+- For the `scroll` action via HTTP, use `"scrollX"` / `"scrollY"` for pixel deltas, or `"selector"` to scroll an element into view. Example: `{"kind":"scroll","scrollY":1500}` or `{"kind":"scroll","selector":"#footer"}`. The `x`/`y` fields are target viewport coordinates, not scroll deltas.
+- The download HTTP endpoint (`GET /download?url=...` or `GET /tabs/TAB_ID/download?url=...`) returns JSON `{contentType, data (base64), size, url}`, not raw bytes. Decode `data` with base64 to get the file. Only `http`/`https` URLs are allowed. Private/internal hosts are blocked unless listed in `security.downloadAllowedDomains`.
 
 ### Export, debug, and verification
 

--- a/skills/pinchtab/references/api.md
+++ b/skills/pinchtab/references/api.md
@@ -153,6 +153,8 @@ curl "/text?mode=raw"
 
 Returns `{url, title, text}`. Cheapest option (~1K tokens for most pages).
 
+Default mode picks the first **visible** `<article>` / `[role="main"]` / `<main>` (skips `display:none`) and strips nav/footer/ads. Use `mode=raw` for full `innerText`, or `/snapshot` for structured UI text like prices and button labels.
+
 ## PDF export
 
 Prefer returning base64 or raw bytes unless the user explicitly wants a file written to disk.

--- a/tests/benchmark/BASELINE_TASKS.md
+++ b/tests/benchmark/BASELINE_TASKS.md
@@ -474,7 +474,7 @@ curl -X POST http://localhost:9867/tabs/TAB_ID/action \
   -H "Content-Type: application/json" \
   -d '{"kind":"click","selector":"#checkout-btn"}'
 
-curl "http://localhost:9867/tabs/TAB_ID/snapshot?format=compact&maxTokens=500" \
+curl "http://localhost:9867/tabs/TAB_ID/snapshot?format=compact&maxTokens=2000" \
   -H "Authorization: Bearer benchmark-token"
 ```
 **Pass if**: Contains `VERIFY_CHECKOUT_SUCCESS_ORDER` AND `ORDER_TOTAL_449_98`.
@@ -508,7 +508,7 @@ curl -X POST http://localhost:9867/tabs/TAB_ID/action \
   -H "Content-Type: application/json" \
   -d '{"kind":"click","selector":"#submit-comment"}'
 
-curl "http://localhost:9867/tabs/TAB_ID/snapshot?format=compact&maxTokens=500" \
+curl "http://localhost:9867/tabs/TAB_ID/snapshot?format=compact&maxTokens=2000" \
   -H "Authorization: Bearer benchmark-token"
 ```
 **Pass if**: First snapshot contains `VERIFY_WIKI_GO_LANG_88888` AND final snapshot contains `COMMENT_POSTED_RATING_5_TEXT_RECEIVED`.
@@ -944,21 +944,27 @@ curl -X POST http://localhost:9867/navigate \
   -H "Content-Type: application/json" \
   -d '{"tabId":"TAB_ID","url":"http://fixtures/scroll.html"}'
 
-curl -X POST http://localhost:9867/tabs/TAB_ID/evaluate \
+curl -X POST http://localhost:9867/tabs/TAB_ID/action \
   -H "Authorization: Bearer benchmark-token" \
   -H "Content-Type: application/json" \
-  -d '{"expression":"window.scrollTo(0, 1500); document.querySelector(\"#middle-block\").innerText;"}'
+  -d '{"kind":"scroll","scrollY":1500}'
+
+curl "http://localhost:9867/tabs/TAB_ID/snapshot?format=compact&maxTokens=1500" \
+  -H "Authorization: Bearer benchmark-token"
 ```
-**Pass if**: Response value contains `SCROLL_MIDDLE_MARKER`.
+**Pass if**: Snapshot contains `SCROLL_MIDDLE_MARKER`.
 
 ### 17.2 Scroll to footer
 ```bash
-curl -X POST http://localhost:9867/tabs/TAB_ID/evaluate \
+curl -X POST http://localhost:9867/tabs/TAB_ID/action \
   -H "Authorization: Bearer benchmark-token" \
   -H "Content-Type: application/json" \
-  -d '{"expression":"document.querySelector(\"#footer\").scrollIntoView(); document.querySelector(\"#footer\").innerText;"}'
+  -d '{"kind":"scroll","selector":"#footer"}'
+
+curl "http://localhost:9867/tabs/TAB_ID/snapshot?format=compact&maxTokens=1500" \
+  -H "Authorization: Bearer benchmark-token"
 ```
-**Pass if**: Response value contains `SCROLL_REACHED_FOOTER`.
+**Pass if**: Snapshot contains `SCROLL_REACHED_FOOTER`.
 
 ---
 
@@ -966,17 +972,15 @@ curl -X POST http://localhost:9867/tabs/TAB_ID/evaluate \
 
 ### 18.1 Download a file
 ```bash
-curl -X POST http://localhost:9867/navigate \
-  -H "Authorization: Bearer benchmark-token" \
-  -H "Content-Type: application/json" \
-  -d '{"tabId":"TAB_ID","url":"http://fixtures/download-sample.txt"}'
+curl "http://localhost:9867/tabs/TAB_ID/download?url=http://fixtures/download-sample.txt" \
+  -H "Authorization: Bearer benchmark-token" | \
+  jq -r .data | base64 -d > /tmp/benchmark-download.txt
 
-curl "http://localhost:9867/tabs/TAB_ID/text" \
-  -H "Authorization: Bearer benchmark-token"
+grep "DOWNLOAD_FILE_CONTENT_VERIFIED" /tmp/benchmark-download.txt
 ```
-**Pass if**: Response text contains `DOWNLOAD_FILE_CONTENT_VERIFIED`.
+**Pass if**: File exists and contains `DOWNLOAD_FILE_CONTENT_VERIFIED`.
 
-**Note**: PinchTab's `/download` endpoint blocks private/internal IPs as a safety measure. For local fixture downloads, navigate to the file URL and read body text instead.
+**Note**: The download endpoint returns JSON with `{contentType, data (base64), size, url}`, not the raw file. Decode `.data` to get the file contents. For PinchTab to download from internal hosts (like `fixtures`), the domain must be in `security.downloadAllowedDomains` config.
 
 ---
 

--- a/tests/benchmark/config/pinchtab.json
+++ b/tests/benchmark/config/pinchtab.json
@@ -35,15 +35,15 @@
     "allowDownload": true,
     "allowUpload": true,
     "allowClipboard": true,
+    "allowedDomains": [
+      "fixtures",
+      "localhost",
+      "127.0.0.1",
+      "::1",
+      "172.18.0.2"
+    ],
     "idpi": {
-      "enabled": true,
-      "allowedDomains": [
-        "fixtures",
-        "localhost",
-        "127.0.0.1",
-        "::1",
-        "172.18.0.2"
-      ]
+      "enabled": true
     }
   },
   "activity": {


### PR DESCRIPTION
## Summary
- fix benchmark-discovered runtime issues around readability root selection, selector-targeted scroll, and download validation behavior
- promote `AllowedDomains` to the top-level runtime config so benchmark/runtime config handling stays consistent across handlers, CLI, and reporting
- align benchmark baseline tasks, benchmark config, endpoint docs, and PinchTab skill guidance with the current optimization loop findings

## Why
This is a follow-up benchmark optimization branch focused on tightening the small runtime and config issues uncovered by the evolving benchmark suite, while keeping the benchmark docs/config in sync with the resulting behavior.

## Validation
- `go test ./...`
