### PR TITLE
fix(engine): harden lite navigation and download fallback network guards

### DIFF
--- a/internal/engine/lite.go
+++ b/internal/engine/lite.go
@@ -69,7 +69,7 @@ func (l *LiteEngine) Navigate(ctx context.Context, url string) (*NavigateResult,
 	req.Header.Set("User-Agent", "Mozilla/5.0 (compatible; PinchTab-Lite/1.0)")
 	req.Header.Set("Accept", "text/html,application/xhtml+xml,*/*")
 
-	resp, err := l.client.Do(req)
+	resp, err := l.clientForNavigate(ctx).Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("lite navigate fetch: %w", err)
 	}

--- a/internal/engine/lite.go
+++ b/internal/engine/lite.go
@@ -55,7 +55,9 @@ func (l *LiteEngine) Navigate(ctx context.Context, url string) (*NavigateResult,
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
-	// Validate and sanitize URL to prevent SSRF (CodeQL go/request-forgery).
+	// Normalize the request URL for construction. SSRF enforcement happens
+	// before this call in the handler and again at redirect/dial time in
+	// clientForNavigate.
 	safeURL, err := urls.Sanitize(url)
 	if err != nil {
 		return nil, fmt.Errorf("lite navigate: %w", err)

--- a/internal/engine/lite_network.go
+++ b/internal/engine/lite_network.go
@@ -1,0 +1,168 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/netip"
+
+	"github.com/pinchtab/pinchtab/internal/netguard"
+)
+
+const liteDefaultMaxRedirects = 10
+
+var dialLiteAddress = func(ctx context.Context, network, addr string) (net.Conn, error) {
+	return (&net.Dialer{}).DialContext(ctx, network, addr)
+}
+
+func (l *LiteEngine) clientForNavigate(ctx context.Context) *http.Client {
+	policy := navigateNetworkPolicyFromContext(ctx)
+	if policy == nil {
+		return l.client
+	}
+
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.Proxy = nil
+	transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		return dialGuardedLiteAddress(ctx, network, addr, policy)
+	}
+
+	return &http.Client{
+		Timeout:   l.client.Timeout,
+		Transport: transport,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if exceededLiteRedirectLimit(len(via), policy.MaxRedirects) {
+				return fmt.Errorf("too many redirects")
+			}
+			return validateLiteRedirectTarget(req, policy)
+		},
+	}
+}
+
+func exceededLiteRedirectLimit(hops, maxRedirects int) bool {
+	if maxRedirects < 0 {
+		maxRedirects = liteDefaultMaxRedirects
+	}
+	return hops > maxRedirects
+}
+
+func validateLiteRedirectTarget(req *http.Request, policy *NavigateNetworkPolicy) error {
+	if req == nil || req.URL == nil || policy == nil || policy.AllowInternal {
+		return nil
+	}
+
+	host := req.URL.Hostname()
+	if host == "" {
+		return fmt.Errorf("redirect target missing host")
+	}
+	if netguard.IsLocalHost(host) {
+		return &NetworkPolicyBlockedError{Reason: fmt.Sprintf("redirect to blocked local host %s", host)}
+	}
+	if _, err := netguard.ResolveAndValidatePublicIPs(req.Context(), host); err != nil {
+		if errors.Is(err, netguard.ErrPrivateInternalIP) {
+			return &NetworkPolicyBlockedError{Reason: fmt.Sprintf("redirect to blocked private/internal host %s", host)}
+		}
+		return fmt.Errorf("redirect resolve %s: %w", host, err)
+	}
+	return nil
+}
+
+func dialGuardedLiteAddress(ctx context.Context, network, addr string, policy *NavigateNetworkPolicy) (net.Conn, error) {
+	if policy == nil || policy.AllowInternal {
+		return dialLiteAddress(ctx, network, addr)
+	}
+
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, err
+	}
+
+	ips, err := resolveLiteDialIPs(ctx, host, policy)
+	if err != nil {
+		return nil, err
+	}
+
+	var lastErr error
+	for _, ip := range ips {
+		conn, err := dialLiteAddress(ctx, network, net.JoinHostPort(ip.String(), port))
+		if err == nil {
+			return conn, nil
+		}
+		lastErr = err
+	}
+	if lastErr == nil {
+		lastErr = fmt.Errorf("no validated addresses for %s", host)
+	}
+	return nil, lastErr
+}
+
+func resolveLiteDialIPs(ctx context.Context, host string, policy *NavigateNetworkPolicy) ([]net.IP, error) {
+	if host == "" {
+		return nil, fmt.Errorf("missing host")
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		if err := validateLiteDialIP(ip, policy); err != nil {
+			return nil, err
+		}
+		return []net.IP{ip}, nil
+	}
+
+	ips, err := netguard.ResolveHostIPs(ctx, "ip", host)
+	if err != nil || len(ips) == 0 {
+		return nil, netguard.ErrResolveHost
+	}
+
+	seen := make(map[netip.Addr]struct{}, len(ips))
+	out := make([]net.IP, 0, len(ips))
+	for _, ip := range ips {
+		if err := validateLiteDialIP(ip, policy); err != nil {
+			return nil, err
+		}
+		addr, ok := netip.AddrFromSlice(ip)
+		if !ok {
+			return nil, &NetworkPolicyBlockedError{Reason: fmt.Sprintf("navigation connected to blocked remote IP %s", ip.String())}
+		}
+		addr = addr.Unmap()
+		if _, ok := seen[addr]; ok {
+			continue
+		}
+		seen[addr] = struct{}{}
+		out = append(out, ip)
+	}
+	return out, nil
+}
+
+func validateLiteDialIP(ip net.IP, policy *NavigateNetworkPolicy) error {
+	if policy == nil || policy.AllowInternal {
+		return nil
+	}
+	if err := netguard.ValidatePublicIP(ip); err == nil {
+		return nil
+	}
+
+	if ipInTrustedCIDRs(ip, policy.TrustedProxyCIDRs) {
+		return nil
+	}
+
+	if addr, ok := netip.AddrFromSlice(ip); ok {
+		addr = addr.Unmap()
+		for _, trusted := range policy.TrustedResolvedIP {
+			if trusted == addr {
+				return nil
+			}
+		}
+	}
+
+	return &NetworkPolicyBlockedError{Reason: fmt.Sprintf("navigation connected to blocked remote IP %s", ip.String())}
+}
+
+func ipInTrustedCIDRs(ip net.IP, trusted []*net.IPNet) bool {
+	for _, cidr := range trusted {
+		if cidr.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/engine/lite_test.go
+++ b/internal/engine/lite_test.go
@@ -2,10 +2,14 @@ package engine
 
 import (
 	"context"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/netip"
 	"strings"
 	"testing"
+
+	"github.com/pinchtab/pinchtab/internal/netguard"
 )
 
 func newTestServer(body string) *httptest.Server {
@@ -225,6 +229,72 @@ func TestLiteEngine_ScriptStyleSkipped(t *testing.T) {
 		if n.Tag == "script" || n.Tag == "style" {
 			t.Errorf("snapshot should skip %s elements", n.Tag)
 		}
+	}
+}
+
+func TestLiteEngine_NavigateBlocksRedirectToPrivateIP(t *testing.T) {
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://169.254.169.254/latest/meta-data/", http.StatusFound)
+	}))
+	defer redirector.Close()
+
+	oldDial := dialLiteAddress
+	dialLiteAddress = func(ctx context.Context, network, _ string) (net.Conn, error) {
+		return (&net.Dialer{}).DialContext(ctx, network, redirector.Listener.Addr().String())
+	}
+	t.Cleanup(func() { dialLiteAddress = oldDial })
+
+	oldResolve := netguard.ResolveHostIPs
+	netguard.ResolveHostIPs = func(context.Context, string, string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("93.184.216.34")}, nil
+	}
+	t.Cleanup(func() { netguard.ResolveHostIPs = oldResolve })
+
+	lite := NewLiteEngine()
+	defer func() { _ = lite.Close() }()
+
+	ctx := WithNavigateNetworkPolicy(context.Background(), &NavigateNetworkPolicy{MaxRedirects: -1})
+	_, err := lite.Navigate(ctx, "http://safe.example/index.html")
+	if err == nil {
+		t.Fatal("expected redirect to private IP to be blocked")
+	}
+	if !IsNetworkPolicyBlocked(err) {
+		t.Fatalf("expected network policy block, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "redirect to blocked") {
+		t.Fatalf("expected redirect block error, got %v", err)
+	}
+}
+
+func TestLiteEngine_NavigateAllowsTrustedResolvedPrivateIP(t *testing.T) {
+	page := newTestServer(`<html><head><title>Trusted</title></head><body>ok</body></html>`)
+	defer page.Close()
+
+	oldDial := dialLiteAddress
+	dialLiteAddress = func(ctx context.Context, network, _ string) (net.Conn, error) {
+		return (&net.Dialer{}).DialContext(ctx, network, page.Listener.Addr().String())
+	}
+	t.Cleanup(func() { dialLiteAddress = oldDial })
+
+	oldResolve := netguard.ResolveHostIPs
+	netguard.ResolveHostIPs = func(context.Context, string, string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("10.0.0.5")}, nil
+	}
+	t.Cleanup(func() { netguard.ResolveHostIPs = oldResolve })
+
+	lite := NewLiteEngine()
+	defer func() { _ = lite.Close() }()
+
+	ctx := WithNavigateNetworkPolicy(context.Background(), &NavigateNetworkPolicy{
+		TrustedResolvedIP: []netip.Addr{netip.MustParseAddr("10.0.0.5")},
+		MaxRedirects:      -1,
+	})
+	result, err := lite.Navigate(ctx, "http://trusted.example/index.html")
+	if err != nil {
+		t.Fatalf("expected trusted resolved IP to be allowed, got %v", err)
+	}
+	if result.Title != "Trusted" {
+		t.Fatalf("title = %q, want Trusted", result.Title)
 	}
 }
 

