### PR TITLE
feat(instances): support per-instance allowedDomains security overrides

### DIFF
--- a/cmd/pinchtab/cmd_cli_register.go
+++ b/cmd/pinchtab/cmd_cli_register.go
@@ -274,6 +274,7 @@ func configureManagementFlags() {
 	startInstanceCmd.Flags().String("mode", "", "Instance mode")
 	startInstanceCmd.Flags().String("port", "", "Port number")
 	startInstanceCmd.Flags().StringArray("extension", nil, "Load browser extension (repeatable)")
+	startInstanceCmd.Flags().StringArray("allow-domain", nil, "Add an instance-scoped IDPI allowed domain (repeatable)")
 
 	activityCmd.PersistentFlags().Int("limit", 200, "Maximum number of events to return")
 	activityCmd.PersistentFlags().Int("age-sec", 0, "Only include events from the last N seconds")

--- a/dashboard/src/generated/types.ts
+++ b/dashboard/src/generated/types.ts
@@ -30,6 +30,9 @@ export interface Profile {
   useWhen?: string;
   description?: string;
 }
+export interface SecurityPolicy {
+  allowedDomains?: string[];
+}
 /**
  * Instance represents a running browser instance.
  * Matches internal/bridge/api.go Instance
@@ -47,6 +50,7 @@ export interface Instance {
   attached: boolean; // True if attached rather than locally launched
   attachType?: string;
   cdpUrl?: string; // CDP WebSocket URL (for CDP-attached instances)
+  securityPolicy?: SecurityPolicy;
 }
 /**
  * Agent represents a connected AI agent.

--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -483,6 +483,7 @@ Notes:
 
 - `/instances/start` and `/instances/launch` use `mode`, not `headless`
 - `/instances/launch` is a compatibility alias over `/instances/start`
+- instance start surfaces accept `securityPolicy.allowedDomains` for additive instance-scoped IDPI/domain allowlist overrides
 - create profiles explicitly with `POST /profiles`; `name` is no longer supported on `/instances/launch`
 - `/profiles/{id}/start` uses `headless`
 - attach routes are gated by `security.attach`

--- a/docs/guides/multi-instance.md
+++ b/docs/guides/multi-instance.md
@@ -42,6 +42,7 @@ Notes:
 
 - `POST /instances/launch` still exists as a compatibility endpoint, but it now follows the same semantics as `POST /instances/start`.
 - If you omit `profileId`, PinchTab creates a managed instance with an auto-generated profile name.
+- `securityPolicy.allowedDomains` lets you widen IDPI/domain trust for just that instance. This is additive over the server baseline, so one instance can use `["*"]` while the rest stay on the default allowlist.
 - Starting an instance is only optional in workflows that use shorthand routes with auto-launch behavior, such as the `simple` strategy. In `explicit`, you should assume you need to start one yourself.
 
 ## Open A Tab In A Specific Instance

--- a/docs/guides/security.md
+++ b/docs/guides/security.md
@@ -293,6 +293,18 @@ Supported domain patterns are:
 
 `*` is convenient, but it defeats the main allowlist defense and should be avoided unless you are deliberately disabling domain restriction.
 
+If you need to widen trust for only one managed browser, prefer an instance-scoped override instead of changing the global server policy. `POST /instances/start`, `POST /instances/launch`, and `POST /profiles/{id}/start` accept:
+
+```json
+{
+  "securityPolicy": {
+    "allowedDomains": ["*"]
+  }
+}
+```
+
+That override is additive for that instance only. For example, you can keep the server baseline local-only and start one temporary instance with `allowedDomains: ["*"]` or a narrow extra host list such as `["wikipedia.org"]` without widening the rest of the server.
+
 ## Recommended Config
 
 For a secure local setup:

--- a/docs/reference/instances.md
+++ b/docs/reference/instances.md
@@ -30,7 +30,10 @@ Response shape:
     "profileName": "instance-1741410000000",
     "port": "9999",
     "headless": false,
-    "status": "running"
+    "status": "running",
+    "securityPolicy": {
+      "allowedDomains": ["127.0.0.1", "localhost", "::1", "wikipedia.org"]
+    }
   }
 ]
 ```
@@ -46,9 +49,9 @@ Use `/instances/start` when you want to start by profile ID or profile name, or 
 ```bash
 curl -X POST http://localhost:9867/instances/start \
   -H "Content-Type: application/json" \
-  -d '{"profileId":"prof_278be873","mode":"headed","port":"9999"}'
+  -d '{"profileId":"prof_278be873","mode":"headed","port":"9999","securityPolicy":{"allowedDomains":["wikipedia.org","wikimedia.org"]}}'
 # CLI Alternative
-pinchtab instance start --profile prof_278be873 --mode headed --port 9999
+pinchtab instance start --profile prof_278be873 --mode headed --port 9999 --allow-domain wikipedia.org --allow-domain wikimedia.org
 ```
 
 Request body:
@@ -56,12 +59,15 @@ Request body:
 - `profileId`: optional; accepts a profile ID or an existing profile name
 - `mode`: optional; use `headed` for a visible browser, anything else is treated as headless
 - `port`: optional
+- `securityPolicy.allowedDomains`: optional additive instance-scoped IDPI/domain allowlist entries
 
 Notes:
 
 - if `profileId` is omitted, PinchTab creates an auto-generated temporary profile
 - if `port` is omitted, PinchTab allocates one from the configured instance port range
 - the CLI flag is `--profile`, even though the API field is `profileId`
+- `securityPolicy.allowedDomains` is merged with the server-level `security.allowedDomains` baseline for that instance only
+- you can widen a single instance without changing the server default. For example, `{"securityPolicy":{"allowedDomains":["*"]}}` makes that instance unrestricted while other instances still use the server baseline
 - request-supplied extension paths are rejected; configure `browser.extensionPaths` on the server instead. By default, PinchTab uses the local `extensions/` directory under its state/config folder.
 
 ### `POST /instances/launch`
@@ -71,7 +77,7 @@ Notes:
 ```bash
 curl -X POST http://localhost:9867/instances/launch \
   -H "Content-Type: application/json" \
-  -d '{"profileId":"prof_278be873","mode":"headed"}'
+  -d '{"profileId":"prof_278be873","mode":"headed","securityPolicy":{"allowedDomains":["wikipedia.org"]}}'
 ```
 
 Request body:
@@ -79,6 +85,7 @@ Request body:
 - `profileId`: optional existing profile ID or existing profile name
 - `mode`: optional; `headed` or headless by default
 - `port`: optional
+- `securityPolicy.allowedDomains`: optional additive instance-scoped IDPI/domain allowlist entries
 
 Important:
 
@@ -127,7 +134,7 @@ You can also start an instance from a profile-oriented route:
 ```bash
 curl -X POST http://localhost:9867/profiles/prof_278be873/start \
   -H "Content-Type: application/json" \
-  -d '{"headless":false,"port":"9999"}'
+  -d '{"headless":false,"port":"9999","securityPolicy":{"allowedDomains":["wikipedia.org"]}}'
 ```
 
 This route accepts a profile ID or profile name in the path. Unlike `/instances/start` and `/instances/launch`, its request body uses `headless` instead of `mode`.

--- a/internal/api/types/types.go
+++ b/internal/api/types/types.go
@@ -26,21 +26,26 @@ type Profile struct {
 	Description       string    `json:"description,omitempty"`
 }
 
+type SecurityPolicy struct {
+	AllowedDomains []string `json:"allowedDomains,omitempty"`
+}
+
 // Instance represents a running browser instance.
 // Matches internal/bridge/api.go Instance
 type Instance struct {
-	ID          string    `json:"id"`
-	ProfileID   string    `json:"profileId"`
-	ProfileName string    `json:"profileName"`
-	Port        string    `json:"port"` // Note: string not int
-	URL         string    `json:"url,omitempty"`
-	Headless    bool      `json:"headless"`
-	Status      string    `json:"status"` // starting/running/stopping/stopped/error
-	StartTime   time.Time `json:"startTime"`
-	Error       string    `json:"error,omitempty"`
-	Attached    bool      `json:"attached"` // True if attached rather than locally launched
-	AttachType  string    `json:"attachType,omitempty"`
-	CdpURL      string    `json:"cdpUrl,omitempty"` // CDP WebSocket URL (for CDP-attached instances)
+	ID             string          `json:"id"`
+	ProfileID      string          `json:"profileId"`
+	ProfileName    string          `json:"profileName"`
+	Port           string          `json:"port"` // Note: string not int
+	URL            string          `json:"url,omitempty"`
+	Headless       bool            `json:"headless"`
+	Status         string          `json:"status"` // starting/running/stopping/stopped/error
+	StartTime      time.Time       `json:"startTime"`
+	Error          string          `json:"error,omitempty"`
+	Attached       bool            `json:"attached"` // True if attached rather than locally launched
+	AttachType     string          `json:"attachType,omitempty"`
+	CdpURL         string          `json:"cdpUrl,omitempty"` // CDP WebSocket URL (for CDP-attached instances)
+	SecurityPolicy *SecurityPolicy `json:"securityPolicy,omitempty"`
 }
 
 // Agent represents a connected AI agent.

--- a/internal/bridge/api.go
+++ b/internal/bridge/api.go
@@ -137,19 +137,24 @@ type AnalyticsReport struct {
 	Suggestions    []string       `json:"suggestions,omitempty"`
 }
 
+type SecurityPolicy struct {
+	AllowedDomains []string `json:"allowedDomains,omitempty"`
+}
+
 type Instance struct {
-	ID          string    `json:"id"`                   // Hash-based ID: inst_XXXXXXXX
-	ProfileID   string    `json:"profileId"`            // Hash-based profile ID: prof_XXXXXXXX
-	ProfileName string    `json:"profileName"`          // Human-readable profile name (for display only)
-	Port        string    `json:"port"`                 // Internal: instance port
-	URL         string    `json:"url,omitempty"`        // Canonical base URL for bridge-backed instances
-	Headless    bool      `json:"headless"`             // Mode: headless vs headed
-	Status      string    `json:"status"`               // Status: starting/running/stopping/stopped/error
-	StartTime   time.Time `json:"startTime"`            // When instance was created
-	Error       string    `json:"error,omitempty"`      // Error message if status=error
-	Attached    bool      `json:"attached"`             // True if attached rather than locally launched
-	AttachType  string    `json:"attachType,omitempty"` // "cdp" or "bridge" for attached instances
-	CdpURL      string    `json:"cdpUrl,omitempty"`     // CDP WebSocket URL (for CDP-attached instances)
+	ID             string          `json:"id"`                   // Hash-based ID: inst_XXXXXXXX
+	ProfileID      string          `json:"profileId"`            // Hash-based profile ID: prof_XXXXXXXX
+	ProfileName    string          `json:"profileName"`          // Human-readable profile name (for display only)
+	Port           string          `json:"port"`                 // Internal: instance port
+	URL            string          `json:"url,omitempty"`        // Canonical base URL for bridge-backed instances
+	Headless       bool            `json:"headless"`             // Mode: headless vs headed
+	Status         string          `json:"status"`               // Status: starting/running/stopping/stopped/error
+	StartTime      time.Time       `json:"startTime"`            // When instance was created
+	Error          string          `json:"error,omitempty"`      // Error message if status=error
+	Attached       bool            `json:"attached"`             // True if attached rather than locally launched
+	AttachType     string          `json:"attachType,omitempty"` // "cdp" or "bridge" for attached instances
+	CdpURL         string          `json:"cdpUrl,omitempty"`     // CDP WebSocket URL (for CDP-attached instances)
+	SecurityPolicy *SecurityPolicy `json:"securityPolicy,omitempty"`
 }
 
 type InstanceTab struct {

--- a/internal/cli/actions/actions_instance.go
+++ b/internal/cli/actions/actions_instance.go
@@ -22,6 +22,11 @@ func InstanceStart(client *http.Client, base, token string, cmd *cobra.Command) 
 	if exts, _ := cmd.Flags().GetStringArray("extension"); len(exts) > 0 {
 		body["extensionPaths"] = exts
 	}
+	if domains, _ := cmd.Flags().GetStringArray("allow-domain"); len(domains) > 0 {
+		body["securityPolicy"] = map[string]any{
+			"allowedDomains": domains,
+		}
+	}
 	apiclient.DoPost(client, base, token, "/instances/start", body)
 }
 

--- a/internal/orchestrator/handlers_instances.go
+++ b/internal/orchestrator/handlers_instances.go
@@ -9,14 +9,17 @@ import (
 	"time"
 
 	"github.com/pinchtab/pinchtab/internal/authn"
+	"github.com/pinchtab/pinchtab/internal/bridge"
+	"github.com/pinchtab/pinchtab/internal/config"
 	"github.com/pinchtab/pinchtab/internal/httpx"
 )
 
 type startInstanceRequest struct {
-	ProfileID      string   `json:"profileId,omitempty"`
-	Mode           string   `json:"mode,omitempty"`
-	Port           string   `json:"port,omitempty"`
-	ExtensionPaths []string `json:"extensionPaths,omitempty"`
+	ProfileID      string                 `json:"profileId,omitempty"`
+	Mode           string                 `json:"mode,omitempty"`
+	Port           string                 `json:"port,omitempty"`
+	ExtensionPaths []string               `json:"extensionPaths,omitempty"`
+	SecurityPolicy *bridge.SecurityPolicy `json:"securityPolicy,omitempty"`
 }
 
 func (o *Orchestrator) handleGetInstance(w http.ResponseWriter, r *http.Request) {
@@ -134,7 +137,9 @@ func (o *Orchestrator) handleStartByInstanceID(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	started, err := o.Launch(profileName, port, headless, nil)
+	started, err := o.LaunchWithOptions(profileName, port, headless, LaunchOptions{
+		SecurityPolicy: inst.requestedSecurityPolicy,
+	})
 	if err != nil {
 		statusCode := classifyLaunchError(err)
 		httpx.Error(w, statusCode, err)
@@ -241,6 +246,10 @@ func (o *Orchestrator) startInstanceWithRequest(w http.ResponseWriter, r *http.R
 		httpx.Error(w, 400, fmt.Errorf("extensionPaths are not supported on instance start requests; configure browser.extensionPaths on the server instead"))
 		return
 	}
+	if err := validateStartInstanceSecurityPolicy(req.SecurityPolicy); err != nil {
+		httpx.Error(w, 400, err)
+		return
+	}
 
 	var profileName string
 	var err error
@@ -257,7 +266,10 @@ func (o *Orchestrator) startInstanceWithRequest(w http.ResponseWriter, r *http.R
 
 	headless := req.Mode != "headed"
 
-	inst, err := o.Launch(profileName, req.Port, headless, req.ExtensionPaths)
+	inst, err := o.LaunchWithOptions(profileName, req.Port, headless, LaunchOptions{
+		ExtensionPaths: req.ExtensionPaths,
+		SecurityPolicy: req.SecurityPolicy,
+	})
 	if err != nil {
 		statusCode := classifyLaunchError(err)
 		httpx.Error(w, statusCode, err)
@@ -266,6 +278,24 @@ func (o *Orchestrator) startInstanceWithRequest(w http.ResponseWriter, r *http.R
 
 	authn.AuditLog(r, auditEvent, "instanceId", inst.ID, "profileName", profileName)
 	httpx.JSON(w, 201, inst)
+}
+
+func validateStartInstanceSecurityPolicy(policy *bridge.SecurityPolicy) error {
+	if policy == nil {
+		return nil
+	}
+	errs := config.ValidateFileConfig(&config.FileConfig{
+		Security: config.SecurityConfig{
+			AllowedDomains: append([]string(nil), policy.AllowedDomains...),
+			IDPI: config.IDPIConfig{
+				Enabled: true,
+			},
+		},
+	})
+	if len(errs) == 0 {
+		return nil
+	}
+	return fmt.Errorf("invalid securityPolicy.allowedDomains: %w", errs[0])
 }
 
 func (o *Orchestrator) handleInstanceTabs(w http.ResponseWriter, r *http.Request) {

--- a/internal/orchestrator/handlers_instances_test.go
+++ b/internal/orchestrator/handlers_instances_test.go
@@ -4,10 +4,12 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 
 	"github.com/pinchtab/pinchtab/internal/bridge"
+	"github.com/pinchtab/pinchtab/internal/config"
 	"github.com/pinchtab/pinchtab/internal/profiles"
 )
 
@@ -95,5 +97,84 @@ func TestHandleLaunchByNameRejectsExtensionPaths(t *testing.T) {
 	}
 	if !strings.Contains(w.Body.String(), "extensionPaths are not supported on instance start requests") {
 		t.Fatalf("body = %q, want extensionPaths rejection message", w.Body.String())
+	}
+}
+
+func TestHandleStartInstance_AppliesSecurityPolicyOverride(t *testing.T) {
+	old := processAliveFunc
+	processAliveFunc = func(pid int) bool { return pid > 0 }
+	defer func() { processAliveFunc = old }()
+	stubPortAvailability(t, func(int) bool { return true })
+
+	runner := &mockRunner{portAvail: true}
+	o := NewOrchestratorWithRunner(t.TempDir(), runner)
+	o.ApplyRuntimeConfig(&config.RuntimeConfig{
+		AllowedDomains: []string{"127.0.0.1", "localhost"},
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/instances/start", strings.NewReader(`{"mode":"headed","securityPolicy":{"allowedDomains":["wikipedia.org","localhost"]}}`))
+	w := httptest.NewRecorder()
+
+	o.handleStartInstance(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d body=%s", w.Code, http.StatusCreated, w.Body.String())
+	}
+	if !runner.runCalled {
+		t.Fatal("expected instance launch to invoke the runner")
+	}
+
+	var inst bridge.Instance
+	if err := json.NewDecoder(w.Body).Decode(&inst); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if inst.SecurityPolicy == nil {
+		t.Fatal("expected securityPolicy on instance response")
+	}
+	want := []string{"127.0.0.1", "localhost", "wikipedia.org"}
+	if len(inst.SecurityPolicy.AllowedDomains) != len(want) {
+		t.Fatalf("securityPolicy.allowedDomains = %v, want %v", inst.SecurityPolicy.AllowedDomains, want)
+	}
+	for i := range want {
+		if inst.SecurityPolicy.AllowedDomains[i] != want[i] {
+			t.Fatalf("securityPolicy.allowedDomains = %v, want %v", inst.SecurityPolicy.AllowedDomains, want)
+		}
+	}
+
+	cfgPath := envMap(runner.env)["PINCHTAB_CONFIG"]
+	if cfgPath == "" {
+		t.Fatal("PINCHTAB_CONFIG missing from child env")
+	}
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read child config: %v", err)
+	}
+	var childCfg config.FileConfig
+	if err := json.Unmarshal(data, &childCfg); err != nil {
+		t.Fatalf("decode child config: %v", err)
+	}
+	if len(childCfg.Security.AllowedDomains) != len(want) {
+		t.Fatalf("child security.allowedDomains = %v, want %v", childCfg.Security.AllowedDomains, want)
+	}
+	for i := range want {
+		if childCfg.Security.AllowedDomains[i] != want[i] {
+			t.Fatalf("child security.allowedDomains = %v, want %v", childCfg.Security.AllowedDomains, want)
+		}
+	}
+}
+
+func TestHandleStartInstance_RejectsInvalidSecurityPolicyOverride(t *testing.T) {
+	o := NewOrchestratorWithRunner(t.TempDir(), &mockRunner{portAvail: true})
+
+	req := httptest.NewRequest(http.MethodPost, "/instances/start", strings.NewReader(`{"securityPolicy":{"allowedDomains":["bad domain"]}}`))
+	w := httptest.NewRecorder()
+
+	o.handleStartInstance(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d body=%s", w.Code, http.StatusBadRequest, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "invalid securityPolicy.allowedDomains") {
+		t.Fatalf("body = %q, want securityPolicy validation message", w.Body.String())
 	}
 }

--- a/internal/orchestrator/handlers_profiles.go
+++ b/internal/orchestrator/handlers_profiles.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/pinchtab/pinchtab/internal/authn"
+	"github.com/pinchtab/pinchtab/internal/bridge"
 	"github.com/pinchtab/pinchtab/internal/httpx"
 )
 
@@ -30,8 +31,9 @@ func (o *Orchestrator) handleStartByID(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req struct {
-		Port     string `json:"port,omitempty"`
-		Headless bool   `json:"headless"`
+		Port           string                 `json:"port,omitempty"`
+		Headless       bool                   `json:"headless"`
+		SecurityPolicy *bridge.SecurityPolicy `json:"securityPolicy,omitempty"`
 	}
 	if r.ContentLength > 0 {
 		if err := httpx.DecodeJSONBody(w, r, 0, &req); err != nil {
@@ -39,8 +41,14 @@ func (o *Orchestrator) handleStartByID(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+	if err := validateStartInstanceSecurityPolicy(req.SecurityPolicy); err != nil {
+		httpx.Error(w, 400, err)
+		return
+	}
 
-	inst, err := o.Launch(name, req.Port, req.Headless, nil)
+	inst, err := o.LaunchWithOptions(name, req.Port, req.Headless, LaunchOptions{
+		SecurityPolicy: req.SecurityPolicy,
+	})
 	if err != nil {
 		statusCode := classifyLaunchError(err)
 		httpx.Error(w, statusCode, err)

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -86,6 +86,13 @@ type InstanceInternal struct {
 	cdpPort   int
 	cmd       Cmd
 	logBuf    *ringBuffer
+
+	requestedSecurityPolicy *bridge.SecurityPolicy
+}
+
+type LaunchOptions struct {
+	ExtensionPaths []string
+	SecurityPolicy *bridge.SecurityPolicy
 }
 
 func NewOrchestrator(baseDir string) *Orchestrator {
@@ -245,6 +252,12 @@ func installStableBinary(src, dst string) error {
 }
 
 func (o *Orchestrator) Launch(name, port string, headless bool, extensionPaths []string) (*bridge.Instance, error) {
+	return o.LaunchWithOptions(name, port, headless, LaunchOptions{
+		ExtensionPaths: extensionPaths,
+	})
+}
+
+func (o *Orchestrator) LaunchWithOptions(name, port string, headless bool, opts LaunchOptions) (*bridge.Instance, error) {
 	// Validate profile name to prevent path traversal attacks
 	if err := profiles.ValidateProfileName(name); err != nil {
 		return nil, err
@@ -331,7 +344,10 @@ func (o *Orchestrator) Launch(name, port string, headless bool, extensionPaths [
 		return nil, fmt.Errorf("create state dir: %w", err)
 	}
 
-	childConfigPath, err := o.writeChildConfig(port, cdpPort, profilePath, instanceStateDir, headless, extensionPaths)
+	requestedPolicy := cloneSecurityPolicy(opts.SecurityPolicy)
+	effectivePolicy := effectiveSecurityPolicy(o.runtimeCfg, requestedPolicy)
+
+	childConfigPath, err := o.writeChildConfig(port, cdpPort, profilePath, instanceStateDir, headless, opts.ExtensionPaths, effectivePolicy)
 	if err != nil {
 		return nil, fmt.Errorf("write child config: %w", err)
 	}
@@ -352,19 +368,22 @@ func (o *Orchestrator) Launch(name, port string, headless bool, extensionPaths [
 
 	inst := &InstanceInternal{
 		Instance: bridge.Instance{
-			ID:          instanceID,
-			ProfileID:   profileID,
-			ProfileName: name,
-			Port:        port,
-			URL:         o.childInstanceBaseURL(port),
-			Headless:    headless,
-			Status:      "starting",
-			StartTime:   time.Now(),
+			ID:             instanceID,
+			ProfileID:      profileID,
+			ProfileName:    name,
+			Port:           port,
+			URL:            o.childInstanceBaseURL(port),
+			Headless:       headless,
+			Status:         "starting",
+			StartTime:      time.Now(),
+			SecurityPolicy: effectivePolicy,
 		},
 		URL:     o.childInstanceBaseURL(port),
 		cdpPort: cdpPort,
 		cmd:     cmd,
 		logBuf:  logBuf,
+
+		requestedSecurityPolicy: requestedPolicy,
 	}
 
 	o.mu.Lock()
@@ -399,7 +418,7 @@ func portConflictError(port string, inspection PortInspection) error {
 	return fmt.Errorf("instance port %s is already in use on this machine", port)
 }
 
-func (o *Orchestrator) writeChildConfig(port string, cdpPort int, profilePath, instanceStateDir string, headless bool, extensionPaths []string) (string, error) {
+func (o *Orchestrator) writeChildConfig(port string, cdpPort int, profilePath, instanceStateDir string, headless bool, extensionPaths []string, securityPolicy *bridge.SecurityPolicy) (string, error) {
 	fc := config.FileConfigFromRuntime(o.runtimeCfg)
 	fc.Server.Port = port
 	fc.Server.StateDir = instanceStateDir
@@ -412,6 +431,9 @@ func (o *Orchestrator) writeChildConfig(port string, cdpPort int, profilePath, i
 		fc.InstanceDefaults.Mode = "headless"
 	} else {
 		fc.InstanceDefaults.Mode = "headed"
+	}
+	if securityPolicy != nil {
+		fc.Security.AllowedDomains = append([]string(nil), securityPolicy.AllowedDomains...)
 	}
 
 	if len(extensionPaths) > 0 {
@@ -441,6 +463,51 @@ func (o *Orchestrator) writeChildConfig(port string, cdpPort int, profilePath, i
 		return "", err
 	}
 	return configPath, nil
+}
+
+func effectiveSecurityPolicy(cfg *config.RuntimeConfig, requested *bridge.SecurityPolicy) *bridge.SecurityPolicy {
+	var merged []string
+	if cfg != nil {
+		merged = mergeAllowedDomains(merged, cfg.AllowedDomains)
+	}
+	if requested != nil {
+		merged = mergeAllowedDomains(merged, requested.AllowedDomains)
+	}
+	if len(merged) == 0 {
+		return nil
+	}
+	return &bridge.SecurityPolicy{AllowedDomains: merged}
+}
+
+func cloneSecurityPolicy(policy *bridge.SecurityPolicy) *bridge.SecurityPolicy {
+	if policy == nil {
+		return nil
+	}
+	return &bridge.SecurityPolicy{
+		AllowedDomains: append([]string(nil), policy.AllowedDomains...),
+	}
+}
+
+func mergeAllowedDomains(base []string, extras []string) []string {
+	seen := make(map[string]bool, len(base)+len(extras))
+	out := make([]string, 0, len(base)+len(extras))
+	for _, domain := range base {
+		trimmed := strings.TrimSpace(domain)
+		if trimmed == "" || seen[trimmed] {
+			continue
+		}
+		seen[trimmed] = true
+		out = append(out, trimmed)
+	}
+	for _, domain := range extras {
+		trimmed := strings.TrimSpace(domain)
+		if trimmed == "" || seen[trimmed] {
+			continue
+		}
+		seen[trimmed] = true
+		out = append(out, trimmed)
+	}
+	return out
 }
 
 func intPtr(v int) *int {

--- a/tests/e2e/scenarios/infra/security-extended.sh
+++ b/tests/e2e/scenarios/infra/security-extended.sh
@@ -72,6 +72,87 @@ assert_contains "$RESULT" "IDPI\|blocked\|allowed" "IDPI error message"
 end_test
 
 # ─────────────────────────────────────────────────────────────────
+start_test "security: instance-scoped allowedDomains widen one strict instance only"
+
+PIVOT_URL="http://pivot-target:80/index.html"
+
+secure_post /navigate -d "{\"url\":\"${PIVOT_URL}\"}"
+assert_http_status 403 "default strict server blocks pivot-target"
+
+secure_post /instances/start -d '{"mode":"headless","securityPolicy":{"allowedDomains":["pivot-target"]}}'
+assert_http_status 201 "start widened instance"
+SECURE_WIDE_INST_ID=$(echo "$RESULT" | jq -r '.id // empty')
+
+if [ -n "$SECURE_WIDE_INST_ID" ] && wait_for_orchestrator_instance_status "${E2E_SECURE_SERVER}" "${SECURE_WIDE_INST_ID}" "running" 30; then
+  if echo "$RESULT" | jq -e '.securityPolicy.allowedDomains | index("pivot-target")' >/dev/null 2>&1; then
+    echo -e "  ${GREEN}✓${NC} widened instance exposes pivot-target in securityPolicy.allowedDomains"
+    ((ASSERTIONS_PASSED++)) || true
+  else
+    echo -e "  ${RED}✗${NC} widened instance response missing pivot-target in securityPolicy.allowedDomains"
+    ((ASSERTIONS_FAILED++)) || true
+  fi
+
+  secure_post "/instances/${SECURE_WIDE_INST_ID}/tabs/open" "{\"url\":\"${PIVOT_URL}\"}"
+  assert_ok "widened instance can open pivot-target"
+  WIDE_TAB_ID=$(echo "$RESULT" | jq -r '.tabId // empty')
+  if [ -n "$WIDE_TAB_ID" ]; then
+    secure_get "/tabs/${WIDE_TAB_ID}/text"
+    assert_ok "widened instance text works on pivot-target"
+    assert_contains "$RESULT" "Welcome to the E2E test fixtures." "pivot-target serves expected fixture content"
+  fi
+fi
+
+secure_post /navigate -d "{\"url\":\"${PIVOT_URL}\"}"
+assert_http_status 403 "default strict server still blocks pivot-target after widened instance launch"
+
+if [ -n "${SECURE_WIDE_INST_ID:-}" ]; then
+  secure_post "/instances/${SECURE_WIDE_INST_ID}/stop" '{}'
+  assert_ok "stop widened instance"
+  wait_for_instances_gone "${E2E_SECURE_SERVER}" 10 "${SECURE_WIDE_INST_ID}" || true
+fi
+
+end_test
+
+# ─────────────────────────────────────────────────────────────────
+start_test "security: instance-scoped wildcard widens one strict instance only"
+
+PIVOT_URL="http://pivot-target:80/index.html"
+
+secure_post /instances/start -d '{"mode":"headless","securityPolicy":{"allowedDomains":["*"]}}'
+assert_http_status 201 "start wildcard instance"
+SECURE_WILDCARD_INST_ID=$(echo "$RESULT" | jq -r '.id // empty')
+
+if [ -n "$SECURE_WILDCARD_INST_ID" ] && wait_for_orchestrator_instance_status "${E2E_SECURE_SERVER}" "${SECURE_WILDCARD_INST_ID}" "running" 30; then
+  if echo "$RESULT" | jq -e '.securityPolicy.allowedDomains | index("*")' >/dev/null 2>&1; then
+    echo -e "  ${GREEN}✓${NC} wildcard instance exposes * in securityPolicy.allowedDomains"
+    ((ASSERTIONS_PASSED++)) || true
+  else
+    echo -e "  ${RED}✗${NC} wildcard instance response missing * in securityPolicy.allowedDomains"
+    ((ASSERTIONS_FAILED++)) || true
+  fi
+
+  secure_post "/instances/${SECURE_WILDCARD_INST_ID}/tabs/open" "{\"url\":\"${PIVOT_URL}\"}"
+  assert_ok "wildcard instance can open pivot-target"
+  WILDCARD_TAB_ID=$(echo "$RESULT" | jq -r '.tabId // empty')
+  if [ -n "$WILDCARD_TAB_ID" ]; then
+    secure_get "/tabs/${WILDCARD_TAB_ID}/text"
+    assert_ok "wildcard instance text works on pivot-target"
+    assert_contains "$RESULT" "Welcome to the E2E test fixtures." "wildcard instance reaches non-baseline host"
+  fi
+fi
+
+secure_post /navigate -d "{\"url\":\"${PIVOT_URL}\"}"
+assert_http_status 403 "default strict server still blocks pivot-target with wildcard instance running"
+
+if [ -n "${SECURE_WILDCARD_INST_ID:-}" ]; then
+  secure_post "/instances/${SECURE_WILDCARD_INST_ID}/stop" '{}'
+  assert_ok "stop wildcard instance"
+  wait_for_instances_gone "${E2E_SECURE_SERVER}" 10 "${SECURE_WILDCARD_INST_ID}" || true
+fi
+
+end_test
+
+# ─────────────────────────────────────────────────────────────────
 start_test "security: blocked responses include helpful info"
 
 secure_post /evaluate -d '{"expression":"1"}'


### PR DESCRIPTION
## Summary
- allow instance launch/start requests to carry a `securityPolicy.allowedDomains` override
- propagate that per-instance security policy through the orchestrator and expose it on instance metadata
- add CLI, dashboard-generated types, docs, tests, and infra E2E coverage for the instance-scoped allowedDomains model

## Why
Some deployments need a stricter or broader domain allowlist for one orchestrated instance without changing the server-wide default for every other instance. This branch makes that override explicit and instance-local instead of forcing global config churn.

## Validation
- `go test ./...`
