### PR TITLE
fix(bridge): guard tab operations against uninitialized tab manager state

### DIFF
--- a/internal/bridge/bridge.go
+++ b/internal/bridge/bridge.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/chromedp/cdproto/page"
+	"github.com/chromedp/cdproto/target"
 	"github.com/chromedp/chromedp"
 	"github.com/pinchtab/pinchtab/internal/config"
 	"github.com/pinchtab/pinchtab/internal/ids"
@@ -236,6 +237,53 @@ func (b *Bridge) StartNetworkCapture(tabCtx context.Context, tabID string) error
 		return fmt.Errorf("network monitor not initialized")
 	}
 	return b.netMonitor.StartCapture(tabCtx, tabID)
+}
+
+func (b *Bridge) tabManager() (*TabManager, error) {
+	if b == nil || b.TabManager == nil {
+		return nil, fmt.Errorf("tab manager not initialized")
+	}
+	return b.TabManager, nil
+}
+
+func (b *Bridge) CreateTab(url string) (string, context.Context, context.CancelFunc, error) {
+	tm, err := b.tabManager()
+	if err != nil {
+		return "", nil, nil, err
+	}
+	return tm.CreateTab(url)
+}
+
+func (b *Bridge) TabContext(tabID string) (context.Context, string, error) {
+	tm, err := b.tabManager()
+	if err != nil {
+		return nil, "", err
+	}
+	return tm.TabContext(tabID)
+}
+
+func (b *Bridge) ListTargets() ([]*target.Info, error) {
+	tm, err := b.tabManager()
+	if err != nil {
+		return nil, err
+	}
+	return tm.ListTargets()
+}
+
+func (b *Bridge) CloseTab(tabID string) error {
+	tm, err := b.tabManager()
+	if err != nil {
+		return err
+	}
+	return tm.CloseTab(tabID)
+}
+
+func (b *Bridge) FocusTab(tabID string) error {
+	tm, err := b.tabManager()
+	if err != nil {
+		return err
+	}
+	return tm.FocusTab(tabID)
 }
 
 func (b *Bridge) Lock(tabID, owner string, ttl time.Duration) error {

--- a/internal/bridge/bridge_test.go
+++ b/internal/bridge/bridge_test.go
@@ -127,6 +127,54 @@ func TestTabManagerRemoteAllocatorInitialization(t *testing.T) {
 	}
 }
 