--- a/internal/engine/navigate_policy.go
+++ b/internal/engine/navigate_policy.go
@@ -1,0 +1,51 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/netip"
+)
+
+// NavigateNetworkPolicy carries per-request network validation settings for
+// engines that perform server-side HTTP fetches.
+type NavigateNetworkPolicy struct {
+	AllowInternal     bool
+	TrustedProxyCIDRs []*net.IPNet
+	TrustedResolvedIP []netip.Addr
+	MaxRedirects      int
+}
+
+type navigateNetworkPolicyKey struct{}
+
+// WithNavigateNetworkPolicy attaches navigation network policy to a context.
+func WithNavigateNetworkPolicy(ctx context.Context, policy *NavigateNetworkPolicy) context.Context {
+	if policy == nil {
+		return ctx
+	}
+	clone := &NavigateNetworkPolicy{
+		AllowInternal:     policy.AllowInternal,
+		TrustedProxyCIDRs: append([]*net.IPNet(nil), policy.TrustedProxyCIDRs...),
+		TrustedResolvedIP: append([]netip.Addr(nil), policy.TrustedResolvedIP...),
+		MaxRedirects:      policy.MaxRedirects,
+	}
+	return context.WithValue(ctx, navigateNetworkPolicyKey{}, clone)
+}
+
+func navigateNetworkPolicyFromContext(ctx context.Context) *NavigateNetworkPolicy {
+	policy, _ := ctx.Value(navigateNetworkPolicyKey{}).(*NavigateNetworkPolicy)
+	return policy
+}
+
+// NetworkPolicyBlockedError reports a navigation blocked by SSRF protections.
+type NetworkPolicyBlockedError struct {
+	Reason string
+}
+
+func (e *NetworkPolicyBlockedError) Error() string { return e.Reason }
+
+// IsNetworkPolicyBlocked reports whether err is a network policy block.
+func IsNetworkPolicyBlocked(err error) bool {
+	var target *NetworkPolicyBlockedError
+	return errors.As(err, &target)
+}

