### PR TITLE
chore(deps): bump github.com/pinchtab/semantic to v0.1.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/gost-dom/browser v0.11.0
 	github.com/mark3labs/mcp-go v0.45.0
 	github.com/pinchtab/idpishield v0.1.3
-	github.com/pinchtab/semantic v0.1.0
+	github.com/pinchtab/semantic v0.1.1
 	github.com/shirou/gopsutil/v4 v4.26.2
 	github.com/spf13/cobra v1.10.2
 	golang.org/x/net v0.47.0

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,8 @@ github.com/pinchtab/idpishield v0.1.3 h1:x5JWQxTJggXO9N4+13xPHK8Lf5jPGHZtdcHIONI
 github.com/pinchtab/idpishield v0.1.3/go.mod h1:IDxnW0Re5VcM2qOZ0G79GAQcKQMMfcZdlwistKEz5ks=
 github.com/pinchtab/semantic v0.1.0 h1:jVBQmnddU1cCEKtpqk/t9QHrQ9y/VXMtZ0BI3VkLQxk=
 github.com/pinchtab/semantic v0.1.0/go.mod h1:SPKIra6m26faxTxn4dxa1ex1TbGkZDKbJ2r5rCngWoQ=
+github.com/pinchtab/semantic v0.1.1 h1:IRzRYIdQnmJyRPkjjlA3a+4UY/nnT020oxdRLdRdL80=
+github.com/pinchtab/semantic v0.1.1/go.mod h1:SPKIra6m26faxTxn4dxa1ex1TbGkZDKbJ2r5rCngWoQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 h1:o4JXh1EVt9k/+g42oCprj/FisM4qX9L3sZB3upGN2ZU=


### PR DESCRIPTION
## Summary
- bump `github.com/pinchtab/semantic` from `v0.1.0` to `v0.1.1`
- refresh `go.sum` for the updated module version

## Why
This keeps PinchTab current with the latest patch release of the semantic matcher dependency.

## Validation
- `go test ./...`
