### PR TITLE
fix: preserve managed instance mode in simple-autorestart

### DIFF
--- a/internal/strategy/autorestart/autorestart.go
+++ b/internal/strategy/autorestart/autorestart.go
@@ -73,6 +73,7 @@ type Strategy struct {
 
 	mu           sync.Mutex
 	instanceID   string    // Currently managed instance ID
+	headless     bool      // Headless mode of the managed instance
 	restartCount int       // Consecutive restart count
 	lastCrash    time.Time // Last crash timestamp
 	lastStart    time.Time // Last successful start timestamp
@@ -110,7 +111,8 @@ func New(cfg AutorestartConfig) *Strategy {
 	}
 
 	return &Strategy{
-		config: cfg,
+		config:   cfg,
+		headless: cfg.Headless,
 	}
 }
 
@@ -135,6 +137,7 @@ func (s *Strategy) SetRuntimeConfig(cfg *config.RuntimeConfig) {
 	if cfg.HeadlessSet {
 		s.config.Headless = cfg.Headless
 		s.config.HeadlessSet = true
+		s.headless = cfg.Headless
 	}
 }
 
@@ -227,6 +230,7 @@ func (s *Strategy) launchInitial() {
 
 	s.mu.Lock()
 	s.instanceID = inst.ID
+	s.headless = inst.Headless
 	s.lastStart = time.Now()
 	s.mu.Unlock()
 
@@ -339,6 +343,7 @@ func (s *Strategy) restartInstance() {
 	s.mu.Lock()
 	ctx := s.ctx
 	oldID := s.instanceID
+	headless := s.headless
 	s.mu.Unlock()
 
 	if ctx == nil || ctx.Err() != nil {
@@ -356,7 +361,7 @@ func (s *Strategy) restartInstance() {
 		}
 	}
 
-	inst, err := s.orch.Launch(s.config.ProfileName, "", s.config.Headless, nil)
+	inst, err := s.orch.Launch(s.config.ProfileName, "", headless, nil)
 	if err != nil {
 		slog.Error(s.logPrefix("restart failed"),
 			"oldId", oldID,
@@ -370,6 +375,7 @@ func (s *Strategy) restartInstance() {
 
 	s.mu.Lock()
 	s.instanceID = inst.ID
+	s.headless = inst.Headless
 	s.lastStart = time.Now()
 	count := s.restartCount
 	s.restarting = false

--- a/internal/strategy/autorestart/autorestart_test.go
+++ b/internal/strategy/autorestart/autorestart_test.go
@@ -527,6 +527,61 @@ func TestStrategy_HandleCrash_RestartingEvent(t *testing.T) {
 	}
 }
 
+func TestStrategy_LaunchInitial_TracksLaunchedMode(t *testing.T) {
+	orch := orchestrator.NewOrchestratorWithRunner(t.TempDir(), &mockRunner{portAvail: true})
+	s := New(AutorestartConfig{
+		ProfileName: "headed-profile",
+		Headless:    false,
+		HeadlessSet: true,
+	})
+	s.orch = orch
+	s.ctx, s.cancel = context.WithCancel(context.Background())
+	defer s.cancel()
+
+	s.launchInitial()
+
+	s.mu.Lock()
+	instanceID := s.instanceID
+	headless := s.headless
+	s.mu.Unlock()
+
+	if instanceID == "" {
+		t.Fatal("expected launchInitial to track a managed instance")
+	}
+	if headless {
+		t.Fatal("expected launchInitial to preserve headed mode")
+	}
+}
+
+func TestStrategy_RestartInstance_UsesTrackedMode(t *testing.T) {
+	orch := orchestrator.NewOrchestratorWithRunner(t.TempDir(), &mockRunner{portAvail: true})
+	if _, _, err := orch.AttachBridge("default", "http://127.0.0.1:9999", ""); err != nil {
+		t.Fatalf("AttachBridge failed: %v", err)
+	}
+
+	s := New(AutorestartConfig{
+		ProfileName: "default",
+		Headless:    true,
+		HeadlessSet: true,
+	})
+	s.orch = orch
+	s.ctx, s.cancel = context.WithCancel(context.Background())
+	defer s.cancel()
+	s.instanceID = "inst_default_default"
+	s.headless = false
+	s.restarting = true
+
+	s.restartInstance()
+
+	instances := orch.List()
+	if len(instances) != 1 {
+		t.Fatalf("expected 1 managed instance after restart, got %d", len(instances))
+	}
+	if instances[0].Headless {
+		t.Fatalf("expected restarted instance to remain headed, got headless=true")
+	}
+}
+
 func TestStrategy_ContextCancellation(t *testing.T) {
 	s := New(AutorestartConfig{
 		InitBackoff: 10 * time.Second, // Long backoff


### PR DESCRIPTION

## Summary

Fix `simple-autorestart` so it preserves the managed instance's mode across restarts.

Previously, the strategy always relaunched with `s.config.Headless`, which defaults to `true` when `HeadlessSet` is unset. That caused headed instances to come back as headless after restart.

This change:
- tracks the managed instance's actual `headless` state in the autorestart strategy
- records that state after the initial launch succeeds
- uses the tracked state, instead of the static config default, when restarting
- adds regression tests for initial mode tracking and restart mode preservation

## Why I Looked Into This

I hit this while using PinchTab in practice. A headless instance crashed, and I then tried to switch to headed mode for debugging. That exposed that the instance could not actually be switched to headed mode: the autorestart strategy kept reclaiming the profile with a headless relaunch.

That led me to trace the restart path in `simple-autorestart`, where the strategy was reusing a static config value instead of preserving the managed instance's actual mode.

## Root Cause

`simple-autorestart` only reused a static config value and never stored the runtime mode of the instance it was managing. As a result, restart paths fell back to the default headless behavior.

## Testing

- `go test ./internal/strategy/autorestart`

## Notes

This fixes the bug where a managed headed instance could be relaunched in headless mode after stop/crash recovery, which made switching from headless to headed mode effectively impossible.