--- a/internal/handlers/download.go
+++ b/internal/handlers/download.go
@@ -43,6 +43,17 @@ func newDownloadURLGuard(allowedDomains []string) *downloadURLGuard {
 	return &downloadURLGuard{allowedDomains: append([]string(nil), allowedDomains...)}
 }
 
+func (g *downloadURLGuard) isHostAllowed(host string) bool {
+	if len(g.allowedDomains) == 0 {
+		return false
+	}
+	host = netguard.NormalizeHost(host)
+	if host == "" {
+		return false
+	}
+	return g.isDomainAllowed("https://" + host)
+}
+
 // isDomainAllowed reports whether rawURL's domain is on the configured
 // allowlist. Allowlisted domains bypass private-IP checks because they
 // are explicitly trusted by the operator (e.g. internal docker hosts).
@@ -451,7 +462,7 @@ func (h *Handlers) HandleDownload(w http.ResponseWriter, r *http.Request) {
 		// Fall back to a direct Go HTTP fetch using the browser's cookies.
 		if isNavigationAborted(err) {
 			slog.Info("download: Chrome navigation aborted, falling back to direct fetch", "url", dlURL)
-			body, mime, status, fetchErr := h.fetchDirectWithCookies(tCtx, browserCtx, dlURL, maxDownloadBytes)
+			body, mime, status, fetchErr := h.fetchDirectWithCookies(tCtx, browserCtx, dlURL, validator, maxDownloadBytes)
 			if fetchErr != nil {
 				// Return 400 for redirect-blocked errors (SSRF protection)
 				errMsg := fetchErr.Error()
@@ -583,7 +594,7 @@ func (h *Handlers) writeDownloadResponse(w http.ResponseWriter, body []byte, mim
 
 // fetchDirectWithCookies performs a Go HTTP fetch with browser cookies.
 // Fallback for when Chrome navigation aborts (e.g. .gz files).
-func (h *Handlers) fetchDirectWithCookies(ctx context.Context, browserCtx context.Context, dlURL string, maxBytes int) (body []byte, contentType string, statusCode int, err error) {
+func (h *Handlers) fetchDirectWithCookies(ctx context.Context, browserCtx context.Context, dlURL string, validator *downloadURLGuard, maxBytes int) (body []byte, contentType string, statusCode int, err error) {
 	var browserCookies []*network.Cookie
 	if fetchErr := chromedp.Run(browserCtx,
 		chromedp.ActionFunc(func(ctx context.Context) error {
@@ -608,22 +619,7 @@ func (h *Handlers) fetchDirectWithCookies(ctx context.Context, browserCtx contex
 		req.AddCookie(&http.Cookie{Name: c.Name, Value: c.Value})
 	}
 
-	client := &http.Client{
-		Timeout: 30 * time.Second,
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			if len(via) >= 10 {
-				return fmt.Errorf("too many redirects")
-			}
-			host := req.URL.Hostname()
-			if netguard.IsLocalHost(host) {
-				return fmt.Errorf("redirect to local network blocked: %s", host)
-			}
-			if _, err := netguard.ResolveAndValidatePublicIPs(req.Context(), host); err != nil {
-				return fmt.Errorf("redirect to private network blocked: %s", host)
-			}
-			return nil
-		},
-	}
+	client := newGuardedDownloadClient(validator, h.Config.MaxRedirects, 30)
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, "", 0, err

--- a/internal/handlers/download_fallback_test.go
+++ b/internal/handlers/download_fallback_test.go
@@ -2,11 +2,16 @@ package handlers
 
 import (
 	"compress/gzip"
+	"context"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/pinchtab/pinchtab/internal/config"
+	"github.com/pinchtab/pinchtab/internal/netguard"
 )
 
 func TestIsGzipContent(t *testing.T) {
@@ -125,5 +130,72 @@ func TestFetchDirectWithCookies_GzipDecompression(t *testing.T) {
 		}
 	} else {
 		t.Error("expected isGzipContent to return true for .gz URL with gzip content-type")
+	}
+}
+
+func TestFetchDirectWithCookies_BlocksRedirectToPrivateIP(t *testing.T) {
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://169.254.169.254/latest/meta-data/", http.StatusFound)
+	}))
+	defer redirector.Close()
+
+	oldDial := dialDownloadAddress
+	dialDownloadAddress = func(ctx context.Context, network, _ string) (net.Conn, error) {
+		return (&net.Dialer{}).DialContext(ctx, network, redirector.Listener.Addr().String())
+	}
+	t.Cleanup(func() { dialDownloadAddress = oldDial })
+
+	oldResolve := netguard.ResolveHostIPs
+	netguard.ResolveHostIPs = func(context.Context, string, string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("93.184.216.34")}, nil
+	}
+	t.Cleanup(func() { netguard.ResolveHostIPs = oldResolve })
+
+	h := New(&mockBridge{}, &config.RuntimeConfig{MaxRedirects: -1}, nil, nil, nil)
+	_, _, _, err := h.fetchDirectWithCookies(context.Background(), context.Background(), "http://safe.example/file.txt", newDownloadURLGuard(nil), 1024)
+	if err == nil {
+		t.Fatal("expected redirect to private IP to be blocked")
+	}
+	if !strings.Contains(err.Error(), "private/internal IP blocked") && !strings.Contains(err.Error(), "internal or blocked host") && !strings.Contains(err.Error(), "blocked remote IP") {
+		t.Fatalf("expected download guard error, got %v", err)
+	}
+}
+
+func TestFetchDirectWithCookies_BlocksDNSRebinding(t *testing.T) {
+	page := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte("hello"))
+	}))
+	defer page.Close()
+
+	oldDial := dialDownloadAddress
+	dialDownloadAddress = func(ctx context.Context, network, _ string) (net.Conn, error) {
+		return (&net.Dialer{}).DialContext(ctx, network, page.Listener.Addr().String())
+	}
+	t.Cleanup(func() { dialDownloadAddress = oldDial })
+
+	resolveCount := 0
+	oldResolve := netguard.ResolveHostIPs
+	netguard.ResolveHostIPs = func(context.Context, string, string) ([]net.IP, error) {
+		resolveCount++
+		if resolveCount == 1 {
+			return []net.IP{net.ParseIP("93.184.216.34")}, nil
+		}
+		return []net.IP{net.ParseIP("10.0.0.7")}, nil
+	}
+	t.Cleanup(func() { netguard.ResolveHostIPs = oldResolve })
+
+	validator := newDownloadURLGuard(nil)
+	if err := validator.Validate("http://safe.example/file.txt"); err != nil {
+		t.Fatalf("preflight validation should pass on first resolution, got %v", err)
+	}
+
+	h := New(&mockBridge{}, &config.RuntimeConfig{MaxRedirects: -1}, nil, nil, nil)
+	_, _, _, err := h.fetchDirectWithCookies(context.Background(), context.Background(), "http://safe.example/file.txt", validator, 1024)
+	if err == nil {
+		t.Fatal("expected rebinding attempt to be blocked")
+	}
+	if !strings.Contains(err.Error(), "blocked remote IP") {
+		t.Fatalf("expected blocked remote IP error, got %v", err)
 	}
 }

