### PR TITLE
fix(instances): harden extension loading during instance launch

### DIFF
--- a/dashboard/src/components/molecules/StartInstanceModal.test.tsx
+++ b/dashboard/src/components/molecules/StartInstanceModal.test.tsx
@@ -75,7 +75,7 @@ describe("StartInstanceModal", () => {
 
     await waitFor(() => {
       expect(launchInstance).toHaveBeenCalledWith({
-        name: "alpha",
+        profileId: "prof_alpha",
         mode: "headed",
         port: undefined,
       });

--- a/dashboard/src/components/molecules/StartInstanceModal.tsx
+++ b/dashboard/src/components/molecules/StartInstanceModal.tsx
@@ -33,10 +33,10 @@ export default function StartInstanceModal({ open, profile, onClose }: Props) {
   }, [open, profile?.id, profile?.name]);
 
   const launchCommand = useMemo(() => {
-    if (!profile) return "";
+    if (!profile?.id) return "";
 
     const payload: LaunchInstanceRequest = {
-      profileId: profile.id || profile.name,
+      profileId: profile.id,
       mode: headless ? undefined : "headed",
       port: port.trim() || undefined,
     };
@@ -46,13 +46,17 @@ export default function StartInstanceModal({ open, profile, onClose }: Props) {
 
   const handleLaunch = async () => {
     if (!profile || launchLoading) return;
+    if (!profile.id) {
+      setLaunchError("Profile ID missing");
+      return;
+    }
 
     setLaunchError("");
     setLaunchLoading(true);
 
     try {
       const payload: LaunchInstanceRequest = {
-        name: profile.name,
+        profileId: profile.id,
         port: port.trim() || undefined,
         mode: headless ? undefined : "headed",
       };

--- a/dashboard/src/generated/types.ts
+++ b/dashboard/src/generated/types.ts
@@ -202,9 +202,7 @@ export interface InstanceMetrics {
  * LaunchInstanceRequest is the request body for launching an instance.
  */
 export interface LaunchInstanceRequest {
-  profileId?: string; // profile ID (prof_XXXXXXXX)
-  name?: string; // profile name
+  profileId?: string; // profile ID (prof_XXXXXXXX) or existing profile name
   mode?: string; // "headed" or empty for headless
   port?: string; // port number as string
-  extensionPaths?: string[]; // Chrome extension paths to load
 }

--- a/dashboard/src/pages/settings/BrowserSettingsSection.tsx
+++ b/dashboard/src/pages/settings/BrowserSettingsSection.tsx
@@ -61,7 +61,7 @@ export function BrowserSettingsSection({
       </SettingRow>
       <SettingRow
         label="Extension paths"
-        description="Comma-separated extension directories to load."
+        description="Comma-separated extension directories to load. By default, PinchTab uses the local extensions/ folder under its state/config directory. Set custom paths here to override that default, or clear the field to disable extension loading."
       >
         <input
           value={listToCsv(backendConfig.browser.extensionPaths)}

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -160,7 +160,7 @@ Current nested file-config shape:
     "version": "144.0.7559.133",
     "binary": "/path/to/chrome",
     "extraFlags": "--disable-gpu",
-    "extensionPaths": []
+    "extensionPaths": ["/path/to/pinchtab/extensions"]
   },
   "instanceDefaults": {
     "mode": "headless",
@@ -298,6 +298,14 @@ Use the dedicated config fields instead:
 - `browser.remoteDebuggingPort` for the remote debugging port
 
 For Linux container compatibility, use the runtime-managed path instead of `browser.extraFlags`. PinchTab enables `--no-sandbox` automatically when needed.
+
+By default, PinchTab looks for unpacked Chrome extensions in `<server.stateDir>/extensions`. On a normal local install that means the OS-specific PinchTab config directory plus `extensions/`, for example:
+
+- macOS: `~/Library/Application Support/pinchtab/extensions`
+- Linux: `~/.config/pinchtab/extensions`
+- Windows: `%APPDATA%\\pinchtab\\extensions`
+
+You can change or clear that default with `browser.extensionPaths`.
 
 ## Sections
 

--- a/docs/reference/instances.md
+++ b/docs/reference/instances.md
@@ -56,13 +56,13 @@ Request body:
 - `profileId`: optional; accepts a profile ID or an existing profile name
 - `mode`: optional; use `headed` for a visible browser, anything else is treated as headless
 - `port`: optional
-- `extensionPaths`: optional array of extension paths
 
 Notes:
 
 - if `profileId` is omitted, PinchTab creates an auto-generated temporary profile
 - if `port` is omitted, PinchTab allocates one from the configured instance port range
 - the CLI flag is `--profile`, even though the API field is `profileId`
+- request-supplied extension paths are rejected; configure `browser.extensionPaths` on the server instead. By default, PinchTab uses the local `extensions/` directory under its state/config folder.
 
 ### `POST /instances/launch`
 
@@ -79,12 +79,12 @@ Request body:
 - `profileId`: optional existing profile ID or existing profile name
 - `mode`: optional; `headed` or headless by default
 - `port`: optional
-- `extensionPaths`: optional array of extension paths
 
 Important:
 
 - `/instances/launch` does not read a `headless` field. Use `mode:"headed"` when you want a headed browser.
 - `name` is no longer supported on `/instances/launch`. Create the profile first via `POST /profiles`, then use the returned `id` as `profileId`.
+- request-supplied extension paths are rejected; configure `browser.extensionPaths` on the server instead. By default, PinchTab uses the local `extensions/` directory under its state/config folder.
 
 ## Get One Instance
 

--- a/internal/api/types/types.go
+++ b/internal/api/types/types.go
@@ -180,9 +180,7 @@ type InstanceMetrics struct {
 
 // LaunchInstanceRequest is the request body for launching an instance.
 type LaunchInstanceRequest struct {
-	ProfileID      string   `json:"profileId,omitempty"`      // profile ID (prof_XXXXXXXX)
-	Name           string   `json:"name,omitempty"`           // profile name
-	Mode           string   `json:"mode,omitempty"`           // "headed" or empty for headless
-	Port           string   `json:"port,omitempty"`           // port number as string
-	ExtensionPaths []string `json:"extensionPaths,omitempty"` // Chrome extension paths to load
+	ProfileID string `json:"profileId,omitempty"` // profile ID (prof_XXXXXXXX) or existing profile name
+	Mode      string `json:"mode,omitempty"`      // "headed" or empty for headless
+	Port      string `json:"port,omitempty"`      // port number as string
 }

--- a/internal/bridge/init_test.go
+++ b/internal/bridge/init_test.go
@@ -1,6 +1,8 @@
 package bridge
 
 import (
+	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
@@ -84,6 +86,43 @@ func TestBuildChromeArgsSanitizesUnsafeAndReservedExtraFlags(t *testing.T) {
 		if slices.Contains(args, forbidden) {
 			t.Fatalf("did not expect forbidden extra flag %q in %v", forbidden, args)
 		}
+	}
+}
+
+func TestBuildChromeArgsSkipsMissingExtensionPaths(t *testing.T) {
+	args := buildChromeArgs(&config.RuntimeConfig{
+		ExtensionPaths: []string{filepath.Join(t.TempDir(), "missing-extension")},
+	}, 9222)
+
+	if !slices.Contains(args, "--disable-extensions") {
+		t.Fatalf("expected missing extension paths to fall back to --disable-extensions, got %v", args)
+	}
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "--load-extension=") {
+			t.Fatalf("did not expect load-extension arg for missing path: %v", args)
+		}
+	}
+}
+
+func TestBuildChromeArgsIncludesExistingExtensionPaths(t *testing.T) {
+	extensionDir := filepath.Join(t.TempDir(), "extensions", "example")
+	if err := os.MkdirAll(extensionDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	args := buildChromeArgs(&config.RuntimeConfig{
+		ExtensionPaths: []string{extensionDir},
+	}, 9222)
+
+	found := false
+	for _, arg := range args {
+		if arg == "--load-extension="+extensionDir {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected load-extension arg for existing path in %v", args)
 	}
 }
 

--- a/internal/bridge/runtime/init.go
+++ b/internal/bridge/runtime/init.go
@@ -133,20 +133,12 @@ func setupAllocator(cfg *config.RuntimeConfig, bundle *stealth.Bundle, hooks Hoo
 		opts = append(opts, chromedp.Flag("headless", false))
 	}
 
-	if len(cfg.ExtensionPaths) > 0 {
-		var validPaths []string
-		for _, path := range cfg.ExtensionPaths {
-			if _, err := os.Stat(path); err == nil {
-				validPaths = append(validPaths, path)
-			}
-		}
-		if len(validPaths) > 0 {
-			joined := strings.Join(validPaths, ",")
-			opts = append(opts, chromedp.Flag("disable-extensions", false))
-			opts = append(opts, chromedp.Flag("load-extension", joined))
-			opts = append(opts, chromedp.Flag("disable-extensions-except", joined))
-			slog.Info("loading extensions", "paths", joined)
-		}
+	if validPaths := existingExtensionPaths(cfg.ExtensionPaths); len(validPaths) > 0 {
+		joined := strings.Join(validPaths, ",")
+		opts = append(opts, chromedp.Flag("disable-extensions", false))
+		opts = append(opts, chromedp.Flag("load-extension", joined))
+		opts = append(opts, chromedp.Flag("disable-extensions-except", joined))
+		slog.Info("loading extensions", "paths", joined)
 	} else {
 		opts = append(opts, chromedp.Flag("disable-extensions", true))
 	}
@@ -408,13 +400,26 @@ func BuildChromeArgs(cfg *config.RuntimeConfig, port int) []string {
 	return buildChromeArgsWithBundle(cfg, nil, port)
 }
 
+func existingExtensionPaths(paths []string) []string {
+	if len(paths) == 0 {
+		return nil
+	}
+	validPaths := make([]string, 0, len(paths))
+	for _, path := range paths {
+		if _, err := os.Stat(path); err == nil {
+			validPaths = append(validPaths, path)
+		}
+	}
+	return validPaths
+}
+
 func buildChromeArgsWithBundle(cfg *config.RuntimeConfig, bundle *stealth.Bundle, port int) []string {
 	bundle = ensureStealthBundle(cfg, bundle)
 	args := append([]string{fmt.Sprintf("--remote-debugging-port=%d", port)}, BaseChromeFlagArgs()...)
 	args = append(args, bundle.Launch.Args...)
 
-	if len(cfg.ExtensionPaths) > 0 {
-		joined := strings.Join(cfg.ExtensionPaths, ",")
+	if validPaths := existingExtensionPaths(cfg.ExtensionPaths); len(validPaths) > 0 {
+		joined := strings.Join(validPaths, ",")
 		args = append(args, "--load-extension="+joined, "--disable-extensions-except="+joined)
 	} else {
 		args = append(args, "--disable-extensions")

--- a/internal/config/config_file.go
+++ b/internal/config/config_file.go
@@ -58,7 +58,8 @@ func DefaultFileConfig() FileConfig {
 			StateDir: userConfigDir(),
 		},
 		Browser: BrowserConfig{
-			ChromeVersion: "144.0.7559.133",
+			ChromeVersion:  "144.0.7559.133",
+			ExtensionPaths: []string{defaultExtensionsDir(userConfigDir())},
 		},
 		InstanceDefaults: InstanceDefaultsConfig{
 			Mode:              "headless",

--- a/internal/config/config_file_test.go
+++ b/internal/config/config_file_test.go
@@ -28,6 +28,10 @@ func TestDefaultFileConfig(t *testing.T) {
 	if fc.Security.Attach.Enabled == nil || *fc.Security.Attach.Enabled {
 		t.Errorf("DefaultFileConfig.Security.Attach.Enabled = %v, want explicit false", formatBoolPtr(fc.Security.Attach.Enabled))
 	}
+	wantExtensionsDir := defaultExtensionsDir(userConfigDir())
+	if len(fc.Browser.ExtensionPaths) != 1 || fc.Browser.ExtensionPaths[0] != wantExtensionsDir {
+		t.Errorf("DefaultFileConfig.Browser.ExtensionPaths = %v, want [%q]", fc.Browser.ExtensionPaths, wantExtensionsDir)
+	}
 	if fc.Security.AllowEvaluate == nil || *fc.Security.AllowEvaluate {
 		t.Errorf("DefaultFileConfig.Security.AllowEvaluate = %v, want explicit false", formatBoolPtr(fc.Security.AllowEvaluate))
 	}
@@ -213,6 +217,10 @@ func TestDefaultFileConfigJSON(t *testing.T) {
 	}
 	if parsed.Security.AllowEvaluate == nil || *parsed.Security.AllowEvaluate {
 		t.Errorf("round-trip Security.AllowEvaluate = %v, want explicit false", formatBoolPtr(parsed.Security.AllowEvaluate))
+	}
+	wantExtensionsDir := defaultExtensionsDir(userConfigDir())
+	if len(parsed.Browser.ExtensionPaths) != 1 || parsed.Browser.ExtensionPaths[0] != wantExtensionsDir {
+		t.Errorf("round-trip Browser.ExtensionPaths = %v, want [%q]", parsed.Browser.ExtensionPaths, wantExtensionsDir)
 	}
 	if parsed.Security.AllowMacro == nil || *parsed.Security.AllowMacro {
 		t.Errorf("round-trip Security.AllowMacro = %v, want explicit false", formatBoolPtr(parsed.Security.AllowMacro))

--- a/internal/config/config_load.go
+++ b/internal/config/config_load.go
@@ -54,7 +54,7 @@ func Load() *RuntimeConfig {
 		MaxParallelTabs:   0,
 		ChromeBinary:      "", // Set via config.json only
 		ChromeExtraFlags:  "",
-		ExtensionPaths:    nil,
+		ExtensionPaths:    []string{defaultExtensionsDir(userConfigDir())},
 		UserAgent:         "",
 		NoAnimations:      false,
 		StealthLevel:      "light",
@@ -355,8 +355,8 @@ func applyFileConfig(cfg *RuntimeConfig, fc *FileConfig) {
 	if fc.Browser.ChromeExtraFlags != "" {
 		cfg.ChromeExtraFlags = SanitizeChromeExtraFlags(fc.Browser.ChromeExtraFlags)
 	}
-	if len(fc.Browser.ExtensionPaths) > 0 {
-		cfg.ExtensionPaths = fc.Browser.ExtensionPaths
+	if fc.Browser.ExtensionPaths != nil {
+		cfg.ExtensionPaths = append([]string(nil), fc.Browser.ExtensionPaths...)
 	}
 
 	// Instance defaults

--- a/internal/config/config_load_test.go
+++ b/internal/config/config_load_test.go
@@ -49,6 +49,10 @@ func TestLoadConfigDefaults(t *testing.T) {
 	if cfg.CookieSecure != nil {
 		t.Errorf("default CookieSecure = %v, want nil for auto-detect", *cfg.CookieSecure)
 	}
+	wantExtensionsDir := defaultExtensionsDir(userConfigDir())
+	if len(cfg.ExtensionPaths) != 1 || cfg.ExtensionPaths[0] != wantExtensionsDir {
+		t.Errorf("default ExtensionPaths = %v, want [%q]", cfg.ExtensionPaths, wantExtensionsDir)
+	}
 	if len(cfg.DownloadAllowedDomains) != 0 {
 		t.Errorf("default DownloadAllowedDomains = %v, want empty list", cfg.DownloadAllowedDomains)
 	}
@@ -468,6 +472,24 @@ func TestApplyFileConfigToRuntime_CopiesDownloadAllowedDomains(t *testing.T) {
 	}
 	if cfg.DownloadAllowedDomains[0] != "pinchtab.com" {
 		t.Fatalf("ApplyFileConfigToRuntime copied list = %v, want original values", cfg.DownloadAllowedDomains)
+	}
+}
+
+func TestApplyFileConfigToRuntime_AllowsExplicitEmptyExtensionPaths(t *testing.T) {
+	cfg := &RuntimeConfig{
+		StateDir:       userConfigDir(),
+		ExtensionPaths: []string{defaultExtensionsDir(userConfigDir())},
+	}
+	fc := &FileConfig{
+		Browser: BrowserConfig{
+			ExtensionPaths: []string{},
+		},
+	}
+
+	ApplyFileConfigToRuntime(cfg, fc)
+
+	if len(cfg.ExtensionPaths) != 0 {
+		t.Fatalf("ApplyFileConfigToRuntime ExtensionPaths = %v, want explicit empty list", cfg.ExtensionPaths)
 	}
 }
 

--- a/internal/config/config_utils.go
+++ b/internal/config/config_utils.go
@@ -59,6 +59,13 @@ func DefaultConfigPath() string {
 	return filepath.Join(userConfigDir(), "config.json")
 }
 
+func defaultExtensionsDir(baseDir string) string {
+	if strings.TrimSpace(baseDir) == "" {
+		baseDir = userConfigDir()
+	}
+	return filepath.Join(baseDir, "extensions")
+}
+
 func dirExists(path string) bool {
 	info, err := os.Stat(path)
 	if err != nil {

--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -254,6 +254,23 @@ func TestOpenAPIIncludesEvaluateAwaitPromiseSchema(t *testing.T) {
 	}
 }
 
+func TestHandleTabMetricsReturns404ForUnknownTab(t *testing.T) {
+	h := New(&mockBridge{failTab: true}, &config.RuntimeConfig{}, nil, nil, nil)
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux, nil)
+
+	req := httptest.NewRequest("GET", "/tabs/invalid_tab_id/metrics", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 from /tabs/{id}/metrics for unknown tab, got %d body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "tab not found") {
+		t.Fatalf("expected not-found response body, got %q", w.Body.String())
+	}
+}
+
 func TestHandleNavigate(t *testing.T) {
 	stubNavigateHostResolution(t, func(context.Context, string, string) ([]net.IP, error) {
 		return []net.IP{net.ParseIP("93.184.216.34")}, nil

--- a/internal/handlers/health_tabs.go
+++ b/internal/handlers/health_tabs.go
@@ -132,6 +132,11 @@ func (h *Handlers) HandleTabMetrics(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if _, _, err := h.Bridge.TabContext(tabID); err != nil {
+		httpx.Error(w, http.StatusNotFound, fmt.Errorf("tab not found"))
+		return
+	}
+
 	mem, err := h.Bridge.GetMemoryMetrics(tabID)
 	if err != nil {
 		httpx.Error(w, 500, fmt.Errorf("failed to get metrics: %w", err))

--- a/internal/orchestrator/handlers_instances.go
+++ b/internal/orchestrator/handlers_instances.go
@@ -237,6 +237,11 @@ func (o *Orchestrator) handleStartInstance(w http.ResponseWriter, r *http.Reques
 }
 
 func (o *Orchestrator) startInstanceWithRequest(w http.ResponseWriter, r *http.Request, req startInstanceRequest, auditEvent string) {
+	if len(req.ExtensionPaths) > 0 {
+		httpx.Error(w, 400, fmt.Errorf("extensionPaths are not supported on instance start requests; configure browser.extensionPaths on the server instead"))
+		return
+	}
+
 	var profileName string
 	var err error
 

--- a/internal/orchestrator/handlers_instances_test.go
+++ b/internal/orchestrator/handlers_instances_test.go
@@ -65,3 +65,35 @@ func TestHandleLaunchByNameAliasesStartSemantics(t *testing.T) {
 		t.Fatal("Headless = true, want false for mode=headed")
 	}
 }
+
+func TestHandleStartInstanceRejectsExtensionPaths(t *testing.T) {
+	o := NewOrchestratorWithRunner(t.TempDir(), &mockRunner{portAvail: true})
+
+	req := httptest.NewRequest(http.MethodPost, "/instances/start", strings.NewReader(`{"extensionPaths":["/tmp/malicious-ext"]}`))
+	w := httptest.NewRecorder()
+
+	o.handleStartInstance(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d body=%s", w.Code, http.StatusBadRequest, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "extensionPaths are not supported on instance start requests") {
+		t.Fatalf("body = %q, want extensionPaths rejection message", w.Body.String())
+	}
+}
+
+func TestHandleLaunchByNameRejectsExtensionPaths(t *testing.T) {
+	o := NewOrchestratorWithRunner(t.TempDir(), &mockRunner{portAvail: true})
+
+	req := httptest.NewRequest(http.MethodPost, "/instances/launch", strings.NewReader(`{"extensionPaths":["/tmp/malicious-ext"]}`))
+	w := httptest.NewRecorder()
+
+	o.handleLaunchByName(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d body=%s", w.Code, http.StatusBadRequest, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "extensionPaths are not supported on instance start requests") {
+		t.Fatalf("body = %q, want extensionPaths rejection message", w.Body.String())
+	}
+}

--- a/tests/e2e/scenarios/infra/system-basic.sh
+++ b/tests/e2e/scenarios/infra/system-basic.sh
@@ -251,55 +251,20 @@ fi
 
 end_test
 
-# --- T2: Instance start with extension via API ---
-start_test "Extension config: instance start accepts extensionPaths"
+# --- T2: Instance start rejects request-level extension injection ---
+start_test "Extension config: instance start rejects extensionPaths"
 
 pt_post /instances/start '{"extensionPaths":["/extensions/test-extension"]}'
-assert_ok "instance start with extension"
-INST_ID=$(echo "$RESULT" | jq -r '.id')
-INST_PORT=$(echo "$RESULT" | jq -r '.port')
-E2E_SERVER="http://pinchtab:${INST_PORT}"
-wait_for_instance_ready "${E2E_SERVER}"
-E2E_SERVER=$ORIG_URL
-
-assert_instance_logs_poll_all \
-  "$INST_ID" \
-  "API-started instance logs extension path" \
-  "loading extensions" \
-  "paths=/extensions/test-extension"
+assert_not_ok "instance start rejects extensionPaths"
+assert_contains "$RESULT" "extensionPaths are not supported" "extensionPaths rejection message"
 
 end_test
 
-# --- T3: Global + API injected extensions (Additive) ---
-start_test "Additive extensions: global + API paths merged"
+# --- T3: Launch alias also rejects request-level extension injection ---
+start_test "Extension config: launch alias rejects extensionPaths"
 
-pt_post /instances/start '{"extensionPaths":["/extensions/test-extension-api"]}'
-assert_ok "instance start"
-INST_ID=$(echo "$RESULT" | jq -r '.id')
-INST_PORT=$(echo "$RESULT" | jq -r '.port')
-
-E2E_SERVER="http://pinchtab:${INST_PORT}"
-
-wait_for_instance_ready "${E2E_SERVER}"
-
-pt_post /navigate "{\"url\":\"${FIXTURES_URL}/index.html\"}"
-assert_ok "navigate"
-assert_instance_logs_poll_all \
-  "$INST_ID" \
-  "child instance logs merged extension paths" \
-  "loading extensions" \
-  "paths=/extensions/test-extension,/extensions/test-extension-api"
-MERGE_PASS=$?
-
-assert_instance_logs_poll \
-  "$INST_ID" \
-  "chrome initialized successfully" \
-  "child instance chrome initialized"
-
-if [ $MERGE_PASS -ne 0 ]; then
-  print_extension_hints "$INST_ID"
-fi
-
-E2E_SERVER=$ORIG_URL
+pt_post /instances/launch '{"extensionPaths":["/extensions/test-extension-api"]}'
+assert_not_ok "launch rejects extensionPaths"
+assert_contains "$RESULT" "extensionPaths are not supported" "launch rejection message"
 
 end_test


### PR DESCRIPTION
## Summary
- reject request-supplied extension paths during instance start/launch and keep extension loading server-configured
- load only existing configured extension directories during Chrome startup so stale paths do not break launch
- introduce a predictable default local extensions directory under the PinchTab config/state area
- update dashboard/types/docs/tests to reflect the hardened instance launch behavior

## Why
Instance launch should not depend on request-time filesystem paths for Chrome extensions. This branch makes extension loading more predictable and safer by moving it fully under server configuration and by ignoring stale extension directories instead of letting them break startup.

## Validation
- `go test ./...`
