### PR TITLE
feat(observability): enrich activity events and expose retention settings

### DIFF
--- a/dashboard/src/pages/SettingsPage.tsx
+++ b/dashboard/src/pages/SettingsPage.tsx
@@ -18,6 +18,7 @@ import { ProfilesSettingsSection } from "./settings/ProfilesSettingsSection";
 import { SecurityIdpiSettingsSection } from "./settings/SecurityIdpiSettingsSection";
 import { SecuritySettingsSection } from "./settings/SecuritySettingsSection";
 import { AutoSolverSettingsSection } from "./settings/AutoSolverSettingsSection";
+import { ObservabilitySettingsSection } from "./settings/ObservabilitySettingsSection";
 import {
   backendSaveNotice,
   sections,
@@ -122,6 +123,13 @@ function renderActiveSection(
         <AutoSolverSettingsSection
           backendConfig={options.backendConfig}
           backendState={options.backendState}
+          updateBackendSection={options.updateBackendSection}
+        />
+      );
+    case "observability":
+      return (
+        <ObservabilitySettingsSection
+          backendConfig={options.backendConfig}
           updateBackendSection={options.updateBackendSection}
         />
       );

--- a/dashboard/src/pages/settings/ObservabilitySettingsSection.tsx
+++ b/dashboard/src/pages/settings/ObservabilitySettingsSection.tsx
@@ -1,0 +1,79 @@
+import type { BackendConfig } from "../../types";
+import type { UpdateBackendSection } from "./settingsShared";
+import { fieldClass } from "./settingsShared";
+import { SectionCard, SettingRow } from "./SettingsSharedComponents";
+
+interface ObservabilitySettingsSectionProps {
+  backendConfig: BackendConfig;
+  updateBackendSection: UpdateBackendSection;
+}
+
+export function ObservabilitySettingsSection({
+  backendConfig,
+  updateBackendSection,
+}: ObservabilitySettingsSectionProps) {
+  const activity = backendConfig.observability.activity;
+
+  const updateActivity = (
+    patch: Partial<BackendConfig["observability"]["activity"]>,
+  ) => {
+    updateBackendSection("observability", {
+      activity: { ...activity, ...patch },
+    });
+  };
+
+  return (
+    <SectionCard
+      title="Observability"
+      description="Activity logging tracks API requests for debugging and audit trails. Logs are stored locally and can be queried via the Activity page."
+    >
+      <SettingRow
+        label="Activity logging"
+        description="Enable or disable activity event recording."
+      >
+        <label className="flex cursor-pointer items-center gap-3">
+          <input
+            type="checkbox"
+            checked={activity.enabled}
+            onChange={(e) => updateActivity({ enabled: e.target.checked })}
+            className="h-4 w-4 rounded border-border-subtle bg-bg-elevated text-primary focus:ring-primary/50"
+          />
+          <span className="text-sm text-text-secondary">
+            {activity.enabled ? "Enabled" : "Disabled"}
+          </span>
+        </label>
+      </SettingRow>
+
+      <SettingRow
+        label="Retention (days)"
+        description="How long to keep activity logs before automatic cleanup. Longer retention uses more disk space but provides better audit history."
+      >
+        <input
+          type="number"
+          min={1}
+          max={365}
+          value={activity.retentionDays}
+          onChange={(e) =>
+            updateActivity({ retentionDays: Number(e.target.value) })
+          }
+          className={fieldClass}
+        />
+      </SettingRow>
+
+      <SettingRow
+        label="Session idle timeout (seconds)"
+        description="Time before an inactive agent session is considered idle. Used for grouping activity by session."
+      >
+        <input
+          type="number"
+          min={60}
+          value={activity.sessionIdleSec}
+          onChange={(e) =>
+            updateActivity({ sessionIdleSec: Number(e.target.value) })
+          }
+          className={fieldClass}
+        />
+      </SettingRow>
+    </SectionCard>
+  );
+}

--- a/dashboard/src/pages/settings/settingsShared.ts
+++ b/dashboard/src/pages/settings/settingsShared.ts
@@ -15,7 +15,8 @@ export type SectionId =
   | "network"
   | "browser"
   | "timeouts"
-  | "autosolver";
+  | "autosolver"
+  | "observability";
 
 export const sections: Array<{
   id: SectionId;
@@ -71,6 +72,11 @@ export const sections: Array<{
     id: "autosolver",
     label: "AutoSolver",
     description: "Challenge-solving behavior and config-file-backed providers.",
+  },
+  {
+    id: "observability",
+    label: "Observability",
+    description: "Activity logging and retention settings.",
   },
 ];
 

--- a/dashboard/src/types/index.ts
+++ b/dashboard/src/types/index.ts
@@ -284,7 +284,7 @@ export const defaultBackendConfig: BackendConfig = {
     activity: {
       enabled: true,
       sessionIdleSec: 1800,
-      retentionDays: 1,
+      retentionDays: 30,
       stateDir: "",
       events: {
         dashboard: false,

--- a/internal/activity/activity.go
+++ b/internal/activity/activity.go
@@ -15,7 +15,7 @@ import (
 const (
 	defaultQueryLimit    = 200
 	maxQueryLimit        = 1000
-	defaultRetentionDays = 1
+	defaultRetentionDays = 30
 )
 
 type Config struct {

--- a/internal/config/config_file.go
+++ b/internal/config/config_file.go
@@ -36,7 +36,7 @@ func DefaultFileConfig() FileConfig {
 	attachEnabled := false
 	activityEnabled := true
 	activitySessionIdleSec := 1800
-	activityRetentionDays := 1
+	activityRetentionDays := 30
 	activityDashboardEvents := false
 	activityServerEvents := false
 	activityBridgeEvents := false

--- a/internal/config/config_load.go
+++ b/internal/config/config_load.go
@@ -96,7 +96,7 @@ func Load() *RuntimeConfig {
 			Activity: ActivityConfig{
 				Enabled:        true,
 				SessionIdleSec: 1800,
-				RetentionDays:  1,
+				RetentionDays:  30,
 				StateDir:       "",
 			},
 		},

--- a/internal/config/config_load_test.go
+++ b/internal/config/config_load_test.go
@@ -100,8 +100,8 @@ func TestLoadConfigDefaults(t *testing.T) {
 	if !cfg.Observability.Activity.Enabled {
 		t.Errorf("default Observability.Activity.Enabled = %v, want true", cfg.Observability.Activity.Enabled)
 	}
-	if cfg.Observability.Activity.RetentionDays != 1 {
-		t.Errorf("default Observability.Activity.RetentionDays = %d, want 1", cfg.Observability.Activity.RetentionDays)
+	if cfg.Observability.Activity.RetentionDays != 30 {
+		t.Errorf("default Observability.Activity.RetentionDays = %d, want 30", cfg.Observability.Activity.RetentionDays)
 	}
 	if cfg.Observability.Activity.Events.Dashboard {
 		t.Errorf("default Observability.Activity.Events.Dashboard = %v, want false", cfg.Observability.Activity.Events.Dashboard)

--- a/internal/handlers/cache.go
+++ b/internal/handlers/cache.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/pinchtab/pinchtab/internal/activity"
 	"github.com/pinchtab/pinchtab/internal/httpx"
 )
 
@@ -23,6 +24,8 @@ func (h *Handlers) HandleCacheClear(w http.ResponseWriter, r *http.Request) {
 		httpx.Error(w, http.StatusInternalServerError, fmt.Errorf("clear cache: %w", err))
 		return
 	}
+
+	h.recordActivity(r, activity.Update{Action: "cache.clear"})
 
 	httpx.JSON(w, http.StatusOK, map[string]any{"status": "cleared"})
 }

--- a/internal/handlers/clipboard.go
+++ b/internal/handlers/clipboard.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/pinchtab/pinchtab/internal/activity"
 	"github.com/pinchtab/pinchtab/internal/httpx"
 )
 
@@ -63,6 +64,8 @@ func (h *Handlers) HandleClipboardRead(w http.ResponseWriter, r *http.Request) {
 
 	text := h.clipboard.Read()
 
+	h.recordActivity(r, activity.Update{Action: "clipboard.read"})
+
 	slog.Info("clipboard: read",
 		"textLen", len(text),
 		"remoteAddr", r.RemoteAddr,
@@ -102,6 +105,8 @@ func (h *Handlers) HandleClipboardWrite(w http.ResponseWriter, r *http.Request) 
 	}
 
 	h.clipboard.Write(*req.Text)
+
+	h.recordActivity(r, activity.Update{Action: "clipboard.write"})
 
 	slog.Info("clipboard: write",
 		"textLen", len(*req.Text),

--- a/internal/handlers/console.go
+++ b/internal/handlers/console.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/pinchtab/pinchtab/internal/activity"
 	"github.com/pinchtab/pinchtab/internal/bridge"
 	"github.com/pinchtab/pinchtab/internal/httpx"
 )
@@ -64,6 +65,9 @@ func (h *Handlers) HandleGetConsoleLogs(w http.ResponseWriter, r *http.Request) 
 	if logs == nil {
 		logs = make([]bridge.LogEntry, 0)
 	}
+
+	h.recordActivity(r, activity.Update{Action: "console.logs", TabID: tabID})
+
 	httpx.JSON(w, http.StatusOK, map[string]any{
 		"tabId":   tabID,
 		"console": logs,
@@ -78,6 +82,9 @@ func (h *Handlers) HandleClearConsoleLogs(w http.ResponseWriter, r *http.Request
 	}
 
 	h.Bridge.ClearConsoleLogs(tabID)
+
+	h.recordActivity(r, activity.Update{Action: "console.clear", TabID: tabID})
+
 	httpx.JSON(w, http.StatusOK, map[string]any{
 		"success": true,
 		"tabId":   tabID,
@@ -100,6 +107,9 @@ func (h *Handlers) HandleGetErrorLogs(w http.ResponseWriter, r *http.Request) {
 	if errors == nil {
 		errors = make([]bridge.ErrorEntry, 0)
 	}
+
+	h.recordActivity(r, activity.Update{Action: "errors.logs", TabID: tabID})
+
 	httpx.JSON(w, http.StatusOK, map[string]any{
 		"tabId":  tabID,
 		"errors": errors,
@@ -114,6 +124,9 @@ func (h *Handlers) HandleClearErrorLogs(w http.ResponseWriter, r *http.Request) 
 	}
 
 	h.Bridge.ClearErrorLogs(tabID)
+
+	h.recordActivity(r, activity.Update{Action: "errors.clear", TabID: tabID})
+
 	httpx.JSON(w, http.StatusOK, map[string]any{
 		"success": true,
 		"tabId":   tabID,

--- a/internal/handlers/cookies.go
+++ b/internal/handlers/cookies.go
@@ -14,6 +14,7 @@ import (
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/network"
 	"github.com/chromedp/chromedp"
+	"github.com/pinchtab/pinchtab/internal/activity"
 	"github.com/pinchtab/pinchtab/internal/httpx"
 )
 
@@ -59,6 +60,8 @@ func (h *Handlers) HandleGetCookies(w http.ResponseWriter, r *http.Request) {
 		}
 		cookies = filtered
 	}
+
+	h.recordActivity(r, activity.Update{Action: "cookies.read"})
 
 	result := make([]map[string]any, len(cookies))
 	for i, c := range cookies {
@@ -191,6 +194,8 @@ func (h *Handlers) HandleSetCookies(w http.ResponseWriter, r *http.Request) {
 			successCount++
 		}
 	}
+
+	h.recordActivity(r, activity.Update{Action: "cookies.write"})
 
 	httpx.JSON(w, 200, map[string]any{
 		"set":    successCount,

--- a/internal/handlers/dialog.go
+++ b/internal/handlers/dialog.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/pinchtab/pinchtab/internal/activity"
 	"github.com/pinchtab/pinchtab/internal/bridge"
 	"github.com/pinchtab/pinchtab/internal/httpx"
 )
@@ -89,6 +90,12 @@ func (h *Handlers) HandleTabDialog(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handlers) handleDialogAction(w http.ResponseWriter, r *http.Request, ctx context.Context, tabID string, accept bool, promptText string) {
+	action := "dialog.dismiss"
+	if accept {
+		action = "dialog.accept"
+	}
+	h.recordActivity(r, activity.Update{Action: action, TabID: tabID})
+
 	dm := h.Bridge.GetDialogManager()
 	if dm == nil {
 		httpx.Error(w, 500, fmt.Errorf("dialog manager not available"))

--- a/internal/handlers/download.go
+++ b/internal/handlers/download.go
@@ -24,6 +24,7 @@ import (
 	"github.com/chromedp/cdproto/fetch"
 	"github.com/chromedp/cdproto/network"
 	"github.com/chromedp/chromedp"
+	"github.com/pinchtab/pinchtab/internal/activity"
 	"github.com/pinchtab/pinchtab/internal/authn"
 	"github.com/pinchtab/pinchtab/internal/bridge"
 	"github.com/pinchtab/pinchtab/internal/config"
@@ -466,6 +467,7 @@ func (h *Handlers) HandleDownload(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			responseMIME = mime
+			h.recordActivity(r, activity.Update{Action: "download", URL: dlURL})
 			h.writeDownloadResponse(w, body, responseMIME, dlURL, output, filePath, raw, maxDownloadBytes)
 			return
 		}
@@ -512,6 +514,7 @@ func (h *Handlers) HandleDownload(w http.ResponseWriter, r *http.Request) {
 		httpx.Error(w, 500, fmt.Errorf("get response body: %w", err))
 		return
 	}
+	h.recordActivity(r, activity.Update{Action: "download", URL: dlURL})
 	h.writeDownloadResponse(w, body, responseMIME, dlURL, output, filePath, raw, maxDownloadBytes)
 }
 

--- a/internal/handlers/evaluate.go
+++ b/internal/handlers/evaluate.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/chromedp/cdproto/runtime"
 	"github.com/chromedp/chromedp"
+	"github.com/pinchtab/pinchtab/internal/activity"
 	"github.com/pinchtab/pinchtab/internal/httpx"
 )
 
@@ -74,6 +75,8 @@ func (h *Handlers) HandleEvaluate(w http.ResponseWriter, r *http.Request) {
 		httpx.Error(w, 500, fmt.Errorf("evaluate: %w", err))
 		return
 	}
+
+	h.recordActivity(r, activity.Update{Action: "evaluate"})
 
 	httpx.JSON(w, 200, map[string]any{"result": result})
 }

--- a/internal/handlers/find.go
+++ b/internal/handlers/find.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/chromedp/chromedp"
+	"github.com/pinchtab/pinchtab/internal/activity"
 	"github.com/pinchtab/pinchtab/internal/bridge"
 	"github.com/pinchtab/pinchtab/internal/httpx"
 	"github.com/pinchtab/semantic"
@@ -192,6 +193,8 @@ func (h *Handlers) HandleFind(w http.ResponseWriter, r *http.Request) {
 	if resp.Matches == nil {
 		resp.Matches = []semantic.ElementMatch{}
 	}
+
+	h.recordActivity(r, activity.Update{Action: "find"})
 
 	// Cache intent for recovery: store the query + best-match descriptor
 	// so the recovery engine can reconstruct a search if the ref goes stale.

--- a/internal/handlers/lock_shutdown.go
+++ b/internal/handlers/lock_shutdown.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/pinchtab/pinchtab/internal/activity"
 	"github.com/pinchtab/pinchtab/internal/authn"
 	"github.com/pinchtab/pinchtab/internal/bridge"
 	"github.com/pinchtab/pinchtab/internal/httpx"
@@ -40,6 +41,8 @@ func (h *Handlers) HandleTabLock(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	h.recordActivity(r, activity.Update{Action: "tab.lock", TabID: req.TabID})
+
 	lock := h.Bridge.TabLockInfo(req.TabID)
 	httpx.JSON(w, 200, map[string]any{
 		"locked":    true,
@@ -66,6 +69,8 @@ func (h *Handlers) HandleTabUnlock(w http.ResponseWriter, r *http.Request) {
 		httpx.Error(w, 409, err)
 		return
 	}
+
+	h.recordActivity(r, activity.Update{Action: "tab.unlock", TabID: req.TabID})
 
 	httpx.JSON(w, 200, map[string]any{"unlocked": true})
 }

--- a/internal/handlers/navigation.go
+++ b/internal/handlers/navigation.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/chromedp/cdproto/page"
 	"github.com/chromedp/chromedp"
+	"github.com/pinchtab/pinchtab/internal/activity"
 	"github.com/pinchtab/pinchtab/internal/bridge"
 	"github.com/pinchtab/pinchtab/internal/engine"
 	"github.com/pinchtab/pinchtab/internal/httpx"
@@ -431,6 +432,9 @@ func (h *Handlers) HandleTab(w http.ResponseWriter, r *http.Request) {
 			httpx.Error(w, 500, err)
 			return
 		}
+
+		h.recordActivity(r, activity.Update{Action: "tab.close", TabID: req.TabID})
+
 		httpx.JSON(w, 200, map[string]any{"closed": true})
 
 	case "focus":
@@ -442,6 +446,9 @@ func (h *Handlers) HandleTab(w http.ResponseWriter, r *http.Request) {
 			httpx.Error(w, 404, err)
 			return
 		}
+
+		h.recordActivity(r, activity.Update{Action: "tab.focus", TabID: req.TabID})
+
 		httpx.JSON(w, 200, map[string]any{"focused": true, "tabId": req.TabID})
 
 	default:

--- a/internal/handlers/state.go
+++ b/internal/handlers/state.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/chromedp/cdproto/network"
 	"github.com/chromedp/chromedp"
+	"github.com/pinchtab/pinchtab/internal/activity"
 	"github.com/pinchtab/pinchtab/internal/httpx"
 	"github.com/pinchtab/pinchtab/internal/state"
 )
@@ -37,6 +38,8 @@ func (h *Handlers) HandleStateList(w http.ResponseWriter, r *http.Request) {
 		httpx.Error(w, 500, fmt.Errorf("list states: %w", err))
 		return
 	}
+
+	h.recordActivity(r, activity.Update{Action: "state.list"})
 
 	httpx.JSON(w, 200, map[string]any{
 		"states": entries,
@@ -70,6 +73,8 @@ func (h *Handlers) HandleStateShow(w http.ResponseWriter, r *http.Request) {
 		httpx.Error(w, 500, fmt.Errorf("load state: %w", err))
 		return
 	}
+
+	h.recordActivity(r, activity.Update{Action: "state.show"})
 
 	httpx.JSON(w, 200, sf)
 }
@@ -239,6 +244,8 @@ func (h *Handlers) HandleStateSave(w http.ResponseWriter, r *http.Request) {
 		httpx.Error(w, 500, fmt.Errorf("save state: %w", err))
 		return
 	}
+
+	h.recordActivity(r, activity.Update{Action: "state.save"})
 
 	slog.Info("state saved",
 		"name", sf.Name,
@@ -413,6 +420,8 @@ func (h *Handlers) HandleStateLoad(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	h.recordActivity(r, activity.Update{Action: "state.load"})
+
 	slog.Info("state loaded",
 		"name", req.Name,
 		"path", path,
@@ -451,6 +460,8 @@ func (h *Handlers) HandleStateDelete(w http.ResponseWriter, r *http.Request) {
 		httpx.Error(w, 500, fmt.Errorf("delete state: %w", err))
 		return
 	}
+
+	h.recordActivity(r, activity.Update{Action: "state.delete"})
 
 	slog.Info("state deleted",
 		"name", name,
@@ -491,6 +502,8 @@ func (h *Handlers) HandleStateClean(w http.ResponseWriter, r *http.Request) {
 		httpx.Error(w, 500, fmt.Errorf("clean states: %w", err))
 		return
 	}
+
+	h.recordActivity(r, activity.Update{Action: "state.clean"})
 
 	slog.Info("state clean",
 		"olderThanHours", req.OlderThanHours,

--- a/internal/handlers/stealth.go
+++ b/internal/handlers/stealth.go
@@ -11,6 +11,7 @@ import (
 	"github.com/chromedp/cdproto/emulation"
 	"github.com/chromedp/cdproto/page"
 	"github.com/chromedp/chromedp"
+	"github.com/pinchtab/pinchtab/internal/activity"
 	"github.com/pinchtab/pinchtab/internal/httpx"
 )
 
@@ -96,6 +97,8 @@ func (h *Handlers) HandleFingerprintRotate(w http.ResponseWriter, r *http.Reques
 	if tracker, ok := h.Bridge.(interface{ SetFingerprintRotateActive(string, bool) }); ok {
 		tracker.SetFingerprintRotateActive(resolvedTabID, true)
 	}
+
+	h.recordActivity(r, activity.Update{Action: "fingerprint.rotate", TabID: resolvedTabID})
 
 	httpx.JSON(w, 200, map[string]any{
 		"fingerprint": fp,

--- a/internal/handlers/storage.go
+++ b/internal/handlers/storage.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/pinchtab/pinchtab/internal/activity"
 	"github.com/pinchtab/pinchtab/internal/httpx"
 )
 
@@ -82,6 +83,8 @@ func (h *Handlers) handleStorageGet(w http.ResponseWriter, r *http.Request) {
 		httpx.Error(w, 500, fmt.Errorf("parse storage result: %w", err))
 		return
 	}
+
+	h.recordActivity(r, activity.Update{Action: "storage.read"})
 
 	slog.Info("storage: get",
 		"type", storageType,
@@ -166,6 +169,8 @@ func (h *Handlers) handleStorageSet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	h.recordActivity(r, activity.Update{Action: "storage.write"})
+
 	slog.Info("storage: set",
 		"type", req.Type,
 		"key", req.Key,
@@ -243,6 +248,8 @@ func (h *Handlers) handleStorageDelete(w http.ResponseWriter, r *http.Request) {
 		httpx.Error(w, 500, fmt.Errorf("parse storage delete result: %w", err))
 		return
 	}
+
+	h.recordActivity(r, activity.Update{Action: "storage.delete"})
 
 	slog.Info("storage: delete",
 		"type", req.Type,

--- a/internal/handlers/upload.go
+++ b/internal/handlers/upload.go
@@ -14,6 +14,7 @@ import (
 	"github.com/chromedp/cdproto/dom"
 	"github.com/chromedp/cdproto/runtime"
 	"github.com/chromedp/chromedp"
+	"github.com/pinchtab/pinchtab/internal/activity"
 	"github.com/pinchtab/pinchtab/internal/httpx"
 )
 
@@ -158,6 +159,8 @@ func (h *Handlers) HandleUpload(w http.ResponseWriter, r *http.Request) {
 		httpx.Error(w, 500, fmt.Errorf("upload: %w", err))
 		return
 	}
+
+	h.recordActivity(r, activity.Update{Action: "upload", TabID: resolvedTabID})
 
 	httpx.JSON(w, 200, map[string]any{
 		"status": "ok",

--- a/internal/handlers/wait.go
+++ b/internal/handlers/wait.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/chromedp/chromedp"
+	"github.com/pinchtab/pinchtab/internal/activity"
 	"github.com/pinchtab/pinchtab/internal/httpx"
 )
 
@@ -139,6 +140,8 @@ func (h *Handlers) handleWaitCore(w http.ResponseWriter, r *http.Request, req wa
 		httpx.Error(w, 400, fmt.Errorf("one of selector, text, url, load, fn, or ms is required"))
 		return
 	}
+
+	h.recordActivity(r, activity.Update{Action: "wait." + mode, TabID: req.TabID})
 	if mode == "fn" && !h.evaluateEnabled() {
 		httpx.ErrorCode(w, 403, "evaluate_disabled", httpx.DisabledEndpointMessage("evaluate", "security.allowEvaluate"), false, map[string]any{
 			"setting": "security.allowEvaluate",


### PR DESCRIPTION
## Summary
- enrich activity events with more useful action/context metadata across navigation, evaluate, state, storage, upload, clipboard, wait, and related handlers
- expose observability activity settings in the dashboard so operators can manage activity enablement, retention days, and session idle timeout without editing config by hand
- keep observability config load/save behavior aligned with the dashboard settings surface

## Why
The existing activity log was useful but too thin in several important handler paths. This branch makes the audit/debug trail more informative while also making the core observability retention controls accessible in the dashboard.

## Validation
- `go test ./...`