--- a/internal/handlers/download_network.go
+++ b/internal/handlers/download_network.go
@@ -1,0 +1,127 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/netip"
+	"time"
+
+	"github.com/pinchtab/pinchtab/internal/netguard"
+)
+
+const downloadFallbackDefaultMaxRedirects = 10
+
+var dialDownloadAddress = func(ctx context.Context, network, addr string) (net.Conn, error) {
+	return (&net.Dialer{}).DialContext(ctx, network, addr)
+}
+
+func newGuardedDownloadClient(validator *downloadURLGuard, maxRedirects int, timeoutSeconds int) *http.Client {
+	if validator == nil {
+		validator = newDownloadURLGuard(nil)
+	}
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.Proxy = nil
+	transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		return dialGuardedDownloadAddress(ctx, network, addr, validator)
+	}
+
+	return &http.Client{
+		Timeout:   timeDurationSeconds(timeoutSeconds),
+		Transport: transport,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if exceededDownloadRedirectLimit(len(via), maxRedirects) {
+				return fmt.Errorf("too many redirects")
+			}
+			if err := validator.Validate(req.URL.String()); err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+}
+
+func exceededDownloadRedirectLimit(hops, maxRedirects int) bool {
+	if maxRedirects < 0 {
+		maxRedirects = downloadFallbackDefaultMaxRedirects
+	}
+	return hops > maxRedirects
+}
+
+func dialGuardedDownloadAddress(ctx context.Context, network, addr string, validator *downloadURLGuard) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, err
+	}
+
+	allowInternal := validator != nil && validator.isHostAllowed(host)
+	ips, err := resolveDownloadDialIPs(ctx, host, allowInternal)
+	if err != nil {
+		return nil, err
+	}
+
+	var lastErr error
+	for _, ip := range ips {
+		conn, err := dialDownloadAddress(ctx, network, net.JoinHostPort(ip.String(), port))
+		if err == nil {
+			return conn, nil
+		}
+		lastErr = err
+	}
+	if lastErr == nil {
+		lastErr = fmt.Errorf("no validated addresses for %s", host)
+	}
+	return nil, lastErr
+}
+
+func resolveDownloadDialIPs(ctx context.Context, host string, allowInternal bool) ([]net.IP, error) {
+	if host == "" {
+		return nil, fmt.Errorf("missing host")
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		if !allowInternal {
+			if err := validateDownloadDialIP(ip); err != nil {
+				return nil, err
+			}
+		}
+		return []net.IP{ip}, nil
+	}
+
+	ips, err := netguard.ResolveHostIPs(ctx, "ip", host)
+	if err != nil || len(ips) == 0 {
+		return nil, netguard.ErrResolveHost
+	}
+
+	seen := make(map[netip.Addr]struct{}, len(ips))
+	out := make([]net.IP, 0, len(ips))
+	for _, ip := range ips {
+		if !allowInternal {
+			if err := validateDownloadDialIP(ip); err != nil {
+				return nil, err
+			}
+		}
+		addr, ok := netip.AddrFromSlice(ip)
+		if !ok {
+			return nil, fmt.Errorf("download connected to blocked remote IP %s", ip.String())
+		}
+		addr = addr.Unmap()
+		if _, ok := seen[addr]; ok {
+			continue
+		}
+		seen[addr] = struct{}{}
+		out = append(out, ip)
+	}
+	return out, nil
+}
+
+func validateDownloadDialIP(ip net.IP) error {
+	if err := netguard.ValidatePublicIP(ip); err != nil {
+		return fmt.Errorf("download connected to blocked remote IP %s", ip.String())
+	}
+	return nil
+}
+
+func timeDurationSeconds(seconds int) time.Duration {
+	return time.Duration(seconds) * time.Second
+}

