### PR TITLE
feat(dashboard): polish default launch UX and runtime reliability

### DIFF
--- a/dashboard/src/components/molecules/StartInstanceModal.test.tsx
+++ b/dashboard/src/components/molecules/StartInstanceModal.test.tsx
@@ -34,6 +34,7 @@ describe("StartInstanceModal", () => {
     const command = document.querySelector("textarea") as HTMLTextAreaElement;
     expect(command.value).toContain('"profileId":"prof_alpha"');
     expect(command.value).toContain('"mode":"headed"');
+    expect(command.value).toContain("Authorization: Bearer <token>");
 
     await userEvent.type(
       screen.getByPlaceholderText("Auto-select from configured range"),
@@ -83,5 +84,27 @@ describe("StartInstanceModal", () => {
     expect(fetchInstances).toHaveBeenCalledTimes(1);
     expect(useAppStore.getState().instances).toEqual(updatedInstances);
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("prevents launch when port input is invalid", async () => {
+    const { launchInstance } = await import("../../services/api");
+
+    render(
+      <StartInstanceModal open={true} profile={profile} onClose={() => {}} />,
+    );
+
+    const portInput = screen.getByPlaceholderText(
+      "Auto-select from configured range",
+    );
+    await userEvent.type(portInput, "invalid-port");
+
+    expect(
+      screen.getByText("Port must be a whole number between 1 and 65535."),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Start" })).toBeDisabled();
+
+    await userEvent.click(screen.getByRole("button", { name: "Start" }));
+
+    expect(launchInstance).not.toHaveBeenCalled();
   });
 });

--- a/dashboard/src/components/molecules/StartInstanceModal.tsx
+++ b/dashboard/src/components/molecules/StartInstanceModal.tsx
@@ -10,6 +10,30 @@ interface Props {
   onClose: () => void;
 }
 
+const PORT_VALIDATION_ERROR =
+  "Port must be a whole number between 1 and 65535.";
+
+function normalizeLaunchPort(rawPort: string): {
+  port?: string;
+  error?: string;
+} {
+  const trimmed = rawPort.trim();
+  if (!trimmed) {
+    return {};
+  }
+
+  if (!/^\d+$/.test(trimmed)) {
+    return { error: PORT_VALIDATION_ERROR };
+  }
+
+  const numericPort = Number(trimmed);
+  if (numericPort < 1 || numericPort > 65535) {
+    return { error: PORT_VALIDATION_ERROR };
+  }
+
+  return { port: String(numericPort) };
+}
+
 export default function StartInstanceModal({ open, profile, onClose }: Props) {
   const { setInstances } = useAppStore();
   const [port, setPort] = useState("");
@@ -17,6 +41,10 @@ export default function StartInstanceModal({ open, profile, onClose }: Props) {
   const [launchError, setLaunchError] = useState("");
   const [launchLoading, setLaunchLoading] = useState(false);
   const [copyFeedback, setCopyFeedback] = useState("");
+  const { port: normalizedPort, error: portError } = useMemo(
+    () => normalizeLaunchPort(port),
+    [port],
+  );
 
   useEffect(() => {
     if (open) {
@@ -38,16 +66,20 @@ export default function StartInstanceModal({ open, profile, onClose }: Props) {
     const payload: LaunchInstanceRequest = {
       profileId: profile.id,
       mode: headless ? undefined : "headed",
-      port: port.trim() || undefined,
+      port: normalizedPort,
     };
 
-    return `curl -X POST http://localhost:9867/instances/start -H "Content-Type: application/json" -d '${JSON.stringify(payload)}'`;
-  }, [headless, port, profile]);
+    return `curl -X POST http://localhost:9867/instances/start -H "Content-Type: application/json" -H "Authorization: Bearer <token>" -d '${JSON.stringify(payload)}'`;
+  }, [headless, normalizedPort, profile]);
 
   const handleLaunch = async () => {
     if (!profile || launchLoading) return;
     if (!profile.id) {
       setLaunchError("Profile ID missing");
+      return;
+    }
+    if (portError) {
+      setLaunchError(portError);
       return;
     }
 
@@ -57,7 +89,7 @@ export default function StartInstanceModal({ open, profile, onClose }: Props) {
     try {
       const payload: LaunchInstanceRequest = {
         profileId: profile.id,
-        port: port.trim() || undefined,
+        port: normalizedPort,
         mode: headless ? undefined : "headed",
       };
 
@@ -88,7 +120,11 @@ export default function StartInstanceModal({ open, profile, onClose }: Props) {
   return (
     <Modal
       open={open}
-      onClose={onClose}
+      onClose={() => {
+        if (!launchLoading) {
+          onClose();
+        }
+      }}
       title="🖥️ Start Profile"
       actions={
         <>
@@ -103,6 +139,7 @@ export default function StartInstanceModal({ open, profile, onClose }: Props) {
             variant="primary"
             onClick={handleLaunch}
             loading={launchLoading}
+            disabled={Boolean(portError)}
           >
             Start
           </Button>
@@ -121,10 +158,14 @@ export default function StartInstanceModal({ open, profile, onClose }: Props) {
           value={port}
           onChange={(e) => setPort(e.target.value)}
         />
-        <p className="-mt-2 text-xs text-text-muted">
-          Leave blank to auto-select a free port from the configured instance
-          port range.
-        </p>
+        {portError ? (
+          <p className="-mt-2 text-xs text-destructive">{portError}</p>
+        ) : (
+          <p className="-mt-2 text-xs text-text-muted">
+            Leave blank to auto-select a free port from the configured instance
+            port range.
+          </p>
+        )}
         <label className="flex items-center gap-2 text-sm text-text-secondary">
           <input
             type="checkbox"
@@ -152,6 +193,10 @@ export default function StartInstanceModal({ open, profile, onClose }: Props) {
               <span className="text-xs text-success">{copyFeedback}</span>
             )}
           </div>
+          <p className="mt-2 text-xs text-text-muted">
+            Replace <code>{"<token>"}</code> with the value from{" "}
+            <code>pinchtab config token</code> when auth is enabled.
+          </p>
         </div>
       </div>
     </Modal>

--- a/dashboard/src/pages/MonitoringPage.test.tsx
+++ b/dashboard/src/pages/MonitoringPage.test.tsx
@@ -109,6 +109,27 @@ describe("MonitoringPage", () => {
     expect(screen.getByText("prof_beta")).toBeInTheDocument();
   });
 
+  it("refreshes instances after stopping a running instance", async () => {
+    render(
+      <MemoryRouter initialEntries={["/dashboard/monitoring"]}>
+        <Routes>
+          <Route path="/dashboard/monitoring" element={<MonitoringPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Stop" })).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "Stop" }));
+
+    await waitFor(() => {
+      expect(api.stopInstance).toHaveBeenCalledWith("inst_beta");
+    });
+    expect(api.fetchInstances).toHaveBeenCalled();
+  });
+
   it("retries while waiting for an expected default instance", async () => {
     useAppStore.setState({
       instances: [],
@@ -189,6 +210,9 @@ describe("MonitoringPage", () => {
     await userEvent.click(
       await screen.findByRole("button", { name: "Start Default Instance" }),
     );
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Start Headed" }),
+    );
 
     await waitFor(() => {
       expect(api.launchInstance).toHaveBeenCalledWith({
@@ -197,5 +221,42 @@ describe("MonitoringPage", () => {
       });
     });
     expect(api.fetchInstances).toHaveBeenCalled();
+  });
+
+  it("can start the default instance in headless mode", async () => {
+    vi.mocked(api.fetchBackendConfig).mockResolvedValueOnce({
+      config: {
+        multiInstance: { strategy: "no-instance" },
+        profiles: { defaultProfile: "default" },
+        instanceDefaults: { mode: "headed" },
+      },
+    } as never);
+    useAppStore.setState({
+      instances: [],
+      currentTabs: {},
+      selectedMonitoringInstanceId: null,
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/dashboard/monitoring"]}>
+        <Routes>
+          <Route path="/dashboard/monitoring" element={<MonitoringPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Start Default Instance" }),
+    );
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Start Headless" }),
+    );
+
+    await waitFor(() => {
+      expect(api.launchInstance).toHaveBeenCalledWith({
+        profileId: "default",
+        mode: undefined,
+      });
+    });
   });
 });

--- a/dashboard/src/pages/MonitoringPage.tsx
+++ b/dashboard/src/pages/MonitoringPage.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAppStore } from "../stores/useAppStore";
-import { Button, EmptyState, ErrorBoundary } from "../components/atoms";
+import { Button, EmptyState, ErrorBoundary, Modal } from "../components/atoms";
 import InstanceListItem from "../instances/InstanceListItem";
 import InstanceTabsPanel from "../tabs/InstanceTabsPanel";
 import * as api from "../services/api";
@@ -31,14 +31,23 @@ export default function MonitoringPage() {
   >(undefined);
   const [startupRetryCount, setStartupRetryCount] = useState(0);
   const [startingDefaultInstance, setStartingDefaultInstance] = useState(false);
+  const [startingDefaultMode, setStartingDefaultMode] = useState<
+    "headed" | "headless" | null
+  >(null);
+  const [showDefaultModeModal, setShowDefaultModeModal] = useState(false);
   const [launchError, setLaunchError] = useState("");
   const memoryEnabled = settings.monitoring?.memoryMetrics ?? false;
 
   // Fetch backend strategy once
   useEffect(() => {
+    let cancelled = false;
+
     const load = async () => {
       try {
         const cfg = await api.fetchBackendConfig();
+        if (cancelled) {
+          return;
+        }
         setStrategy(cfg.config.multiInstance.strategy);
         setDefaultProfileId(cfg.config.profiles.defaultProfile || "default");
         setDefaultLaunchMode(
@@ -49,6 +58,10 @@ export default function MonitoringPage() {
       }
     };
     void load();
+
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   const refreshInstances = useCallback(async () => {
@@ -120,27 +133,36 @@ export default function MonitoringPage() {
   const handleStop = async (id: string) => {
     try {
       await api.stopInstance(id);
+      await refreshInstances();
     } catch (e) {
       console.error("Failed to stop instance", e);
     }
   };
 
-  const handleStartDefaultInstance = async () => {
+  const handleStartDefaultInstance = async (mode: "headed" | "headless") => {
+    if (startingDefaultInstance) {
+      return;
+    }
+
     setLaunchError("");
     setStartingDefaultInstance(true);
+    setStartingDefaultMode(mode);
+
     try {
       await api.launchInstance({
         profileId: defaultProfileId,
-        mode: defaultLaunchMode,
+        mode: mode === "headed" ? "headed" : undefined,
       });
       await refreshInstances();
       setStartupRetryCount(0);
+      setShowDefaultModeModal(false);
     } catch (error) {
       console.error("Failed to start default instance", error);
       setLaunchError(
         error instanceof Error ? error.message : "Failed to start instance",
       );
     } finally {
+      setStartingDefaultMode(null);
       setStartingDefaultInstance(false);
     }
   };
@@ -151,13 +173,15 @@ export default function MonitoringPage() {
   );
   const waitingForExpectedInstance =
     expectsAutoInstance && !hasAvailableInstance && startupRetriesRemaining > 0;
+  const prefersHeadedLaunch = defaultLaunchMode === "headed";
 
   const manualActions = (
     <div className="flex flex-wrap items-center justify-center gap-2">
       <Button
         variant="primary"
         onClick={() => {
-          void handleStartDefaultInstance();
+          setLaunchError("");
+          setShowDefaultModeModal(true);
         }}
         loading={startingDefaultInstance}
       >
@@ -210,90 +234,144 @@ export default function MonitoringPage() {
 
   return (
     <ErrorBoundary>
-      <div className="flex h-full flex-col overflow-hidden">
-        {instances.length === 0 && (
-          <div className="flex flex-1 items-center justify-center">
-            {renderEmptyMonitoringState()}
-          </div>
-        )}
+      <>
+        <div className="flex h-full flex-col overflow-hidden">
+          {instances.length === 0 && (
+            <div className="flex flex-1 items-center justify-center">
+              {renderEmptyMonitoringState()}
+            </div>
+          )}
 
-        {instances.length > 0 && (
-          <div className="dashboard-panel flex flex-1 flex-col overflow-hidden rounded-none! border-t-0">
-            <div className="flex flex-1 overflow-hidden">
-              {!sidebarCollapsed && (
-                <div className="w-64 shrink-0 overflow-auto border-r border-border-subtle bg-bg-surface/50">
-                  <div className="flex items-center justify-between border-b border-border-subtle px-3 py-1.5">
-                    <span className="text-xs font-medium text-text-muted">
-                      Instances
-                    </span>
-                    <button
-                      type="button"
-                      onClick={() => setSidebarCollapsed(true)}
-                      title="Collapse sidebar"
-                      className="rounded p-1 text-text-muted transition-colors hover:bg-white/10 hover:text-text-secondary"
-                    >
-                      <svg
-                        viewBox="0 0 24 24"
-                        aria-hidden="true"
-                        className="h-3.5 w-3.5"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="2"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
+          {instances.length > 0 && (
+            <div className="dashboard-panel flex flex-1 flex-col overflow-hidden rounded-none! border-t-0">
+              <div className="flex flex-1 overflow-hidden">
+                {!sidebarCollapsed && (
+                  <div className="w-64 shrink-0 overflow-auto border-r border-border-subtle bg-bg-surface/50">
+                    <div className="flex items-center justify-between border-b border-border-subtle px-3 py-1.5">
+                      <span className="text-xs font-medium text-text-muted">
+                        Instances
+                      </span>
+                      <button
+                        type="button"
+                        onClick={() => setSidebarCollapsed(true)}
+                        title="Collapse sidebar"
+                        className="rounded p-1 text-text-muted transition-colors hover:bg-white/10 hover:text-text-secondary"
                       >
-                        <polyline points="15 18 9 12 15 6" />
-                      </svg>
-                    </button>
-                  </div>
-                  <div>
-                    {instances.map((inst) => (
-                      <InstanceListItem
-                        key={inst.id}
-                        instance={inst}
-                        tabCount={currentTabs[inst.id]?.length ?? 0}
-                        memoryMB={
-                          memoryEnabled ? currentMemory[inst.id] : undefined
-                        }
-                        selected={selectedId === inst.id}
-                        autoRestart={
-                          inst.profileName === "default" &&
-                          (strategy === "always-on" ||
-                            strategy === "simple-autorestart")
-                        }
-                        onClick={() => setSelectedId(inst.id)}
-                        onStop={() => handleStop(inst.id)}
-                        onOpenProfile={() =>
-                          navigate("/dashboard/profiles", {
-                            state: {
-                              selectedProfileKey:
-                                inst.profileId || inst.profileName,
-                            },
-                          })
-                        }
-                      />
-                    ))}
-                  </div>
-                </div>
-              )}
-
-              {/* Selected instance details */}
-              <div className="flex flex-1 flex-col overflow-hidden">
-                {selectedInstance ? (
-                  <InstanceTabsPanel
-                    tabs={selectedTabs}
-                    instanceId={selectedId || undefined}
-                  />
-                ) : (
-                  <div className="flex flex-1 items-center justify-center px-6">
-                    {renderEmptyMonitoringState()}
+                        <svg
+                          viewBox="0 0 24 24"
+                          aria-hidden="true"
+                          className="h-3.5 w-3.5"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="2"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                        >
+                          <polyline points="15 18 9 12 15 6" />
+                        </svg>
+                      </button>
+                    </div>
+                    <div>
+                      {instances.map((inst) => (
+                        <InstanceListItem
+                          key={inst.id}
+                          instance={inst}
+                          tabCount={currentTabs[inst.id]?.length ?? 0}
+                          memoryMB={
+                            memoryEnabled ? currentMemory[inst.id] : undefined
+                          }
+                          selected={selectedId === inst.id}
+                          autoRestart={
+                            inst.profileName === "default" &&
+                            (strategy === "always-on" ||
+                              strategy === "simple-autorestart")
+                          }
+                          onClick={() => setSelectedId(inst.id)}
+                          onStop={() => handleStop(inst.id)}
+                          onOpenProfile={() =>
+                            navigate("/dashboard/profiles", {
+                              state: {
+                                selectedProfileKey:
+                                  inst.profileId || inst.profileName,
+                              },
+                            })
+                          }
+                        />
+                      ))}
+                    </div>
                   </div>
                 )}
+
+                {/* Selected instance details */}
+                <div className="flex flex-1 flex-col overflow-hidden">
+                  {selectedInstance ? (
+                    <InstanceTabsPanel
+                      tabs={selectedTabs}
+                      instanceId={selectedId || undefined}
+                    />
+                  ) : (
+                    <div className="flex flex-1 items-center justify-center px-6">
+                      {renderEmptyMonitoringState()}
+                    </div>
+                  )}
+                </div>
               </div>
             </div>
-          </div>
-        )}
-      </div>
+          )}
+        </div>
+
+        <Modal
+          open={showDefaultModeModal}
+          onClose={() => {
+            if (!startingDefaultInstance) {
+              setShowDefaultModeModal(false);
+            }
+          }}
+          title="Start Default Instance"
+          actions={
+            <>
+              <Button
+                variant="secondary"
+                onClick={() => setShowDefaultModeModal(false)}
+                disabled={startingDefaultInstance}
+              >
+                Cancel
+              </Button>
+              <Button
+                variant={prefersHeadedLaunch ? "primary" : "secondary"}
+                onClick={() => {
+                  void handleStartDefaultInstance("headed");
+                }}
+                loading={startingDefaultMode === "headed"}
+                disabled={startingDefaultInstance}
+              >
+                Start Headed
+              </Button>
+              <Button
+                variant={prefersHeadedLaunch ? "secondary" : "primary"}
+                onClick={() => {
+                  void handleStartDefaultInstance("headless");
+                }}
+                loading={startingDefaultMode === "headless"}
+                disabled={startingDefaultInstance}
+              >
+                Start Headless
+              </Button>
+            </>
+          }
+        >
+          <p>Choose how to launch the default profile for this session.</p>
+          {launchError && (
+            <div className="mt-3 rounded border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+              {launchError}
+            </div>
+          )}
+          <p className="mt-2 text-xs text-text-muted">
+            Configured default mode:{" "}
+            {defaultLaunchMode === "headed" ? "headed" : "headless"}
+          </p>
+        </Modal>
+      </>
     </ErrorBoundary>
   );
 }

--- a/dashboard/src/profiles/InstanceLogsPanel.test.tsx
+++ b/dashboard/src/profiles/InstanceLogsPanel.test.tsx
@@ -65,6 +65,39 @@ describe("InstanceLogsPanel", () => {
     expect(screen.getByText("streamed logs")).toBeInTheDocument();
   });
 
+  it("keeps streamed logs when the initial fetch resolves late", async () => {
+    let onLogs: ((logs: string) => void) | undefined;
+    let resolveInitialFetch: ((value: string) => void) | undefined;
+
+    fetchInstanceLogs.mockImplementation(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveInitialFetch = resolve;
+        }),
+    );
+    subscribeToInstanceLogs.mockImplementation((_id, handlers) => {
+      onLogs = handlers.onLogs;
+      return () => {};
+    });
+
+    render(<InstanceLogsPanel instanceId="inst_123" />);
+
+    await waitFor(() => {
+      expect(subscribeToInstanceLogs).toHaveBeenCalledTimes(1);
+    });
+
+    await act(async () => {
+      onLogs?.("fresh stream logs");
+    });
+
+    await act(async () => {
+      resolveInitialFetch?.("stale initial logs");
+    });
+
+    expect(screen.getByText("fresh stream logs")).toBeInTheDocument();
+    expect(screen.queryByText("stale initial logs")).not.toBeInTheDocument();
+  });
+
   it("shows the empty state when no instance is available", () => {
     render(<InstanceLogsPanel />);
 

--- a/dashboard/src/profiles/InstanceLogsPanel.tsx
+++ b/dashboard/src/profiles/InstanceLogsPanel.tsx
@@ -13,6 +13,7 @@ export default function InstanceLogsPanel({
   const [logs, setLogs] = useState("");
   const [loading, setLoading] = useState(false);
   const bottomRef = useRef<HTMLDivElement>(null);
+  const streamVersionRef = useRef(0);
 
   useEffect(() => {
     if (!instanceId) {
@@ -22,12 +23,16 @@ export default function InstanceLogsPanel({
     }
 
     let cancelled = false;
+    const fetchStartedAtVersion = streamVersionRef.current;
     setLoading(true);
 
     api
       .fetchInstanceLogs(instanceId)
       .then((nextLogs) => {
-        if (!cancelled) {
+        if (
+          !cancelled &&
+          streamVersionRef.current === fetchStartedAtVersion
+        ) {
           setLogs(nextLogs);
         }
       })
@@ -54,7 +59,10 @@ export default function InstanceLogsPanel({
     }
 
     return api.subscribeToInstanceLogs(instanceId, {
-      onLogs: (nextLogs) => setLogs(nextLogs),
+      onLogs: (nextLogs) => {
+        streamVersionRef.current += 1;
+        setLogs(nextLogs);
+      },
     });
   }, [instanceId]);
 

--- a/dashboard/src/profiles/InstanceLogsPanel.tsx
+++ b/dashboard/src/profiles/InstanceLogsPanel.tsx
@@ -29,10 +29,7 @@ export default function InstanceLogsPanel({
     api
       .fetchInstanceLogs(instanceId)
       .then((nextLogs) => {
-        if (
-          !cancelled &&
-          streamVersionRef.current === fetchStartedAtVersion
-        ) {
+        if (!cancelled && streamVersionRef.current === fetchStartedAtVersion) {
           setLogs(nextLogs);
         }
       })

--- a/dashboard/src/services/api.test.ts
+++ b/dashboard/src/services/api.test.ts
@@ -3,13 +3,17 @@ import {
   createProfile,
   fetchProfiles,
   handleRealtimeAuthFailure,
+  launchInstance,
   probeBackendAuth,
+  resetRealtimeAuthProbeStateForTests,
 } from "./api";
 import { SERVER_UNREACHABLE_EVENT } from "./auth";
 
 describe("api request headers", () => {
   beforeEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
+    resetRealtimeAuthProbeStateForTests();
   });
 
   it("tags dashboard GET requests with the dashboard source header", async () => {
@@ -65,6 +69,31 @@ describe("api request headers", () => {
     );
   });
 
+  it("starts instances through the canonical start endpoint", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        id: "inst_default",
+        profileId: "default",
+        profileName: "default",
+        port: "9868",
+        headless: true,
+        status: "starting",
+        startTime: "2026-03-06T10:00:00Z",
+        attached: false,
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await launchInstance({ profileId: "default", mode: "headed" });
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/instances/start");
+    expect(new Headers(init.headers).get("X-PinchTab-Source")).toBe(
+      "dashboard",
+    );
+  });
+
   it("dispatches a server-unreachable event when requests lose transport", async () => {
     const handler = vi.fn();
     const fetchMock = vi.fn().mockRejectedValue(new TypeError("NetworkError"));
@@ -87,5 +116,74 @@ describe("api request headers", () => {
 
     expect(handler).toHaveBeenCalledTimes(1);
     window.removeEventListener(SERVER_UNREACHABLE_EVENT, handler);
+  });
+
+  it("deduplicates concurrent realtime auth probes", async () => {
+    let resolveFetch:
+      | ((value: {
+          ok: boolean;
+          json: () => Promise<{
+            version: string;
+            uptime: number;
+            profiles: number;
+            instances: number;
+            agents: number;
+            authRequired: boolean;
+          }>;
+        }) => void)
+      | undefined;
+    const fetchMock = vi.fn().mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveFetch = resolve;
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const firstProbe = handleRealtimeAuthFailure();
+    const secondProbe = handleRealtimeAuthFailure();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    resolveFetch?.({
+      ok: true,
+      json: async () => ({
+        version: "test",
+        uptime: 1,
+        profiles: 0,
+        instances: 0,
+        agents: 0,
+        authRequired: false,
+      }),
+    });
+
+    await Promise.all([firstProbe, secondProbe]);
+  });
+
+  it("throttles realtime auth probes inside the cooldown window", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-15T00:00:00Z"));
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        version: "test",
+        uptime: 1,
+        profiles: 0,
+        instances: 0,
+        agents: 0,
+        authRequired: false,
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await handleRealtimeAuthFailure();
+    await handleRealtimeAuthFailure();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    vi.setSystemTime(Date.now() + 3001);
+    await handleRealtimeAuthFailure();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/dashboard/src/services/api.ts
+++ b/dashboard/src/services/api.ts
@@ -35,6 +35,14 @@ import {
 const BASE = ""; // Uses proxy in dev
 const DASHBOARD_SOURCE_HEADER = "X-PinchTab-Source";
 const DASHBOARD_SOURCE = "dashboard";
+const REALTIME_AUTH_PROBE_COOLDOWN_MS = 3000;
+let realtimeAuthProbeInFlight: Promise<void> | null = null;
+let lastRealtimeAuthProbeAt = 0;
+
+export function resetRealtimeAuthProbeStateForTests(): void {
+  realtimeAuthProbeInFlight = null;
+  lastRealtimeAuthProbeAt = 0;
+}
 
 type RequestMeta = {
   suppressAuthRedirect?: boolean;
@@ -210,7 +218,8 @@ export async function fetchInstances(): Promise<Instance[]> {
 export async function launchInstance(
   data: LaunchInstanceRequest,
 ): Promise<Instance> {
-  return request<Instance>("/instances/launch", {
+  // Use the canonical start endpoint to avoid legacy launch alias validation edge cases.
+  return request<Instance>("/instances/start", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(data),
@@ -616,12 +625,27 @@ export async function postProgress(
 }
 
 export async function handleRealtimeAuthFailure(): Promise<void> {
-  try {
-    const result = await probeBackendAuth();
-    if (result.mode === "required") {
-      dispatchAuthRequired("missing_token");
-    }
-  } catch {
-    dispatchServerUnreachable();
+  const now = Date.now();
+  if (realtimeAuthProbeInFlight) {
+    return realtimeAuthProbeInFlight;
   }
+  if (now - lastRealtimeAuthProbeAt < REALTIME_AUTH_PROBE_COOLDOWN_MS) {
+    return;
+  }
+
+  lastRealtimeAuthProbeAt = now;
+  realtimeAuthProbeInFlight = (async () => {
+    try {
+      const result = await probeBackendAuth();
+      if (result.mode === "required") {
+        dispatchAuthRequired("missing_token");
+      }
+    } catch {
+      dispatchServerUnreachable();
+    }
+  })().finally(() => {
+    realtimeAuthProbeInFlight = null;
+  });
+
+  return realtimeAuthProbeInFlight;
 }

--- a/dashboard/src/types/index.ts
+++ b/dashboard/src/types/index.ts
@@ -310,7 +310,7 @@ export const defaultBackendConfig: BackendConfig = {
   autoSolver: {
     enabled: false,
     maxAttempts: 8,
-    solvers: ["cloudflare", "semantic", "capsolver", "twocaptcha"],
+    solvers: ["cloudflare", "semantic"],
     llmProvider: "",
     llmFallback: false,
   },


### PR DESCRIPTION
## Summary
This PR delivers a focused dashboard polish pass around default instance launch UX, API reliability, and log-view consistency.

## What Changed
1. Start Instance modal hardening
- Added port validation for numeric range (1-65535) before launch calls.
- Disabled launch action while the port input is invalid.
- Prevented modal close during in-flight launch to avoid interrupted state.
- Updated backup curl command guidance to include auth header usage.

2. Monitoring default-launch UX improvements
- Added explicit headed/headless launch selection modal from empty-state action.
- Prevented modal dismissal while launch is running.
- Emphasized the configured default launch mode in modal actions.
- Ensured instance list refresh after stop/start operations and retained retry handling while waiting for expected auto-started instances.

3. API runtime guard improvements
- Switched dashboard launch calls to canonical endpoint: POST /instances/start.
- Added realtime auth probe throttling + in-flight deduplication to prevent event-storm probe spam.
- Exposed test-only probe-state reset helper for deterministic unit tests.

4. Logs race-condition protection
- Prevented stale initial log fetch responses from overwriting fresher streamed logs.

5. Dashboard defaults alignment
- Aligned dashboard autosolver defaults to supported solver set.

## Tests
Validated on this branch with:
- npm --prefix dashboard run typecheck
- npm --prefix dashboard run lint
- npm --prefix dashboard run test:run -- src/components/molecules/StartInstanceModal.test.tsx src/pages/MonitoringPage.test.tsx src/profiles/InstanceLogsPanel.test.tsx src/services/api.test.ts

All targeted suites passed (21/21 tests).

## Scope Notes
- This PR intentionally includes dashboard-only files.
- Unrelated local edits in internal and npm paths were not committed.