+func TestCreateTab_RejectsNilTabManager(t *testing.T) {
+	var tm *TabManager
+
+	_, _, _, err := tm.CreateTab("about:blank")
+	if err == nil {
+		t.Fatal("CreateTab should fail when tab manager is nil")
+	}
+	if err.Error() != "tab manager not initialized" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestBridgeTabOperations_RejectNilTabManager(t *testing.T) {
+	b := &Bridge{}
+
+	tests := []struct {
+		name string
+		run  func() error
+	}{
+		{name: "tab context", run: func() error {
+			_, _, err := b.TabContext("")
+			return err
+		}},
+		{name: "list targets", run: func() error {
+			_, err := b.ListTargets()
+			return err
+		}},
+		{name: "close tab", run: func() error {
+			return b.CloseTab("tab1")
+		}},
+		{name: "focus tab", run: func() error {
+			return b.FocusTab("tab1")
+		}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.run()
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if err.Error() != "tab manager not initialized" {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
 func TestTabContext_RejectsUnknownTabID(t *testing.T) {
 	// TabContext should reject tab IDs that aren't tracked
 	tm := NewTabManager(context.Background(), &config.RuntimeConfig{}, nil, nil, nil)

--- a/internal/bridge/tab_manager.go
+++ b/internal/bridge/tab_manager.go
@@ -109,7 +109,13 @@ func (tm *TabManager) closePopupTarget(targetID, openerID target.ID, url string)
 	defer cancel()
 	logURL := internalurls.RedactForLog(url)
 
-	if err := target.CloseTarget(targetID).Do(cdp.WithExecutor(closeCtx, chromedp.FromContext(closeCtx).Browser)); err != nil {
+	execCtx, err := browserExecutorContext(closeCtx)
+	if err != nil {
+		slog.Debug("popup close skipped", "targetId", targetID, "openerId", openerID, "url", logURL, "err", err)
+		return
+	}
+
+	if err := target.CloseTarget(targetID).Do(execCtx); err != nil {
 		slog.Debug("popup close failed", "targetId", targetID, "openerId", openerID, "url", logURL, "err", err)
 		return
 	}
@@ -125,6 +131,17 @@ func (tm *TabManager) markAccessed(tabID string) {
 	}
 	tm.currentTab = tabID
 	tm.mu.Unlock()
+}
+
+func browserExecutorContext(ctx context.Context) (context.Context, error) {
+	if ctx == nil {
+		return nil, fmt.Errorf("no browser context available")
+	}
+	c := chromedp.FromContext(ctx)
+	if c == nil || c.Browser == nil {
+		return nil, fmt.Errorf("no browser executor available")
+	}
+	return cdp.WithExecutor(ctx, c.Browser), nil
 }
 
 // selectCurrentTrackedTab returns the current tab ID, falling back to the most
@@ -170,6 +187,9 @@ func (tm *TabManager) AccessedTabIDs() map[string]bool {
 }
 
 func (tm *TabManager) TabContext(tabID string) (context.Context, string, error) {
+	if tm == nil {
+		return nil, "", fmt.Errorf("tab manager not initialized")
+	}
 	if tabID == "" {
 		// Resolve to current tracked tab
 		tm.mu.RLock()
@@ -288,11 +308,14 @@ func (tm *TabManager) closeLRUTab() error {
 }
 
 func (tm *TabManager) CreateTab(url string) (string, context.Context, context.CancelFunc, error) {
+	if tm == nil {
+		return "", nil, nil, fmt.Errorf("tab manager not initialized")
+	}
 	if tm.browserCtx == nil {
 		return "", nil, nil, fmt.Errorf("no browser context available")
 	}
 
-	if tm.config.MaxTabs > 0 {
+	if tm.config != nil && tm.config.MaxTabs > 0 {
 		// Count managed tabs for eviction decisions. Using Chrome's target list
 		// would include unmanaged targets (e.g. the initial about:blank tab),
 		// causing premature eviction of managed tabs.
@@ -343,13 +366,13 @@ func (tm *TabManager) CreateTab(url string) (string, context.Context, context.Ca
 
 	var blockPatterns []string
 
-	if tm.config.BlockAds {
+	if tm.config != nil && tm.config.BlockAds {
 		blockPatterns = CombineBlockPatterns(blockPatterns, AdBlockPatterns)
 	}
 
-	if tm.config.BlockMedia {
+	if tm.config != nil && tm.config.BlockMedia {
 		blockPatterns = CombineBlockPatterns(blockPatterns, MediaBlockPatterns)
-	} else if tm.config.BlockImages {
+	} else if tm.config != nil && tm.config.BlockImages {
 		blockPatterns = CombineBlockPatterns(blockPatterns, ImageBlockPatterns)
 	}
 
@@ -372,7 +395,9 @@ func (tm *TabManager) CreateTab(url string) (string, context.Context, context.Ca
 		if err := chromedp.Run(navCtx, chromedp.Navigate(url)); err != nil {
 			navCancel()
 			cancel()
-			_ = target.CloseTarget(targetID).Do(cdp.WithExecutor(tm.browserCtx, chromedp.FromContext(tm.browserCtx).Browser))
+			if execCtx, execErr := browserExecutorContext(tm.browserCtx); execErr == nil {
+				_ = target.CloseTarget(targetID).Do(execCtx)
+			}
 			return "", nil, nil, fmt.Errorf("navigate: %w", err)
 		}
 		navCancel()
@@ -414,6 +439,9 @@ func (tm *TabManager) CreateTab(url string) (string, context.Context, context.Ca
 }
 
 func (tm *TabManager) CloseTab(tabID string) error {
+	if tm == nil {
+		return fmt.Errorf("tab manager not initialized")
+	}
 	// Guard against closing the last tab to prevent Chrome from exiting
 	targets, err := tm.ListTargets()
 	if err != nil {
@@ -440,7 +468,17 @@ func (tm *TabManager) CloseTab(tabID string) error {
 	closeCtx, closeCancel := context.WithTimeout(tm.browserCtx, 5*time.Second)
 	defer closeCancel()
 
-	if err := target.CloseTarget(target.ID(cdpTargetID)).Do(cdp.WithExecutor(closeCtx, chromedp.FromContext(closeCtx).Browser)); err != nil {
+	execCtx, execErr := browserExecutorContext(closeCtx)
+	if execErr != nil {
+		if !tracked {
+			return fmt.Errorf("tab %s not found", tabID)
+		}
+		slog.Debug("close target skipped", "tabId", tabID, "cdpId", cdpTargetID, "err", execErr)
+		tm.purgeTrackedTabState(tabID, cdpTargetID)
+		return nil
+	}
+
+	if err := target.CloseTarget(target.ID(cdpTargetID)).Do(execCtx); err != nil {
 		if !tracked {
 			return fmt.Errorf("tab %s not found", tabID)
 		}
@@ -454,6 +492,9 @@ func (tm *TabManager) CloseTab(tabID string) error {
 // FocusTab activates a tab by ID, bringing it to the foreground and setting it
 // as the current tab for subsequent operations.
 func (tm *TabManager) FocusTab(tabID string) error {
+	if tm == nil {
+		return fmt.Errorf("tab manager not initialized")
+	}
 	ctx, resolvedID, err := tm.TabContext(tabID)
 	if err != nil {
 		return err

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -4,6 +4,7 @@ package handlers
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"strconv"
 	"time"
@@ -113,6 +114,17 @@ type restartStatusProvider interface {
 // ensureChrome ensures Chrome is initialized before handling requests that need it
 func (h *Handlers) ensureChrome() error {
 	return h.Bridge.EnsureChrome(h.Config)
+}
+
+func (h *Handlers) ensureChromeOrRespond(w http.ResponseWriter) bool {
+	if err := h.ensureChrome(); err != nil {
+		if h.writeBridgeUnavailable(w, err) {
+			return false
+		}
+		httpx.Error(w, 500, fmt.Errorf("chrome initialization: %w", err))
+		return false
+	}
+	return true
 }
 
 func (h *Handlers) bridgeRestartStatus() (bool, time.Duration) {

--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -25,6 +25,8 @@ type mockBridge struct {
 	lastErrorLimit   int
 	fingerprintTabs  map[string]bool
 	frameScopes      map[string]bridge.FrameScope
+	ensureChromeErr  error
+	ensureChromeCall int
 }
 
 func (m *mockBridge) TabContext(tabID string) (context.Context, string, error) {
@@ -70,8 +72,8 @@ func (m *mockBridge) FocusTab(tabID string) error {
 }
 
 func (m *mockBridge) EnsureChrome(cfg *config.RuntimeConfig) error {
-	// Mock implementation - just return nil
-	return nil
+	m.ensureChromeCall++
+	return m.ensureChromeErr
 }
 
 func (m *mockBridge) RestartBrowser(cfg *config.RuntimeConfig) error {

--- a/internal/handlers/navigation.go
+++ b/internal/handlers/navigation.go
@@ -146,6 +146,9 @@ func (h *Handlers) HandleNavigate(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("X-Engine", "chrome")
 
 	// Ensure Chrome is initialized
+	if !h.ensureChromeOrRespond(w) {
+		return
+	}
 
 	// Default to creating new tab (API design: /navigate always creates new tab)
 	// Unless explicitly reusing an existing tab by specifying TabID
@@ -394,6 +397,10 @@ func (h *Handlers) HandleTab(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
+		if !h.ensureChromeOrRespond(w) {
+			return
+		}
+
 		// Create a blank tab first so the requested URL becomes the first
 		// real history entry.
 		newTabID, ctx, _, err := h.Bridge.CreateTab("")
@@ -440,6 +447,9 @@ func (h *Handlers) HandleTab(w http.ResponseWriter, r *http.Request) {
 			httpx.Error(w, 400, fmt.Errorf("tabId required"))
 			return
 		}
+		if !h.ensureChromeOrRespond(w) {
+			return
+		}
 
 		if err := h.Bridge.CloseTab(req.TabID); err != nil {
 			httpx.Error(w, 500, err)
@@ -453,6 +463,9 @@ func (h *Handlers) HandleTab(w http.ResponseWriter, r *http.Request) {
 	case "focus":
 		if req.TabID == "" {
 			httpx.Error(w, 400, fmt.Errorf("tabId required"))
+			return
+		}
+		if !h.ensureChromeOrRespond(w) {
 			return
 		}
 		if err := h.Bridge.FocusTab(req.TabID); err != nil {
@@ -495,6 +508,9 @@ func (h *Handlers) HandleTabReload(w http.ResponseWriter, r *http.Request) {
 
 // HandleBack navigates the current (or specified) tab back in history.
 func (h *Handlers) HandleBack(w http.ResponseWriter, r *http.Request) {
+	if !h.ensureChromeOrRespond(w) {
+		return
+	}
 	tabID := r.URL.Query().Get("tabId")
 	ctx, resolvedID, err := h.Bridge.TabContext(tabID)
 	if err != nil {
@@ -530,6 +546,9 @@ func (h *Handlers) HandleBack(w http.ResponseWriter, r *http.Request) {
 
 // HandleForward navigates the current (or specified) tab forward in history.
 func (h *Handlers) HandleForward(w http.ResponseWriter, r *http.Request) {
+	if !h.ensureChromeOrRespond(w) {
+		return
+	}
 	tabID := r.URL.Query().Get("tabId")
 	ctx, resolvedID, err := h.Bridge.TabContext(tabID)
 	if err != nil {
@@ -598,6 +617,9 @@ func navigateErrorWithHint(w http.ResponseWriter, code int, err error, url strin
 
 // HandleReload reloads the current (or specified) tab.
 func (h *Handlers) HandleReload(w http.ResponseWriter, r *http.Request) {
+	if !h.ensureChromeOrRespond(w) {
+		return
+	}
 	tabID := r.URL.Query().Get("tabId")
 	ctx, resolvedID, err := h.Bridge.TabContext(tabID)
 	if err != nil {

--- a/internal/handlers/navigation_test.go
+++ b/internal/handlers/navigation_test.go
@@ -33,6 +33,50 @@ func TestHandleNavigate_InvalidJSON(t *testing.T) {
 	}
 }
 
+func TestHandleNavigate_EnsureChromeFailureStopsBeforeCreateTab(t *testing.T) {
+	m := &mockBridge{ensureChromeErr: fmt.Errorf("bridge init failed")}
+	h := New(m, &config.RuntimeConfig{}, nil, nil, nil)
+
+	req := httptest.NewRequest("POST", "/navigate", bytes.NewReader([]byte(`{"url":"about:blank"}`)))
+	w := httptest.NewRecorder()
+	h.HandleNavigate(w, req)
+
+	if w.Code != 500 {
+		t.Fatalf("expected 500, got %d: %s", w.Code, w.Body.String())
+	}
+	if m.ensureChromeCall != 1 {
+		t.Fatalf("expected EnsureChrome to be called once, got %d", m.ensureChromeCall)
+	}
+	if len(m.createTabURLs) != 0 {
+		t.Fatalf("CreateTab should not be called when EnsureChrome fails, got %v", m.createTabURLs)
+	}
+	if !strings.Contains(w.Body.String(), "chrome initialization") {
+		t.Fatalf("expected chrome initialization error, got %s", w.Body.String())
+	}
+}
+
+func TestHandleTab_EnsureChromeFailureStopsBeforeCreateTab(t *testing.T) {
+	m := &mockBridge{ensureChromeErr: fmt.Errorf("bridge init failed")}
+	h := New(m, &config.RuntimeConfig{}, nil, nil, nil)
+
+	req := httptest.NewRequest("POST", "/tab", bytes.NewReader([]byte(`{"action":"new","url":"about:blank"}`)))
+	w := httptest.NewRecorder()
+	h.HandleTab(w, req)
+
+	if w.Code != 500 {
+		t.Fatalf("expected 500, got %d: %s", w.Code, w.Body.String())
+	}
+	if m.ensureChromeCall != 1 {
+		t.Fatalf("expected EnsureChrome to be called once, got %d", m.ensureChromeCall)
+	}
+	if len(m.createTabURLs) != 0 {
+		t.Fatalf("CreateTab should not be called when EnsureChrome fails, got %v", m.createTabURLs)
+	}
+	if !strings.Contains(w.Body.String(), "chrome initialization") {
+		t.Fatalf("expected chrome initialization error, got %s", w.Body.String())
+	}
+}
+
 func TestValidateNavigateURL_RejectsUnsupportedSchemes(t *testing.T) {
 	for _, rawURL := range []string{
 		"javascript:alert(1)",


### PR DESCRIPTION
## Summary
- fail fast when bridge/tab-manager-backed operations are attempted before the tab manager is initialized
- harden `TabContext` recovery so auto-tracked tabs still require a real active context before use
- ensure Chrome initialization earlier in navigation paths so requests do not wander into partially initialized bridge state
- add bridge/handler/navigation tests covering uninitialized tab-manager and inactive-context cases

## Why
Some request paths could still reach tab operations before bridge state was fully initialized, leading to confusing downstream failures instead of a clear, early error. This branch tightens those guards so the invariant is explicit and test-covered.

Related to #469.

## Validation
- `go test ./...`
