### PR TITLE
refactor(config): remove active IDPI allowedDomains alias paths

### DIFF
--- a/cmd/pinchtab/cmd_wizard.go
+++ b/cmd/pinchtab/cmd_wizard.go
@@ -166,7 +166,6 @@ func applyGuardUp(cfg *config.FileConfig) {
 	cfg.Security.IDPI.ScanContent = true
 	cfg.Security.IDPI.WrapContent = true
 	cfg.Security.AllowedDomains = []string{"127.0.0.1", "localhost", "::1"}
-	cfg.Security.IDPI.AllowedDomains = append([]string(nil), cfg.Security.AllowedDomains...)
 	cfg.Server.Bind = "127.0.0.1"
 }
 
@@ -179,8 +178,9 @@ func applyGuardDown(cfg *config.FileConfig) {
 	cfg.Security.AllowScreencast = &t
 	cfg.Security.IDPI.Enabled = false
 	cfg.Security.IDPI.StrictMode = false
+	cfg.Security.IDPI.ScanContent = false
+	cfg.Security.IDPI.WrapContent = false
 	cfg.Security.AllowedDomains = nil
-	cfg.Security.IDPI.AllowedDomains = nil
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────

--- a/cmd/pinchtab/cmd_wizard_test.go
+++ b/cmd/pinchtab/cmd_wizard_test.go
@@ -13,7 +13,6 @@ func TestRunNonInteractiveSetupDoesNotPrintToken(t *testing.T) {
 	cfg := config.DefaultFileConfig()
 	cfg.Server.Token = "very-secret-token-value"
 	cfg.Security.AllowedDomains = []string{"localhost"}
-	cfg.Security.IDPI.AllowedDomains = []string{"localhost"}
 
 	output := captureStdout(t, func() {
 		if !runNonInteractiveSetup(&cfg, configPath, true) {

--- a/internal/bridge/bridge_test.go
+++ b/internal/bridge/bridge_test.go
@@ -228,17 +228,17 @@ func TestShouldBlockPopupTarget(t *testing.T) {
 
 func TestEvaluateTabPolicy(t *testing.T) {
 	cfg := config.IDPIConfig{
-		Enabled:        true,
-		AllowedDomains: []string{"example.com"},
-		StrictMode:     true,
+		Enabled:    true,
+		StrictMode: true,
 	}
+	allowedDomains := []string{"example.com"}
 
-	allowed := EvaluateTabPolicy("https://example.com/path", cfg)
+	allowed := EvaluateTabPolicy("https://example.com/path", cfg, allowedDomains)
 	if allowed.Threat || allowed.Blocked {
 		t.Fatalf("expected allowed domain to pass, got %+v", allowed)
 	}
 
-	blocked := EvaluateTabPolicy("https://evil.example.net/path", cfg)
+	blocked := EvaluateTabPolicy("https://evil.example.net/path", cfg, allowedDomains)
 	if !blocked.Threat || !blocked.Blocked {
 		t.Fatalf("expected blocked domain to fail, got %+v", blocked)
 	}

--- a/internal/bridge/tab_policy.go
+++ b/internal/bridge/tab_policy.go
@@ -19,8 +19,8 @@ type TabPolicyState struct {
 	UpdatedAt  time.Time
 }
 
-func EvaluateTabPolicy(rawURL string, cfg config.IDPIConfig) TabPolicyState {
-	result := idpi.CheckDomain(rawURL, cfg)
+func EvaluateTabPolicy(rawURL string, cfg config.IDPIConfig, allowedDomains []string) TabPolicyState {
+	result := idpi.CheckDomain(rawURL, cfg, allowedDomains)
 	return TabPolicyState{
 		CurrentURL: rawURL,
 		Threat:     result.Threat,
@@ -84,7 +84,7 @@ func (tm *TabManager) refreshTabPolicyFromContext(tabID string, ctx context.Cont
 }
 
 func (tm *TabManager) updateTabPolicy(tabID, rawURL string) TabPolicyState {
-	state := EvaluateTabPolicy(rawURL, tm.config.IDPI)
+	state := EvaluateTabPolicy(rawURL, tm.config.IDPI, tm.config.AllowedDomains)
 
 	tm.mu.Lock()
 	if entry := tm.tabs[tabID]; entry != nil {

--- a/internal/config/config_file.go
+++ b/internal/config/config_file.go
@@ -90,7 +90,6 @@ func DefaultFileConfig() FileConfig {
 			},
 			IDPI: IDPIConfig{
 				Enabled:        true,
-				AllowedDomains: append([]string(nil), defaultLocalAllowedDomains...),
 				StrictMode:     true,
 				ScanContent:    true,
 				WrapContent:    true,
@@ -589,7 +588,7 @@ func FileConfigFromRuntime(cfg *RuntimeConfig) FileConfig {
 			AllowMacro:             &allowMacro,
 			AllowScreencast:        &allowScreencast,
 			AllowDownload:          &allowDownload,
-			AllowedDomains:         append([]string(nil), cfg.IDPI.AllowedDomains...),
+			AllowedDomains:         append([]string(nil), cfg.AllowedDomains...),
 			DownloadAllowedDomains: downloadAllowedDomains,
 			DownloadMaxBytes:       &downloadMaxBytes,
 			AllowUpload:            &allowUpload,

--- a/internal/config/config_file_test.go
+++ b/internal/config/config_file_test.go
@@ -64,8 +64,8 @@ func TestDefaultFileConfig(t *testing.T) {
 	if !fc.Security.IDPI.Enabled {
 		t.Errorf("DefaultFileConfig.Security.IDPI.Enabled = %v, want true", fc.Security.IDPI.Enabled)
 	}
-	if len(fc.Security.IDPI.AllowedDomains) != 3 || fc.Security.IDPI.AllowedDomains[0] != "127.0.0.1" {
-		t.Errorf("DefaultFileConfig.Security.IDPI.AllowedDomains = %v, want local-only allowlist", fc.Security.IDPI.AllowedDomains)
+	if len(fc.Security.AllowedDomains) != 3 || fc.Security.AllowedDomains[0] != "127.0.0.1" {
+		t.Errorf("DefaultFileConfig.Security.AllowedDomains = %v, want local-only allowlist", fc.Security.AllowedDomains)
 	}
 	if !fc.Security.IDPI.StrictMode {
 		t.Errorf("DefaultFileConfig.Security.IDPI.StrictMode = %v, want true", fc.Security.IDPI.StrictMode)
@@ -259,8 +259,8 @@ func TestDefaultFileConfigJSON(t *testing.T) {
 	if !parsed.Security.IDPI.Enabled {
 		t.Errorf("round-trip Security.IDPI.Enabled = %v, want true", parsed.Security.IDPI.Enabled)
 	}
-	if len(parsed.Security.IDPI.AllowedDomains) != 3 || parsed.Security.IDPI.AllowedDomains[0] != "127.0.0.1" {
-		t.Errorf("round-trip Security.IDPI.AllowedDomains = %v, want local-only allowlist", parsed.Security.IDPI.AllowedDomains)
+	if len(parsed.Security.AllowedDomains) != 3 || parsed.Security.AllowedDomains[0] != "127.0.0.1" {
+		t.Errorf("round-trip Security.AllowedDomains = %v, want local-only allowlist", parsed.Security.AllowedDomains)
 	}
 	if !parsed.Security.IDPI.StrictMode {
 		t.Errorf("round-trip Security.IDPI.StrictMode = %v, want true", parsed.Security.IDPI.StrictMode)
@@ -283,7 +283,6 @@ func TestFileConfigJSONPreservesExplicitZeroValues(t *testing.T) {
 	fc.InstanceDefaults.UserAgent = ""
 	fc.Security.IDPI.StrictMode = false
 	fc.Security.AllowedDomains = []string{}
-	fc.Security.IDPI.AllowedDomains = []string{}
 	fc.Security.IDPI.CustomPatterns = []string{}
 	fc.Security.IDPI.ShieldThreshold = 30
 

--- a/internal/config/config_load.go
+++ b/internal/config/config_load.go
@@ -25,6 +25,7 @@ func Load() *RuntimeConfig {
 		AllowMacro:             false,
 		AllowScreencast:        false,
 		AllowDownload:          false,
+		AllowedDomains:         append([]string(nil), defaultLocalAllowedDomains...),
 		DownloadAllowedDomains: nil,
 		DownloadMaxBytes:       DefaultDownloadMaxBytes,
 		AllowUpload:            false,
@@ -81,7 +82,6 @@ func Load() *RuntimeConfig {
 		// IDPI defaults
 		IDPI: IDPIConfig{
 			Enabled:        true,
-			AllowedDomains: append([]string(nil), defaultLocalAllowedDomains...),
 			StrictMode:     true,
 			ScanContent:    true,
 			WrapContent:    true,
@@ -278,11 +278,7 @@ func applyFileConfig(cfg *RuntimeConfig, fc *FileConfig) {
 	cfg.TrustedResolveCIDRs = append([]string(nil), fc.Security.TrustedResolveCIDRs...)
 	// IDPI – copy the whole struct; individual fields have safe zero-value defaults.
 	cfg.IDPI = fc.Security.IDPI
-	// Unified allowlist: security.allowedDomains is the canonical source,
-	// with a legacy fallback to security.idpi.allowedDomains.
 	cfg.AllowedDomains = effectiveSecurityAllowedDomains(fc.Security)
-	// Mirror onto IDPI for existing consumers that still read the deprecated field.
-	cfg.IDPI.AllowedDomains = append([]string(nil), cfg.AllowedDomains...)
 	if fc.Observability.Activity.Enabled != nil {
 		cfg.Observability.Activity.Enabled = *fc.Observability.Activity.Enabled
 	}

--- a/internal/config/config_load_test.go
+++ b/internal/config/config_load_test.go
@@ -85,8 +85,8 @@ func TestLoadConfigDefaults(t *testing.T) {
 	if !cfg.IDPI.Enabled {
 		t.Errorf("default IDPI.Enabled = %v, want true", cfg.IDPI.Enabled)
 	}
-	if len(cfg.IDPI.AllowedDomains) != 3 || cfg.IDPI.AllowedDomains[0] != "127.0.0.1" {
-		t.Errorf("default IDPI.AllowedDomains = %v, want local-only allowlist", cfg.IDPI.AllowedDomains)
+	if len(cfg.AllowedDomains) != 3 || cfg.AllowedDomains[0] != "127.0.0.1" {
+		t.Errorf("default AllowedDomains = %v, want local-only allowlist", cfg.AllowedDomains)
 	}
 	if !cfg.IDPI.StrictMode {
 		t.Errorf("default IDPI.StrictMode = %v, want true", cfg.IDPI.StrictMode)
@@ -387,8 +387,8 @@ func TestApplyFileConfigToRuntimeResetsSecurityFlagsToSafeDefaults(t *testing.T)
 	if !cfg.IDPI.Enabled {
 		t.Errorf("ApplyFileConfigToRuntime IDPI.Enabled = %v, want true", cfg.IDPI.Enabled)
 	}
-	if len(cfg.IDPI.AllowedDomains) != 3 || cfg.IDPI.AllowedDomains[0] != "127.0.0.1" {
-		t.Errorf("ApplyFileConfigToRuntime IDPI.AllowedDomains = %v, want local-only allowlist", cfg.IDPI.AllowedDomains)
+	if len(cfg.AllowedDomains) != 3 || cfg.AllowedDomains[0] != "127.0.0.1" {
+		t.Errorf("ApplyFileConfigToRuntime AllowedDomains = %v, want local-only allowlist", cfg.AllowedDomains)
 	}
 	if !cfg.IDPI.StrictMode || !cfg.IDPI.ScanContent || !cfg.IDPI.WrapContent {
 		t.Errorf("ApplyFileConfigToRuntime IDPI = %+v, want strict+scan+wrap enabled", cfg.IDPI)

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -23,9 +23,7 @@ type RuntimeConfig struct {
 	AllowScreencast bool
 	AllowDownload   bool
 	// AllowedDomains is the unified per-instance allowlist sourced from
-	// security.allowedDomains in the file config. Consumers (IDPI guard,
-	// download handler, tab policy) should prefer this list over the
-	// deprecated IDPI.AllowedDomains duplicate.
+	// security.allowedDomains in the file config.
 	AllowedDomains         []string
 	DownloadAllowedDomains []string
 	DownloadMaxBytes       int
@@ -134,7 +132,6 @@ type DashboardSessionRuntimeConfig struct {
 // defense layer.
 type IDPIConfig struct {
 	Enabled        bool     `json:"enabled,omitempty"`
-	AllowedDomains []string `json:"allowedDomains,omitempty"`
 	StrictMode     bool     `json:"strictMode,omitempty"`
 	ScanContent    bool     `json:"scanContent,omitempty"`
 	WrapContent    bool     `json:"wrapContent,omitempty"`

--- a/internal/config/config_utils.go
+++ b/internal/config/config_utils.go
@@ -100,13 +100,7 @@ func effectiveSecurityAllowedDomains(s SecurityConfig) []string {
 	if len(s.AllowedDomains) > 0 {
 		return append([]string(nil), s.AllowedDomains...)
 	}
-	if len(s.IDPI.AllowedDomains) > 0 {
-		return append([]string(nil), s.IDPI.AllowedDomains...)
-	}
 	if s.AllowedDomains != nil {
-		return []string{}
-	}
-	if s.IDPI.AllowedDomains != nil {
 		return []string{}
 	}
 	return nil

--- a/internal/config/editor_get.go
+++ b/internal/config/editor_get.go
@@ -286,8 +286,6 @@ func getIDPIField(i *IDPIConfig, field string) (string, error) {
 	switch field {
 	case "enabled":
 		return strconv.FormatBool(i.Enabled), nil
-	case "allowedDomains":
-		return strings.Join(i.AllowedDomains, ","), nil
 	case "strictMode":
 		return strconv.FormatBool(i.StrictMode), nil
 	case "scanContent":

--- a/internal/config/editor_get_test.go
+++ b/internal/config/editor_get_test.go
@@ -58,7 +58,6 @@ func TestGetConfigValue_RoundTrip(t *testing.T) {
 		{"security.attach.enabled", "true", "true"},
 		{"security.idpi.enabled", "true", "true"},
 		{"security.allowedDomains", "localhost,example.com", "localhost,example.com"},
-		{"security.idpi.allowedDomains", "localhost,example.com", "localhost,example.com"},
 		{"security.idpi.strictMode", "false", "false"},
 		{"security.idpi.scanContent", "true", "true"},
 		{"security.idpi.wrapContent", "true", "true"},

--- a/internal/config/editor_set.go
+++ b/internal/config/editor_set.go
@@ -273,7 +273,6 @@ func setSecurityField(s *SecurityConfig, field, value string) error {
 	}
 	if field == "allowedDomains" {
 		s.AllowedDomains = parseCSVList(value)
-		s.IDPI.AllowedDomains = append([]string(nil), s.AllowedDomains...)
 		return nil
 	}
 	if field == "downloadAllowedDomains" {
@@ -468,9 +467,6 @@ func setIDPIField(s *SecurityConfig, field, value string) error {
 			return fmt.Errorf("security.idpi.enabled: %w", err)
 		}
 		i.Enabled = b
-	case "allowedDomains":
-		s.AllowedDomains = parseCSVList(value)
-		i.AllowedDomains = append([]string(nil), s.AllowedDomains...)
 	case "strictMode":
 		b, err := parseBool(value)
 		if err != nil {

--- a/internal/config/editor_set_test.go
+++ b/internal/config/editor_set_test.go
@@ -213,9 +213,6 @@ func TestSetConfigValue_IDPIFields(t *testing.T) {
 		wantErr bool
 	}{
 		{"security.idpi.enabled", "true", func(fc *FileConfig) bool { return fc.Security.IDPI.Enabled }, false},
-		{"security.idpi.allowedDomains", "localhost, example.com", func(fc *FileConfig) bool {
-			return len(fc.Security.IDPI.AllowedDomains) == 2 && fc.Security.IDPI.AllowedDomains[1] == "example.com"
-		}, false},
 		{"security.idpi.strictMode", "false", func(fc *FileConfig) bool { return !fc.Security.IDPI.StrictMode }, false},
 		{"security.idpi.scanContent", "true", func(fc *FileConfig) bool { return fc.Security.IDPI.ScanContent }, false},
 		{"security.idpi.wrapContent", "true", func(fc *FileConfig) bool { return fc.Security.IDPI.WrapContent }, false},
@@ -223,6 +220,7 @@ func TestSetConfigValue_IDPIFields(t *testing.T) {
 			return len(fc.Security.IDPI.CustomPatterns) == 2 && fc.Security.IDPI.CustomPatterns[0] == "ignore previous instructions"
 		}, false},
 		{"security.idpi.enabled", "maybe", nil, true},
+		{"security.idpi.allowedDomains", "localhost, example.com", nil, true},
 		{"security.idpi.unknown", "value", nil, true},
 	}
 
@@ -241,16 +239,13 @@ func TestSetConfigValue_IDPIFields(t *testing.T) {
 	}
 }
 
-func TestSetConfigValue_SecurityAllowedDomainsAlias(t *testing.T) {
+func TestSetConfigValue_SecurityAllowedDomains(t *testing.T) {
 	fc := &FileConfig{}
 	if err := SetConfigValue(fc, "security.allowedDomains", "localhost, example.com"); err != nil {
 		t.Fatalf("SetConfigValue(security.allowedDomains) error = %v", err)
 	}
 	if len(fc.Security.AllowedDomains) != 2 || fc.Security.AllowedDomains[1] != "example.com" {
-		t.Fatalf("security.allowedDomains = %v, want synced values", fc.Security.AllowedDomains)
-	}
-	if len(fc.Security.IDPI.AllowedDomains) != 2 || fc.Security.IDPI.AllowedDomains[1] != "example.com" {
-		t.Fatalf("security.idpi.allowedDomains alias = %v, want synced values", fc.Security.IDPI.AllowedDomains)
+		t.Fatalf("security.allowedDomains = %v, want parsed values", fc.Security.AllowedDomains)
 	}
 }
 

--- a/internal/config/fileio.go
+++ b/internal/config/fileio.go
@@ -137,7 +137,6 @@ func NormalizeFileConfigAliasesFromJSON(fc *FileConfig, data []byte) {
 
 	var raw rawConfig
 	if err := json.Unmarshal(data, &raw); err != nil || raw.Security == nil {
-		NormalizeFileConfigAliases(fc)
 		return
 	}
 
@@ -147,13 +146,4 @@ func NormalizeFileConfigAliasesFromJSON(fc *FileConfig, data []byte) {
 	case raw.Security.IDPI != nil && raw.Security.IDPI.AllowedDomains != nil:
 		fc.Security.AllowedDomains = append([]string(nil), (*raw.Security.IDPI.AllowedDomains)...)
 	}
-
-	NormalizeFileConfigAliases(fc)
-}
-
-func NormalizeFileConfigAliases(fc *FileConfig) {
-	if fc == nil {
-		return
-	}
-	fc.Security.IDPI.AllowedDomains = append([]string(nil), fc.Security.AllowedDomains...)
 }

--- a/internal/config/fileio_test.go
+++ b/internal/config/fileio_test.go
@@ -57,7 +57,6 @@ func TestLoadAndSaveFileConfigPreservesExplicitZeroValues(t *testing.T) {
 	fc.InstanceDefaults.UserAgent = ""
 	fc.Security.IDPI.StrictMode = false
 	fc.Security.AllowedDomains = []string{}
-	fc.Security.IDPI.AllowedDomains = []string{}
 	fc.Security.IDPI.CustomPatterns = []string{}
 	fc.Security.IDPI.ShieldThreshold = 30
 
@@ -75,9 +74,6 @@ func TestLoadAndSaveFileConfigPreservesExplicitZeroValues(t *testing.T) {
 	}
 	if loaded.Security.IDPI.StrictMode {
 		t.Errorf("loaded strictMode = %v, want false", loaded.Security.IDPI.StrictMode)
-	}
-	if len(loaded.Security.IDPI.AllowedDomains) != 0 {
-		t.Errorf("loaded allowedDomains = %v, want empty list", loaded.Security.IDPI.AllowedDomains)
 	}
 	if len(loaded.Security.AllowedDomains) != 0 {
 		t.Errorf("loaded security.allowedDomains = %v, want empty list", loaded.Security.AllowedDomains)
@@ -114,8 +110,5 @@ func TestLoadFileConfig_PromotesLegacyIDPIAllowedDomains(t *testing.T) {
 	}
 	if got := loaded.Security.AllowedDomains; len(got) != 2 || got[0] != "fixtures" || got[1] != "*.example.com" {
 		t.Fatalf("security.allowedDomains = %v, want promoted legacy values", got)
-	}
-	if got := loaded.Security.IDPI.AllowedDomains; len(got) != 2 || got[0] != "fixtures" || got[1] != "*.example.com" {
-		t.Fatalf("security.idpi.allowedDomains alias = %v, want synced legacy values", got)
 	}
 }

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -151,9 +151,7 @@ func ValidateFileConfig(fc *FileConfig) []error {
 	}
 
 	// IDPI validation
-	idpiCfg := fc.Security.IDPI
-	idpiCfg.AllowedDomains = effectiveSecurityAllowedDomains(fc.Security)
-	errs = append(errs, validateIDPIConfig(idpiCfg)...)
+	errs = append(errs, validateIDPIConfig(fc.Security.IDPI, effectiveSecurityAllowedDomains(fc.Security))...)
 	errs = append(errs, validateAllowedDomainList("security.downloadAllowedDomains", fc.Security.DownloadAllowedDomains)...)
 	errs = append(errs, validateTrustedCIDRList("security.trustedProxyCIDRs", fc.Security.TrustedProxyCIDRs)...)
 	errs = append(errs, validateTrustedCIDRList("security.trustedResolveCIDRs", fc.Security.TrustedResolveCIDRs)...)
@@ -332,12 +330,12 @@ func ValidStrategies() []string {
 
 // validateIDPIConfig validates the security.idpi sub-section.
 // Validation is skipped when IDPI is disabled; a zero-value IDPIConfig is always valid.
-func validateIDPIConfig(cfg IDPIConfig) []error {
+func validateIDPIConfig(cfg IDPIConfig, allowedDomains []string) []error {
 	if !cfg.Enabled {
 		return nil
 	}
 
-	errs := validateAllowedDomainList("security.allowedDomains", cfg.AllowedDomains)
+	errs := validateAllowedDomainList("security.allowedDomains", allowedDomains)
 
 	for _, p := range cfg.CustomPatterns {
 		if strings.TrimSpace(p) == "" {

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -521,9 +521,8 @@ func TestValidEnumValues(t *testing.T) {
 func TestValidateIDPIConfig_Disabled(t *testing.T) {
 	errs := validateIDPIConfig(IDPIConfig{
 		Enabled:        false,
-		AllowedDomains: []string{"", "  ", "file:///etc/passwd"},
 		CustomPatterns: []string{"", "  "},
-	})
+	}, []string{"", "  ", "file:///etc/passwd"})
 	if len(errs) != 0 {
 		t.Errorf("expected no errors when IDPI disabled, got: %v", errs)
 	}
@@ -534,9 +533,8 @@ func TestValidateIDPIConfig_Disabled(t *testing.T) {
 func TestValidateIDPIConfig_ValidConfig(t *testing.T) {
 	errs := validateIDPIConfig(IDPIConfig{
 		Enabled:        true,
-		AllowedDomains: []string{"example.com", "*.example.com", "*"},
 		CustomPatterns: []string{"exfiltrate this", "data leak"},
-	})
+	}, []string{"example.com", "*.example.com", "*"})
 	if len(errs) != 0 {
 		t.Errorf("expected no errors for valid IDPI config, got: %v", errs)
 	}
@@ -556,9 +554,8 @@ func TestValidateIDPIConfig_EmptyDomain(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			errs := validateIDPIConfig(IDPIConfig{
-				Enabled:        true,
-				AllowedDomains: []string{tc.domain},
-			})
+				Enabled: true,
+			}, []string{tc.domain})
 			if len(errs) == 0 {
 				t.Errorf("expected error for empty domain %q, got none", tc.domain)
 			}
@@ -573,9 +570,8 @@ func TestValidateIDPIConfig_EmptyDomain(t *testing.T) {
 // pattern containing internal spaces is rejected.
 func TestValidateIDPIConfig_DomainWithInternalWhitespace(t *testing.T) {
 	errs := validateIDPIConfig(IDPIConfig{
-		Enabled:        true,
-		AllowedDomains: []string{"example .com"},
-	})
+		Enabled: true,
+	}, []string{"example .com"})
 	if len(errs) == 0 {
 		t.Error("expected error for domain with internal whitespace, got none")
 	}
@@ -589,9 +585,8 @@ func TestValidateIDPIConfig_FileSchemeBlocked(t *testing.T) {
 		"file://localhost/etc/passwd",
 	} {
 		errs := validateIDPIConfig(IDPIConfig{
-			Enabled:        true,
-			AllowedDomains: []string{pattern},
-		})
+			Enabled: true,
+		}, []string{pattern})
 		if len(errs) == 0 {
 			t.Errorf("expected error for file:// pattern %q, got none", pattern)
 		}
@@ -763,7 +758,7 @@ func TestValidateIDPIConfig_EmptyCustomPattern(t *testing.T) {
 		errs := validateIDPIConfig(IDPIConfig{
 			Enabled:        true,
 			CustomPatterns: []string{p},
-		})
+		}, nil)
 		if len(errs) == 0 {
 			t.Errorf("expected error for empty custom pattern %q, got none", p)
 		}
@@ -778,9 +773,8 @@ func TestValidateIDPIConfig_EmptyCustomPattern(t *testing.T) {
 func TestValidateIDPIConfig_MultipleErrors(t *testing.T) {
 	errs := validateIDPIConfig(IDPIConfig{
 		Enabled:        true,
-		AllowedDomains: []string{"", "file:///bad"},
 		CustomPatterns: []string{"", "   "},
-	})
+	}, []string{"", "file:///bad"})
 	if len(errs) < 4 {
 		t.Errorf("expected at least 4 IDPI errors, got %d: %v", len(errs), errs)
 	}
@@ -791,9 +785,9 @@ func TestValidateIDPIConfig_MultipleErrors(t *testing.T) {
 func TestValidateFileConfig_IDPIPassthrough(t *testing.T) {
 	fc := &FileConfig{
 		Security: SecurityConfig{
+			AllowedDomains: []string{""}, // invalid
 			IDPI: IDPIConfig{
 				Enabled:        true,
-				AllowedDomains: []string{""},   // invalid
 				CustomPatterns: []string{"  "}, // invalid
 			},
 		},
@@ -811,7 +805,7 @@ func TestValidateIDPIConfig_ScanTimeoutSec(t *testing.T) {
 		errs := validateIDPIConfig(IDPIConfig{
 			Enabled:        true,
 			ScanTimeoutSec: -1,
-		})
+		}, nil)
 		if len(errs) == 0 {
 			t.Error("expected error for negative scanTimeoutSec, got none")
 		}
@@ -824,7 +818,7 @@ func TestValidateIDPIConfig_ScanTimeoutSec(t *testing.T) {
 		errs := validateIDPIConfig(IDPIConfig{
 			Enabled:        true,
 			ScanTimeoutSec: 0, // zero → use built-in default of 5s
-		})
+		}, nil)
 		if len(errs) != 0 {
 			t.Errorf("expected no error for scanTimeoutSec=0, got: %v", errs)
 		}
@@ -834,7 +828,7 @@ func TestValidateIDPIConfig_ScanTimeoutSec(t *testing.T) {
 		errs := validateIDPIConfig(IDPIConfig{
 			Enabled:        true,
 			ScanTimeoutSec: 10,
-		})
+		}, nil)
 		if len(errs) != 0 {
 			t.Errorf("expected no error for scanTimeoutSec=10, got: %v", errs)
 		}

--- a/internal/handlers/download.go
+++ b/internal/handlers/download.go
@@ -50,10 +50,9 @@ func (g *downloadURLGuard) isDomainAllowed(rawURL string) bool {
 		return false
 	}
 	result := idpi.CheckDomain(rawURL, config.IDPIConfig{
-		Enabled:        true,
-		AllowedDomains: append([]string(nil), g.allowedDomains...),
-		StrictMode:     true,
-	})
+		Enabled:    true,
+		StrictMode: true,
+	}, g.allowedDomains)
 	return !result.Blocked
 }
 
@@ -75,10 +74,9 @@ func (g *downloadURLGuard) Validate(rawURL string) error {
 	// Allowlisted domains bypass IP validation (e.g. internal docker hosts).
 	if len(g.allowedDomains) > 0 {
 		result := idpi.CheckDomain(rawURL, config.IDPIConfig{
-			Enabled:        true,
-			AllowedDomains: append([]string(nil), g.allowedDomains...),
-			StrictMode:     true,
-		})
+			Enabled:    true,
+			StrictMode: true,
+		}, g.allowedDomains)
 		if result.Blocked {
 			return fmt.Errorf("domain not allowed by security.downloadAllowedDomains")
 		}

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -53,7 +53,7 @@ func New(b bridge.BridgeAPI, cfg *config.RuntimeConfig, p bridge.ProfileService,
 		IdMgr:        ids.NewManager(),
 		Matcher:      matcher,
 		IntentCache:  intentCache,
-		IDPIGuard:    idpi.NewGuard(cfg.IDPI),
+		IDPIGuard:    idpi.NewGuard(cfg.IDPI, cfg.AllowedDomains),
 	}
 
 	// Wire up the recovery engine with callbacks that delegate back to

--- a/internal/handlers/navigation_test.go
+++ b/internal/handlers/navigation_test.go
@@ -274,10 +274,10 @@ func TestHandleNavigate_AllowsResolvedPrivateIPWhenIDPIAllowlisted(t *testing.T)
 
 	m := &mockBridge{}
 	h := New(m, &config.RuntimeConfig{
+		AllowedDomains: []string{"fixtures"},
 		IDPI: config.IDPIConfig{
-			Enabled:        true,
-			StrictMode:     true,
-			AllowedDomains: []string{"fixtures"},
+			Enabled:    true,
+			StrictMode: true,
 		},
 	}, nil, nil, nil)
 

--- a/internal/handlers/tab_policy.go
+++ b/internal/handlers/tab_policy.go
@@ -53,7 +53,7 @@ func (h *Handlers) enforceCurrentTabDomainPolicy(w http.ResponseWriter, r *http.
 		return "", false
 	}
 
-	state := bridge.EvaluateTabPolicy(currentURL, h.Config.IDPI)
+	state := bridge.EvaluateTabPolicy(currentURL, h.Config.IDPI, h.Config.AllowedDomains)
 	if setter, ok := h.Bridge.(tabPolicyStateSetter); ok {
 		setter.SetTabPolicyState(tabID, state)
 	}

--- a/internal/idpi/domain.go
+++ b/internal/idpi/domain.go
@@ -20,8 +20,8 @@ import (
 //   - "*.example.com" – matches any single subdomain of example.com but NOT
 //     example.com itself
 //   - "*"            – matches any host (effectively disables the whitelist)
-func CheckDomain(rawURL string, cfg config.IDPIConfig) CheckResult {
-	if !cfg.Enabled || len(cfg.AllowedDomains) == 0 {
+func CheckDomain(rawURL string, cfg config.IDPIConfig, allowedDomains []string) CheckResult {
+	if !cfg.Enabled || len(allowedDomains) == 0 {
 		return CheckResult{}
 	}
 	if isAllowedSpecialURL(rawURL) {
@@ -37,7 +37,7 @@ func CheckDomain(rawURL string, cfg config.IDPIConfig) CheckResult {
 			"URL has no domain component and cannot be verified against allowedDomains")
 	}
 
-	if domainAllowed(host, cfg.AllowedDomains) {
+	if domainAllowed(host, allowedDomains) {
 		return CheckResult{}
 	}
 
@@ -47,15 +47,15 @@ func CheckDomain(rawURL string, cfg config.IDPIConfig) CheckResult {
 
 // DomainAllowed reports whether rawURL's host matches an explicit allowedDomains
 // entry under an active IDPI domain allowlist.
-func DomainAllowed(rawURL string, cfg config.IDPIConfig) bool {
-	if !cfg.Enabled || len(cfg.AllowedDomains) == 0 || isAllowedSpecialURL(rawURL) {
+func DomainAllowed(rawURL string, cfg config.IDPIConfig, allowedDomains []string) bool {
+	if !cfg.Enabled || len(allowedDomains) == 0 || isAllowedSpecialURL(rawURL) {
 		return false
 	}
 	host := extractHost(rawURL)
 	if host == "" {
 		return false
 	}
-	return domainAllowed(host, cfg.AllowedDomains)
+	return domainAllowed(host, allowedDomains)
 }
 
 func isAllowedSpecialURL(rawURL string) bool {

--- a/internal/idpi/guard_factory.go
+++ b/internal/idpi/guard_factory.go
@@ -4,11 +4,11 @@ import "github.com/pinchtab/pinchtab/internal/config"
 
 // NewGuard creates the appropriate Guard implementation based on config.
 // Returns a ShieldGuard when IDPI is enabled, noopGuard otherwise.
-func NewGuard(cfg config.IDPIConfig) Guard {
+func NewGuard(cfg config.IDPIConfig, allowedDomains []string) Guard {
 	if !cfg.Enabled {
 		return noopGuard{}
 	}
-	return NewShieldGuard(cfg)
+	return NewShieldGuard(cfg, allowedDomains)
 }
 
 // noopGuard is a Guard that does nothing (IDPI disabled).

--- a/internal/idpi/guard_shield.go
+++ b/internal/idpi/guard_shield.go
@@ -10,12 +10,13 @@ import (
 // ShieldGuard uses the idpishield library for all IDPI scanning:
 // content analysis, domain checking, and content wrapping.
 type ShieldGuard struct {
-	shield *idpishield.Shield
-	cfg    config.IDPIConfig
+	shield         *idpishield.Shield
+	cfg            config.IDPIConfig
+	allowedDomains []string
 }
 
 // NewShieldGuard creates a guard backed by idpishield.
-func NewShieldGuard(cfg config.IDPIConfig) *ShieldGuard {
+func NewShieldGuard(cfg config.IDPIConfig, allowedDomains []string) *ShieldGuard {
 	mode := idpishield.ModeBalanced
 	if cfg.StrictMode {
 		mode = idpishield.ModeDeep
@@ -28,14 +29,15 @@ func NewShieldGuard(cfg config.IDPIConfig) *ShieldGuard {
 
 	shield := idpishield.New(idpishield.Config{
 		Mode:           mode,
-		AllowedDomains: cfg.AllowedDomains,
+		AllowedDomains: allowedDomains,
 		StrictMode:     cfg.StrictMode,
 		BlockThreshold: blockThreshold,
 	})
 
 	return &ShieldGuard{
-		shield: shield,
-		cfg:    cfg,
+		shield:         shield,
+		cfg:            cfg,
+		allowedDomains: append([]string(nil), allowedDomains...),
 	}
 }
 

--- a/internal/idpi/idpi_test.go
+++ b/internal/idpi/idpi_test.go
@@ -17,66 +17,58 @@ func enabledCfg(extra ...func(*config.IDPIConfig)) config.IDPIConfig {
 	return cfg
 }
 
+func allowedDomains(domains ...string) []string {
+	return append([]string(nil), domains...)
+}
+
 // ─── CheckDomain ──────────────────────────────────────────────────────────────
 
 func TestCheckDomain_DisabledAlwaysPasses(t *testing.T) {
-	cfg := config.IDPIConfig{Enabled: false, AllowedDomains: []string{"example.com"}}
-	if r := CheckDomain("https://evil.com", cfg); r.Threat {
+	cfg := config.IDPIConfig{Enabled: false}
+	if r := CheckDomain("https://evil.com", cfg, allowedDomains("example.com")); r.Threat {
 		t.Error("disabled IDPI should never flag a threat")
 	}
 }
 
 func TestCheckDomain_EmptyAllowedListAlwaysPasses(t *testing.T) {
 	cfg := enabledCfg() // no AllowedDomains
-	if r := CheckDomain("https://anything.example.com", cfg); r.Threat {
+	if r := CheckDomain("https://anything.example.com", cfg, nil); r.Threat {
 		t.Error("empty allowedDomains should pass all domains")
 	}
 }
 
 func TestCheckDomain_ExactMatchAllowed(t *testing.T) {
-	cfg := enabledCfg(func(c *config.IDPIConfig) {
-		c.AllowedDomains = []string{"example.com"}
-	})
-	if r := CheckDomain("https://example.com/path", cfg); r.Threat {
+	cfg := enabledCfg()
+	if r := CheckDomain("https://example.com/path", cfg, allowedDomains("example.com")); r.Threat {
 		t.Errorf("exact allowed domain should pass, got reason=%q", r.Reason)
 	}
 }
 
 func TestCheckDomain_ExactMatchBlocked(t *testing.T) {
-	cfg := enabledCfg(func(c *config.IDPIConfig) {
-		c.AllowedDomains = []string{"example.com"}
-	})
-	r := CheckDomain("https://evil.com", cfg)
+	cfg := enabledCfg()
+	r := CheckDomain("https://evil.com", cfg, allowedDomains("example.com"))
 	if !r.Threat {
 		t.Error("domain not in list should be flagged as threat")
 	}
 }
 
 func TestCheckDomain_WildcardMatchesSubdomain(t *testing.T) {
-	cfg := enabledCfg(func(c *config.IDPIConfig) {
-		c.AllowedDomains = []string{"*.example.com"}
-	})
-	if r := CheckDomain("https://api.example.com", cfg); r.Threat {
+	cfg := enabledCfg()
+	if r := CheckDomain("https://api.example.com", cfg, allowedDomains("*.example.com")); r.Threat {
 		t.Errorf("wildcard should allow subdomains, got reason=%q", r.Reason)
 	}
 }
 
 func TestCheckDomain_WildcardDoesNotMatchApex(t *testing.T) {
-	cfg := enabledCfg(func(c *config.IDPIConfig) {
-		c.AllowedDomains = []string{"*.example.com"}
-	})
 	// "*.example.com" must NOT match "example.com" itself
-	if r := CheckDomain("https://example.com", cfg); !r.Threat {
+	if r := CheckDomain("https://example.com", enabledCfg(), allowedDomains("*.example.com")); !r.Threat {
 		t.Error("wildcard pattern should NOT match the apex domain")
 	}
 }
 
 func TestCheckDomain_WildcardDoesNotMatchDeepSubdomain(t *testing.T) {
-	cfg := enabledCfg(func(c *config.IDPIConfig) {
-		c.AllowedDomains = []string{"*.example.com"}
-	})
 	// "*.example.com" must NOT match "a.b.example.com" — it's a single-level wildcard
-	if r := CheckDomain("https://a.b.example.com", cfg); r.Threat {
+	if r := CheckDomain("https://a.b.example.com", enabledCfg(), allowedDomains("*.example.com")); r.Threat {
 		// Actually this DOES match because strings.HasSuffix("a.b.example.com", ".example.com") is true.
 		// Our spec: single-level wildcard allows any depth of subdomain since we use HasSuffix.
 		// This test verifies it is consistent with the documented behaviour.
@@ -85,20 +77,16 @@ func TestCheckDomain_WildcardDoesNotMatchDeepSubdomain(t *testing.T) {
 }
 
 func TestCheckDomain_GlobalWildcardAllowsAll(t *testing.T) {
-	cfg := enabledCfg(func(c *config.IDPIConfig) {
-		c.AllowedDomains = []string{"*"}
-	})
-	if r := CheckDomain("https://attacker.com", cfg); r.Threat {
+	if r := CheckDomain("https://attacker.com", enabledCfg(), allowedDomains("*")); r.Threat {
 		t.Error("global wildcard * should allow all domains")
 	}
 }
 
 func TestCheckDomain_StrictModeBlocks(t *testing.T) {
 	cfg := enabledCfg(func(c *config.IDPIConfig) {
-		c.AllowedDomains = []string{"example.com"}
 		c.StrictMode = true
 	})
-	r := CheckDomain("https://evil.com", cfg)
+	r := CheckDomain("https://evil.com", cfg, allowedDomains("example.com"))
 	if !r.Threat || !r.Blocked {
 		t.Errorf("strict mode: want Threat=true Blocked=true, got Threat=%v Blocked=%v", r.Threat, r.Blocked)
 	}
@@ -106,48 +94,37 @@ func TestCheckDomain_StrictModeBlocks(t *testing.T) {
 
 func TestCheckDomain_WarnModeDoesNotBlock(t *testing.T) {
 	cfg := enabledCfg(func(c *config.IDPIConfig) {
-		c.AllowedDomains = []string{"example.com"}
 		c.StrictMode = false
 	})
-	r := CheckDomain("https://evil.com", cfg)
+	r := CheckDomain("https://evil.com", cfg, allowedDomains("example.com"))
 	if !r.Threat || r.Blocked {
 		t.Errorf("warn mode: want Threat=true Blocked=false, got Threat=%v Blocked=%v", r.Threat, r.Blocked)
 	}
 }
 
 func TestCheckDomain_CaseInsensitive(t *testing.T) {
-	cfg := enabledCfg(func(c *config.IDPIConfig) {
-		c.AllowedDomains = []string{"Example.COM"}
-	})
-	if r := CheckDomain("https://EXAMPLE.com/page", cfg); r.Threat {
+	if r := CheckDomain("https://EXAMPLE.com/page", enabledCfg(), allowedDomains("Example.COM")); r.Threat {
 		t.Error("domain matching should be case-insensitive")
 	}
 }
 
 func TestCheckDomain_BareHostname(t *testing.T) {
-	cfg := enabledCfg(func(c *config.IDPIConfig) {
-		c.AllowedDomains = []string{"example.com"}
-	})
 	// "example.com" without a scheme — Chrome prepends https:// so we support it
-	if r := CheckDomain("example.com", cfg); r.Threat {
+	if r := CheckDomain("example.com", enabledCfg(), allowedDomains("example.com")); r.Threat {
 		t.Errorf("bare hostname should be matched: got reason=%q", r.Reason)
 	}
 }
 
 func TestCheckDomain_WithPort(t *testing.T) {
-	cfg := enabledCfg(func(c *config.IDPIConfig) {
-		c.AllowedDomains = []string{"localhost"}
-	})
 	// Port should be stripped before matching
-	if r := CheckDomain("http://localhost:9867/action", cfg); r.Threat {
+	if r := CheckDomain("http://localhost:9867/action", enabledCfg(), allowedDomains("localhost")); r.Threat {
 		t.Errorf("port should be stripped for domain matching: got reason=%q", r.Reason)
 	}
 }
 
 func TestCheckDomain_MultiplePatterns_FirstMatch(t *testing.T) {
-	cfg := enabledCfg(func(c *config.IDPIConfig) {
-		c.AllowedDomains = []string{"github.com", "*.github.com", "example.com"}
-	})
+	cfg := enabledCfg()
+	domains := allowedDomains("github.com", "*.github.com", "example.com")
 	cases := []struct {
 		url    string
 		threat bool
@@ -158,7 +135,7 @@ func TestCheckDomain_MultiplePatterns_FirstMatch(t *testing.T) {
 		{"https://evil.org", true},
 	}
 	for _, tc := range cases {
-		r := CheckDomain(tc.url, cfg)
+		r := CheckDomain(tc.url, cfg, domains)
 		if r.Threat != tc.threat {
 			t.Errorf("url=%q: want threat=%v got %v (reason=%q)", tc.url, tc.threat, r.Threat, r.Reason)
 		}
@@ -166,10 +143,7 @@ func TestCheckDomain_MultiplePatterns_FirstMatch(t *testing.T) {
 }
 
 func TestCheckDomain_ReasonContainsDomain(t *testing.T) {
-	cfg := enabledCfg(func(c *config.IDPIConfig) {
-		c.AllowedDomains = []string{"example.com"}
-	})
-	r := CheckDomain("https://attacker.io", cfg)
+	r := CheckDomain("https://attacker.io", enabledCfg(), allowedDomains("example.com"))
 	if !strings.Contains(r.Reason, "attacker.io") {
 		t.Errorf("reason should mention the blocked domain, got: %q", r.Reason)
 	}
@@ -178,15 +152,14 @@ func TestCheckDomain_ReasonContainsDomain(t *testing.T) {
 // TestCheckDomain_NoHostURLHandling verifies that only explicitly allowed
 // special URLs bypass the whitelist; other no-host URLs remain blocked.
 func TestCheckDomain_NoHostURLHandling(t *testing.T) {
-	cfg := enabledCfg(func(c *config.IDPIConfig) {
-		c.AllowedDomains = []string{"example.com"}
-	})
+	cfg := enabledCfg()
+	domains := allowedDomains("example.com")
 	allowedNoHostURLs := []string{
 		"about:blank",
 		" ABOUT:BLANK ",
 	}
 	for _, u := range allowedNoHostURLs {
-		r := CheckDomain(u, cfg)
+		r := CheckDomain(u, cfg, domains)
 		if r.Threat {
 			t.Errorf("URL %q should be explicitly allowed despite having no domain", u)
 		}
@@ -198,7 +171,7 @@ func TestCheckDomain_NoHostURLHandling(t *testing.T) {
 		"data:text/html,<h1>x</h1>",
 	}
 	for _, u := range blockedNoHostURLs {
-		r := CheckDomain(u, cfg)
+		r := CheckDomain(u, cfg, domains)
 		if !r.Threat {
 			t.Errorf("URL %q has no domain and active whitelist — must be treated as a threat", u)
 		}
@@ -209,29 +182,28 @@ func TestCheckDomain_NoHostURLHandling(t *testing.T) {
 // empty (feature disabled), even no-host URLs are allowed through.
 func TestCheckDomain_EmptyListAllowsNoHost(t *testing.T) {
 	cfg := enabledCfg() // no AllowedDomains
-	if r := CheckDomain("file:///local/path", cfg); r.Threat {
+	if r := CheckDomain("file:///local/path", cfg, nil); r.Threat {
 		t.Error("empty allowedDomains should pass all URLs including no-host ones")
 	}
 }
 
 func TestDomainAllowed(t *testing.T) {
-	cfg := enabledCfg(func(c *config.IDPIConfig) {
-		c.AllowedDomains = []string{"fixtures", "*.example.com"}
-	})
+	cfg := enabledCfg()
+	domains := allowedDomains("fixtures", "*.example.com")
 
-	if !DomainAllowed("http://fixtures:80/index.html", cfg) {
+	if !DomainAllowed("http://fixtures:80/index.html", cfg, domains) {
 		t.Fatal("expected fixtures to match explicit allowlist")
 	}
-	if !DomainAllowed("https://api.example.com", cfg) {
+	if !DomainAllowed("https://api.example.com", cfg, domains) {
 		t.Fatal("expected wildcard subdomain to match explicit allowlist")
 	}
-	if DomainAllowed("https://evil.com", cfg) {
+	if DomainAllowed("https://evil.com", cfg, domains) {
 		t.Fatal("unexpected allowlist match for evil.com")
 	}
-	if DomainAllowed("about:blank", cfg) {
+	if DomainAllowed("about:blank", cfg, domains) {
 		t.Fatal("special URLs should not count as explicit allowlist matches")
 	}
-	if DomainAllowed("http://fixtures:80/index.html", config.IDPIConfig{}) {
+	if DomainAllowed("http://fixtures:80/index.html", config.IDPIConfig{}, nil) {
 		t.Fatal("disabled/empty IDPI config should not report explicit allowlist matches")
 	}
 }
@@ -241,8 +213,8 @@ func TestDomainAllowed(t *testing.T) {
 // --- Guard wiring tests (config flags + WrapContent format) ---
 // Content scanning correctness is tested in idpishield's own test suite.
 
-func newGuard(cfg config.IDPIConfig) Guard {
-	return NewGuard(cfg)
+func newGuard(cfg config.IDPIConfig, allowedDomains ...string) Guard {
+	return NewGuard(cfg, allowedDomains)
 }
 
 func TestGuard_ScanContent_DisabledAlwaysPasses(t *testing.T) {


### PR DESCRIPTION
## Summary
- remove the active `security.idpi.allowedDomains` alias from runtime/config-editor/wizard paths so `security.allowedDomains` is the single supported allowlist setting
- keep legacy file-loading compatibility by still normalizing old JSON configs onto `security.allowedDomains`
- update IDPI, tab-policy, download, and config tests to reflect the unified allowlist source of truth

## Why
PinchTab had effectively one real allowlist but multiple active config paths pointing at it. This cleanup makes `security.allowedDomains` the single supported setting in active config flows while still loading older config files safely.

## Validation
- `go test ./...`