--- a/internal/handlers/lite_engine_test.go
+++ b/internal/handlers/lite_engine_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/pinchtab/pinchtab/internal/config"
 	"github.com/pinchtab/pinchtab/internal/engine"
+	"github.com/pinchtab/pinchtab/internal/netguard"
 )
 
 func newLiteTestPage() *httptest.Server {
@@ -133,5 +135,36 @@ func TestHandleText_LiteRespectsTabID(t *testing.T) {
 	}
 	if !strings.Contains(w.Body.String(), "first page") {
 		t.Fatalf("expected first page text, got %q", w.Body.String())
+	}
+}
+
+func TestHandleNavigate_LiteBlocksDNSRebinding(t *testing.T) {
+	lite := engine.NewLiteEngine()
+	defer func() { _ = lite.Close() }()
+
+	h := New(&mockBridge{}, &config.RuntimeConfig{Engine: "lite"}, nil, nil, nil)
+	h.Router = engine.NewRouter(engine.ModeLite, lite)
+
+	resolveCount := 0
+	oldResolve := netguard.ResolveHostIPs
+	netguard.ResolveHostIPs = func(context.Context, string, string) ([]net.IP, error) {
+		resolveCount++
+		if resolveCount == 1 {
+			return []net.IP{net.ParseIP("93.184.216.34")}, nil
+		}
+		return []net.IP{net.ParseIP("10.0.0.7")}, nil
+	}
+	t.Cleanup(func() { netguard.ResolveHostIPs = oldResolve })
+
+	req := httptest.NewRequest("POST", "/navigate", strings.NewReader(`{"url":"https://safe.example/index.html"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.HandleNavigate(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for rebinding attempt, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "blocked remote IP") {
+		t.Fatalf("expected blocked remote IP error, got %s", w.Body.String())
 	}
 }

--- a/internal/handlers/navigation.go
+++ b/internal/handlers/navigation.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/netip"
 	"strconv"
 	"strings"
 	"time"
@@ -115,9 +116,21 @@ func (h *Handlers) HandleNavigate(w http.ResponseWriter, r *http.Request) {
 	// --- Lite engine fast path ---
 	if h.useLite(engine.CapNavigate, req.URL) {
 		h.recordEngine(r, "lite")
-		result, err := h.Router.Lite().Navigate(r.Context(), req.URL)
+		var trustedResolvedIP []netip.Addr
+		allowInternal := false
+		if target != nil {
+			trustedResolvedIP = target.trustedResolvedIP
+			allowInternal = target.allowInternal
+		}
+		liteCtx := engine.WithNavigateNetworkPolicy(r.Context(), &engine.NavigateNetworkPolicy{
+			AllowInternal:     allowInternal,
+			TrustedProxyCIDRs: trustedCIDRs,
+			TrustedResolvedIP: trustedResolvedIP,
+			MaxRedirects:      h.Config.MaxRedirects,
+		})
+		result, err := h.Router.Lite().Navigate(liteCtx, req.URL)
 		if err != nil {
-			if engine.IsIDPIBlocked(err) {
+			if engine.IsIDPIBlocked(err) || engine.IsNetworkPolicyBlocked(err) {
 				httpx.Error(w, http.StatusForbidden, err)
 			} else {
 				httpx.Error(w, 502, fmt.Errorf("lite navigate: %w", err))

--- a/tests/e2e/scenarios/api/files-extended.sh
+++ b/tests/e2e/scenarios/api/files-extended.sh
@@ -190,3 +190,13 @@ assert_http_status 400 "redirected internal target blocked"
 assert_contains "$RESULT" "unsafe browser request\|blocked\|private" "redirect SSRF error message"
 
 end_test
+
+# ─────────────────────────────────────────────────────────────────
+start_test "download fallback: gzip download path still succeeds"
+
+pt_get "/download?url=${FIXTURES_URL}/sitemap.xml.gz"
+assert_ok "gzip fallback download"
+assert_json_eq "$RESULT" '.contentType' 'application/xml' "gzip fallback reports decompressed XML content type"
+assert_json_jq "$RESULT" '.size > 0' "gzip fallback returns non-empty body" "gzip fallback body was empty"
+
+end_test

--- a/tests/e2e/scenarios/infra/engine-modes-extended.sh
+++ b/tests/e2e/scenarios/infra/engine-modes-extended.sh
@@ -216,6 +216,16 @@ assert_ok "lite text passes"
 
 end_test
 
+# ─────────────────────────────────────────────────────────────────
+start_test "safe-lite: redirects to internal targets are blocked"
+
+ATTACKER_URL="https://httpbin.org/redirect-to?url=http%3A%2F%2F169.254.169.254%2Flatest%2Fmeta-data%2F"
+lite_post /navigate "{\"url\":\"${ATTACKER_URL}\"}"
+assert_http_status 403 "lite redirect to internal blocked"
+assert_contains "$RESULT" "blocked\|private\|internal" "lite SSRF block message returned"
+
+end_test
+
 # ═══════════════════════════════════════════════════════════════════
 # PART 4: SafeEngine IDPI strict — secure server (chrome engine)
 # ═══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- add guarded dial/redirect handling for lite-engine navigation so it respects the same network trust boundaries as the stronger Chrome path
- introduce shared navigation network policy wiring for lite-mode requests, including trusted resolved IPs, trusted proxy CIDRs, and redirect limits
- harden fallback HTTP download fetching with guarded dialing and redirect validation instead of relying on URL pre-checks alone
- expand tests and E2E coverage around lite-mode and file/download scenarios

## Why
Lite-mode navigation and fallback downloads were still more permissive than the Chrome path in a few important network-validation cases. This branch closes that gap so SSRF-sensitive fetches are checked at dial/redirect time, not just at the initial URL parse step.

## Validation
- `go test ./...`
