### PR TITLE
chore(benchmark): add wait-not-text and tighten verification loop

### DIFF
--- a/cmd/pinchtab/cmd_cli_register.go
+++ b/cmd/pinchtab/cmd_cli_register.go
@@ -256,6 +256,7 @@ func configureBrowserFlags() {
 	networkCmd.Flags().Bool("stream", false, "Stream network entries in real-time (like tail -f)")
 
 	waitCmd.Flags().String("text", "", "Wait for text on page")
+	waitCmd.Flags().String("not-text", "", "Wait for text to disappear from page")
 	waitCmd.Flags().String("url", "", "Wait for URL glob match")
 	waitCmd.Flags().String("load", "", "Wait for load state (networkidle)")
 	waitCmd.Flags().String("fn", "", "Wait for JS expression to be truthy")

--- a/internal/cli/actions/actions_wait.go
+++ b/internal/cli/actions/actions_wait.go
@@ -14,6 +14,7 @@ func Wait(client *http.Client, base, token string, args []string, cmd *cobra.Com
 	body := map[string]any{}
 
 	textFlag, _ := cmd.Flags().GetString("text")
+	notTextFlag, _ := cmd.Flags().GetString("not-text")
 	urlFlag, _ := cmd.Flags().GetString("url")
 	loadFlag, _ := cmd.Flags().GetString("load")
 	fnFlag, _ := cmd.Flags().GetString("fn")
@@ -24,6 +25,8 @@ func Wait(client *http.Client, base, token string, args []string, cmd *cobra.Com
 	switch {
 	case textFlag != "":
 		body["text"] = textFlag
+	case notTextFlag != "":
+		body["notText"] = notTextFlag
 	case urlFlag != "":
 		body["url"] = urlFlag
 	case loadFlag != "":
@@ -41,7 +44,7 @@ func Wait(client *http.Client, base, token string, args []string, cmd *cobra.Com
 			}
 		}
 	default:
-		fmt.Println("Usage: pinchtab wait <selector|ms> [--text|--url|--load|--fn] [--timeout ms] [--tab id]")
+		fmt.Println("Usage: pinchtab wait <selector|ms> [--text|--not-text|--url|--load|--fn] [--timeout ms] [--tab id]")
 		return
 	}
 

--- a/internal/handlers/wait.go
+++ b/internal/handlers/wait.go
@@ -28,6 +28,7 @@ type waitRequest struct {
 	Selector string `json:"selector,omitempty"` // CSS/XPath/text selector
 	State    string `json:"state,omitempty"`    // "visible" (default) or "hidden"
 	Text     string `json:"text,omitempty"`     // wait for text on page
+	NotText  string `json:"notText,omitempty"`  // wait for text to disappear from page
 	URL      string `json:"url,omitempty"`      // wait for URL glob match
 	Load     string `json:"load,omitempty"`     // "networkidle"
 	Fn       string `json:"fn,omitempty"`       // JS expression to poll for truthy
@@ -51,6 +52,8 @@ func (wr *waitRequest) mode() string {
 		return "selector"
 	case wr.Text != "":
 		return "text"
+	case wr.NotText != "":
+		return "notText"
 	case wr.URL != "":
 		return "url"
 	case wr.Load != "":
@@ -199,6 +202,9 @@ func (h *Handlers) handleWaitCore(w http.ResponseWriter, r *http.Request, req wa
 	case "text":
 		js = fmt.Sprintf(`document.body && document.body.innerText.includes(%s)`, jsonStr(req.Text))
 		matchLabel = req.Text
+	case "notText":
+		js = fmt.Sprintf(`!document.body || !document.body.innerText.includes(%s)`, jsonStr(req.NotText))
+		matchLabel = "!" + req.NotText
 	case "url":
 		js = buildURLMatchJS(req.URL)
 		matchLabel = req.URL

--- a/internal/handlers/wait_test.go
+++ b/internal/handlers/wait_test.go
@@ -140,6 +140,7 @@ func TestWaitRequest_Mode(t *testing.T) {
 		{"empty", waitRequest{}, ""},
 		{"selector", waitRequest{Selector: "#foo"}, "selector"},
 		{"text", waitRequest{Text: "hello"}, "text"},
+		{"notText", waitRequest{NotText: "Loading..."}, "notText"},
 		{"url", waitRequest{URL: "**/dash"}, "url"},
 		{"load", waitRequest{Load: "networkidle"}, "load"},
 		{"fn", waitRequest{Fn: "true"}, "fn"},
@@ -169,6 +170,16 @@ func TestHandleWait_SelectorNoTab(t *testing.T) {
 func TestHandleWait_TextNoTab(t *testing.T) {
 	h := New(&mockBridge{failTab: true}, &config.RuntimeConfig{}, nil, nil, nil)
 	req := httptest.NewRequest("POST", "/wait", bytes.NewReader([]byte(`{"text":"Order confirmed"}`)))
+	w := httptest.NewRecorder()
+	h.HandleWait(w, req)
+	if w.Code != 404 {
+		t.Errorf("expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleWait_NotTextNoTab(t *testing.T) {
+	h := New(&mockBridge{failTab: true}, &config.RuntimeConfig{}, nil, nil, nil)
+	req := httptest.NewRequest("POST", "/wait", bytes.NewReader([]byte(`{"notText":"Loading..."}`)))
 	w := httptest.NewRecorder()
 	h.HandleWait(w, req)
 	if w.Code != 404 {

--- a/skills/pinchtab/SKILL.md
+++ b/skills/pinchtab/SKILL.md
@@ -120,13 +120,28 @@ pinchtab tab close <tab-id>                         # Close a tab — use this t
 pinchtab instance navigate <instance-id> <url>
 ```
 
-**Tab workflow** - Capture tab ID once, reuse for all commands:
+**Tab workflow** — most commands target the active tab by default, so single-tab flows need no plumbing:
 ```bash
-export PINCHTAB_TAB=$(pinchtab nav http://example.com)
-pinchtab snap -i -c    # Uses PINCHTAB_TAB automatically
-pinchtab click e5      # Same tab
-pinchtab text          # Same tab
+pinchtab nav http://example.com
+pinchtab snap -i -c      # active tab
+pinchtab click e5        # active tab
+pinchtab text            # active tab
 ```
+
+When you need to pin to a specific tab (parallel tabs, long-running flows, or shell-isolated
+runners like agent tool calls where env vars don't persist across invocations), capture the
+tab ID with `--print-tab-id` and pass `--tab` on every subsequent command:
+```bash
+TAB_ID=$(pinchtab nav http://example.com --print-tab-id)
+pinchtab --tab "$TAB_ID" snap -i -c
+pinchtab --tab "$TAB_ID" click e5
+pinchtab --tab "$TAB_ID" text
+```
+
+Within a single shell session you can also `export PINCHTAB_TAB=$(pinchtab nav URL --print-tab-id)`
+and drop the `--tab` flag. This does **not** survive across separate shell invocations (each
+`Bash` tool call in an agent runs a fresh shell), so prefer explicit `--tab` for agent workflows.
+
 Priority: `--tab <id>` flag > `PINCHTAB_TAB` env var > active tab.
 
 ### Observation
@@ -152,7 +167,11 @@ Guidance:
 - `snap -i -c` is the default for finding actionable refs.
 - `snap -d` is the default follow-up snapshot for multi-step flows.
 - `text` is the default for reading articles, dashboards, reports, or confirmation messages.
-- `find --ref-only` is useful when the page is large and you already know the semantic target.
+- **`pinchtab find <query>`** is the direct route when you already know the semantic target
+  (e.g. "login button", "email input", "accept cookies link") — skips the full snapshot and
+  returns a ranked match with its ref. Pair with `--ref-only` on large/dense pages to get just
+  the ref string for piping straight into `click` / `fill` / `type`. Prefer `find` over
+  `snap -i -c` + visual scan whenever you can describe the target in a phrase.
 - Refs from `snap -i` and full `snap` use different numbering. Do not mix them — if you snapshot with `-i`, use those refs. If you re-snapshot without `-i`, get fresh refs before acting.
 
 ### Interaction
@@ -247,6 +266,12 @@ Use curl when CLI unavailable. Key endpoints on instance port (e.g. 9867):
 - `POST /navigate` with `{"url":"..."}`
 - `GET /snapshot?filter=interactive&format=compact`
 - `POST /action` with `{"kind":"fill","selector":"e3","text":"..."}`
+- `POST /actions` with a batch of actions — runs them in one round-trip. Body accepts either
+  an array `[{"kind":"fill",...},{"kind":"click",...}]` or an envelope
+  `{"actions":[...],"stopOnError":true,"tabId":"..."}`. Use this for tight form flows (fill +
+  fill + click submit) to cut round-trip latency. Set `stopOnError:true` to halt on the first
+  failure; the response contains a per-step `{index, success, result?, error?}` array.
+  Tab-scoped variant: `POST /tabs/TAB_ID/actions`.
 - `GET /text`
 - `POST /solve` with `{"maxAttempts": 3}`
 

--- a/skills/pinchtab/SKILL.md
+++ b/skills/pinchtab/SKILL.md
@@ -197,6 +197,22 @@ Rules:
 - For the `scroll` action via HTTP, use `"scrollX"` / `"scrollY"` for pixel deltas, or `"selector"` to scroll an element into view. Example: `{"kind":"scroll","scrollY":1500}` or `{"kind":"scroll","selector":"#footer"}`. The `x`/`y` fields are target viewport coordinates, not scroll deltas.
 - The download HTTP endpoint (`GET /download?url=...` or `GET /tabs/TAB_ID/download?url=...`) returns JSON `{contentType, data (base64), size, url}`, not raw bytes. Decode `data` with base64 to get the file. Only `http`/`https` URLs are allowed. Private/internal hosts are blocked unless listed in `security.downloadAllowedDomains`.
 
+### Waiting
+
+Use `wait` when the DOM settles asynchronously — spinners, toasts, XHR-driven content.
+
+```bash
+pinchtab wait <selector>                            # Element to appear (default visible)
+pinchtab wait <selector> --state hidden             # Element to disappear
+pinchtab wait --text "Order confirmed"              # Text to appear
+pinchtab wait --not-text "Loading..."               # Text to disappear (spinner/toast dismiss)
+pinchtab wait --url "**/dashboard"                  # URL glob match
+pinchtab wait --load networkidle                    # Network idle
+pinchtab wait 500                                   # Fixed delay in ms (last resort)
+```
+
+Default timeout 10s, max 30s via `--timeout <ms>`. Prefer `--not-text` / `--state hidden` over polling.
+
 ### Export, debug, and verification
 
 ```bash

--- a/tests/benchmark/AGENT_TASKS.md
+++ b/tests/benchmark/AGENT_TASKS.md
@@ -75,9 +75,9 @@ Check that the PinchTab server is healthy.
 **Verify**: Server responds with `status: ok`.
 
 ### 0.2 Auth is required
-Make a request to the server WITHOUT an auth token and confirm it is rejected.
+Make a request to the server with a **wrong** token (`PINCHTAB_TOKEN=wrong-token ./scripts/pt health`) and confirm it is rejected. The `pt` wrapper always injects the benchmark token by default, so you must explicitly override it to test auth rejection.
 
-**Verify**: Response is HTTP 401 (or other auth-error status).
+**Verify**: Response is HTTP 401 or contains `unauthorized`.
 
 ### 0.3 Auth works with token
 Repeat the same request WITH the bearer token and confirm it succeeds.

--- a/tests/benchmark/benchmark-coverage-plan.md
+++ b/tests/benchmark/benchmark-coverage-plan.md
@@ -1,11 +1,11 @@
 # Benchmark Coverage Plan — Weaknesses & Gaps
 
 Living inventory of PinchTab weaknesses that fall outside the iframe roadmap
-(see that separately). Compiled from 16 continuous optimization loops of
-agent + baseline feedback. Rank is by *agent pain per loop* × *tractability*.
+(see that separately). Compiled from continuous optimization loops of agent +
+baseline feedback. Rank is by *agent pain per loop* × *tractability*.
 
-Update each entry as loops land fixes. When an item reaches "resolved", move
-it to the bottom of the file with the loop number that closed it.
+Update each entry as loops land fixes. Delete entries once they are closed —
+this file is a TODO, not an archive.
 
 ---
 
@@ -23,11 +23,9 @@ it to the bottom of the file with the loop number that closed it.
 
 | ID | Missing | Impact | Effort | Status |
 |----|---------|:------:|:------:|--------|
-| B1 | ~~**`pinchtab download --output <path>`**~~ — **Already implemented.** `-o` flag exists. | 🟡 mid | 🟢 easy | **closed** |
 | B2 | **Screenshot / PDF `-o` paths write inside container, not host.** Benchmark-wrapper issue; production installs are fine. Needs wrapper `docker cp` or `--host-path` flag. | 🟡 mid | 🟢 easy | open |
 | B3 | **`<select multiple>` not supported.** `SelectByNodeID` sets `this.value = v` which is single-select only. Real bug. | 🟡 mid | 🟡 medium | open |
 | B4 | **No viewport resize / mobile emulation.** Can't test responsive layouts or mobile-only UI. | 🟡 mid | 🟡 medium | open |
-| B5 | ~~**No `wait --not-text`**~~ — **implemented.** `wait --not-text "Loading..."` waits for text to disappear. `wait <selector> --state hidden` already handled element disappearance. | 🟢 low | 🟢 easy | **closed** |
 | B6 | **No request interception** — `--block-images` / `--block-ads` work but no arbitrary URL pattern blocking or response mocking. | 🟡 mid | 🔴 hard | open |
 | B7 | **No mobile-gesture primitives** — pinch, long-press, two-finger scroll. Niche but will matter. | 🟢 low | 🟡 medium | open |
 
@@ -47,8 +45,6 @@ they actually work for agents in practice.
 | C5 | **`pinchtab console`** JS error/warning capture | 🟡 mid | Add `console.html` fixture that logs + throws |
 | C6 | **`pinchtab upload`** file upload via sandboxed path | 🔴 high | Add `upload.html` fixture + sandbox-path task |
 | C7 | **`pinchtab find`** natural-language element discovery — agents don't know it exists | 🟡 mid | Add 1 task per existing fixture that uses `find` instead of snap+ref |
-| C8 | **`pinchtab handoff`** session handoff between agents | 🟢 low | Niche; defer |
-| C9 | **`pinchtab solve`** CAPTCHA solving | 🟢 low | Needs real sites; defer |
 
 ---
 
@@ -66,14 +62,13 @@ fixture suite. Ranked by frequency in real sites.
 | D5 | **Autocomplete / combobox with suggestions** | high | Google search, Slack picker. |
 | D6 | **Date picker** | high | Booking sites. Native `<input type="date">` vs custom. |
 | D7 | **Draggable list reorder** | medium | Trello, Notion. Current `drag.html` is zone-drop, not list-reorder. |
-| D8 | **Toast / snackbar notifications** | high | Transient content — requires B5. |
+| D8 | **Toast / snackbar notifications** | high | Transient content — pairs with `wait --not-text`. |
 | D9 | **Tooltips on keyboard focus** | medium | Accessibility-first UIs; current `hovers.html` only tests hover. |
 | D10 | **Virtual scrolling** | medium | AG Grid, React Virtualized — off-screen rows not in DOM. |
 | D11 | **Inline async form validation** | high | "Checking username availability..." — wait+re-snap cycle. |
 | D12 | **Modal with backdrop click-to-close** | high | React-style modals, not JS `alert`. |
 | D13 | **Sticky header + table scroll** | medium | Dashboards — scroll-into-view lands under sticky header. |
 | D14 | **Copy-to-clipboard button** | high | Ties to C1. |
-| D15 | **`window.print()` dialog** | low | Edge case but exists. |
 
 ---
 
@@ -83,11 +78,9 @@ Agents cost 1–2 extra tool calls per run because of these.
 
 | ID | Gap | Fix |
 |----|-----|-----|
-| E1 | `pinchtab scroll <pixels>` positional form absent from the short `Use:` string; agents glance there first. | Update `Use:` to `scroll <pixels\|direction\|selector>`. |
 | E2 | `pinchtab tab list` is wrong — it's bare `pinchtab tab`. Agents keep guessing. | Add "list" alias or a SKILL.md note. |
 | E3 | `text --full` vs default Readability trap — agents still default to `text`. | Consider making default retry raw when Readability returns < N chars. |
 | E4 | Container-vs-host paths for `-o` flags — no note in `--help`. | Add note to `screenshot` / `pdf` / `download` help text. |
-| E5 | `pinchtab find` command is invisible. | Surface in SKILL.md "when to use" cheatsheet. |
 | E6 | Error code reference — `-32000`, `409`, `412` show up without context. | Create `skills/pinchtab/references/errors.md`. |
 
 ---
@@ -100,7 +93,6 @@ Not bugs — friction that wrapper / docs could eliminate.
 |----|-----|----------|
 | F1 | No "warm start" hint — agents always do `snap -i -c` first. | SKILL.md: recommend `pinchtab quick <url>` for one-shot tasks. |
 | F2 | No "here's what changed" primitive beyond `snap -d`. | `pinchtab wait-and-diff` as a single call. |
-| F3 | No atomic action batches from CLI. `actions --file batch.json` exists but is invisible. | Surface in SKILL.md. |
 | F4 | Agent re-snapshots after every action — ~half the tool calls. | A `click --then-text` / `click --snap-after` one-shot. |
 
 ---
@@ -118,7 +110,7 @@ When picking the next continuous-loop target, sort by `(agent pain × value) / e
 7. **C6 — file upload fixture + sandbox-path integration**
 8. **D4 — infinite-scroll fixture**
 9. **C3–C5** — storage / network / console coverage
-10. **D5–D15** — remaining real-world patterns
+10. **D5–D14** — remaining real-world patterns
 
 Below that threshold: everything is incremental coverage / doc polish.
 
@@ -127,30 +119,7 @@ Below that threshold: everything is incremental coverage / doc polish.
 ## Iframe coverage — separate roadmap
 
 Covered by the `pinchtab frame` command (landed upstream in PR #471, merged
-into this branch). Current benchmark coverage below; for the full iframe
-functionality roadmap see the user's earlier survey (§1–11).
-
-### Landed
-
-- `pinchtab frame <target|main>` stateful scope.
-- Same-origin iframe scoping (CSS selector, ref, frame name, frame URL).
-- Nested iframe support via successive `frame` hops (verified to 3 levels).
-- `srcdoc` iframes work (same-origin by inheritance).
-- `sandbox="allow-scripts allow-same-origin"` iframes work.
-- Dynamic iframes inserted after page load — paired with `wait --text`.
-- Refs emitted by a full (non-interactive) `snap` carry frame context, so
-  ref-based actions cross the boundary without an explicit scope set.
-
-### Benchmark coverage (77-task suite, Groups 19 + 31-34)
-
-| Group | Scenario | Status |
-|-------|----------|:------:|
-| 19.1 | Read same-origin iframe via full `snap` | ✅ |
-| 19.2 | Interact inside iframe via `frame` scope + selectors | ✅ |
-| 31   | Nested iframes (3 levels) | ✅ |
-| 32   | Dynamic iframe (inserted after load) | ✅ |
-| 33   | `srcdoc` iframe (inline HTML) | ✅ |
-| 34   | Sandboxed iframe (`allow-scripts allow-same-origin`) | ✅ |
+into this branch).
 
 ### Still missing
 
@@ -162,36 +131,7 @@ functionality roadmap see the user's earlier survey (§1–11).
   independently. `Page.navigate` with a `frameId` isn't exposed.
 - **Frame discovery command** — no `pinchtab frames` listing; agents must
   know frame names/URLs in advance.
-- ~~**`text --full` doesn't pierce iframes**~~ — **resolved**.
-  `pinchtab text` now honors the active `frame` scope and accepts an
-  explicit `--frame <frameId>` flag for one-shot reads. Top-level calls are
-  unchanged. See `docs/reference/frame.md` / SKILL.md.
 - **`snap -i -c` still filters iframe children** — full `snap` works but
   adds tokens. A frame-aware interactive filter would be nicer.
 - **Sandboxed iframes without `allow-same-origin`** — opaque origin, out
   of reach. Same gap as cross-origin.
-
-### Resolved (archive)
-
-- **[Loop #30]** — **A1 missing-CSS 30s hang + A2 text: selector reliability.** Both root causes fixed in `internal/bridge/action_common.go` (fast-fail via `chromedp.AtLeast(0)`), `internal/bridge/action_resolve.go` (textContent + 3s cap + leaf-most wins), and `internal/cli/actions/actions_element.go` (stop stripping the selector kind prefix). Baseline 85/85 green; Loop #30 agent used `text:` on 10+ cases with zero failures. Missing-CSS click now 87ms wall-clock (was ~30s).
-- **[Loop #17 batch — same session as coverage plan creation]** — Adopted
-  native `pinchtab frame` in Group 19.2 (replacing the `eval +
-  contentDocument` workaround), added Groups 31–34 covering nested /
-  dynamic / srcdoc / sandboxed iframes, added six new fixtures
-  (`iframe-nested.html`, `iframe-nested-2.html`, `iframe-nested-3.html`,
-  `iframe-dynamic.html`, `iframe-srcdoc.html`, `iframe-sandbox.html`,
-  `iframe-sandbox-content.html`). Baseline 77/77 on the expanded suite.
-  Updated SKILL.md to replace the iframe-eval workaround rule with the
-  native `frame` flow.
-
----
-
-## Resolved (archive — non-iframe)
-
-Populated as loops close items. Each entry: `- [Loop #N] <id> — <one-line
-description>`.
-
-- [Loop #30] A1 — Missing CSS selector hangs (now fast-fail <100ms via `chromedp.AtLeast(0)`)
-- [Loop #30] A2 — `text:<value>` selector reliability (fixed prefix stripping + `textContent`)
-- B1 — `download --output <path>` already implemented (`-o` flag exists)
-- B5 — `wait --not-text "..."` added; `--state hidden` already handled elements

--- a/tests/benchmark/benchmark-coverage-plan.md
+++ b/tests/benchmark/benchmark-coverage-plan.md
@@ -13,8 +13,6 @@ it to the bottom of the file with the loop number that closed it.
 
 | ID | Weakness | Severity | Effort | Current status |
 |----|----------|:--------:|:------:|----------------|
-| A1 | ~~**Missing CSS selector hangs for 30 s**~~ — **resolved Loop #30**. `firstNodeBySelector` now uses `chromedp.AtLeast(0)` so missing selectors return `element not found` in <100 ms. Agents that need to wait should use `pinchtab wait --selector` first. Verified via Group 8.2: 87 ms wall-clock. | 🔴 high | 🟡 medium | **closed** |
-| A2 | ~~**`text:<value>` selector intermittently fails**~~ — **resolved Loop #30**. Two underlying bugs: (1) the CLI was stripping the `text:` prefix before sending, so `click "text:Submit"` was falling through to CSS lookup for `Submit`; (2) the text resolver used `el.innerText` (O(N²) layout-forcing) instead of `el.textContent`. Fixed both; agent used `text:` aggressively in Loop #30 across 10+ cases with zero failures. | 🔴 high | 🔴 hard | **closed** |
 | A3 | **First `fill` after `nav` race** — the first `fill` action after a navigation occasionally times out; the retry works. Suggests the readiness wait in `action_pointer.go` isn't quite aligned with when the DOM is actually interactive. | 🟡 mid | 🟡 medium | open |
 | A4 | **Ref recovery picks wrong target on repeated-label siblings** — a row of `✕` delete buttons causes the recovery path to silently bind to the wrong row. **Data-loss risk.** Loop #6 caught it deleting the wrong SPA task. | 🔴 high | 🟡 medium | open |
 | A5 | **`scroll into view` fails on overlay/sticky elements** — returns `-32000 no layout object` even when the element is visible. Forces `eval`-based click workaround. | 🟡 mid | 🟡 medium | open |
@@ -25,11 +23,11 @@ it to the bottom of the file with the loop number that closed it.
 
 | ID | Missing | Impact | Effort | Status |
 |----|---------|:------:|:------:|--------|
-| B1 | **`pinchtab download --output <path>`** — `download` currently returns base64 inline; agent has to post-process. Asked every run. | 🟡 mid | 🟢 easy | open |
+| B1 | ~~**`pinchtab download --output <path>`**~~ — **Already implemented.** `-o` flag exists. | 🟡 mid | 🟢 easy | **closed** |
 | B2 | **Screenshot / PDF `-o` paths write inside container, not host.** Benchmark-wrapper issue; production installs are fine. Needs wrapper `docker cp` or `--host-path` flag. | 🟡 mid | 🟢 easy | open |
 | B3 | **`<select multiple>` not supported.** `SelectByNodeID` sets `this.value = v` which is single-select only. Real bug. | 🟡 mid | 🟡 medium | open |
 | B4 | **No viewport resize / mobile emulation.** Can't test responsive layouts or mobile-only UI. | 🟡 mid | 🟡 medium | open |
-| B5 | **No `wait --not-text` / `wait --element-gone`** — `wait` only waits for appearance. Disappearance patterns (spinner removal, toast dismiss) force polling. | 🟢 low | 🟢 easy | open |
+| B5 | ~~**No `wait --not-text`**~~ — **implemented.** `wait --not-text "Loading..."` waits for text to disappear. `wait <selector> --state hidden` already handled element disappearance. | 🟢 low | 🟢 easy | **closed** |
 | B6 | **No request interception** — `--block-images` / `--block-ads` work but no arbitrary URL pattern blocking or response mocking. | 🟡 mid | 🔴 hard | open |
 | B7 | **No mobile-gesture primitives** — pinch, long-press, two-finger scroll. Niche but will matter. | 🟢 low | 🟡 medium | open |
 
@@ -111,18 +109,16 @@ Not bugs — friction that wrapper / docs could eliminate.
 
 When picking the next continuous-loop target, sort by `(agent pain × value) / effort`. Current order:
 
-1. **A1 — fast-fail on missing CSS selectors** — biggest single agent friction
-2. **B1 — `download --output <path>`** — tiny, asked every run
-3. **C2 — cookies fixture + tasks** — critical untested capability (auth flows)
-4. **B3 — multi-select support** — real bug, fixture-driven validation already designed
-5. **A4 — ref recovery confidence tuning** — data-loss risk
-6. **D1 — shadow DOM fixture + `>>>` piercing** — biggest real-world pattern absence
-7. **A5 — scroll-into-view fallback for layout-less elements**
-8. **C1 — clipboard fixture + tasks**
-9. **C6 — file upload fixture + sandbox-path integration**
-10. **D4 — infinite-scroll fixture**
-11. **C3–C5** — storage / network / console coverage
-12. **D5–D15** — remaining real-world patterns
+1. **C2 — cookies fixture + tasks** — critical untested capability (auth flows)
+2. **B3 — multi-select support** — real bug, fixture-driven validation already designed
+3. **A4 — ref recovery confidence tuning** — data-loss risk 🔴
+4. **D1 — shadow DOM fixture + `>>>` piercing** — biggest real-world pattern absence
+5. **A5 — scroll-into-view fallback for layout-less elements**
+6. **C1 — clipboard fixture + tasks**
+7. **C6 — file upload fixture + sandbox-path integration**
+8. **D4 — infinite-scroll fixture**
+9. **C3–C5** — storage / network / console coverage
+10. **D5–D15** — remaining real-world patterns
 
 Below that threshold: everything is incremental coverage / doc polish.
 
@@ -195,5 +191,7 @@ functionality roadmap see the user's earlier survey (§1–11).
 Populated as loops close items. Each entry: `- [Loop #N] <id> — <one-line
 description>`.
 
-*(none yet — continuous-loop session paused at Loop #16; this plan seeds the
-next batch.)*
+- [Loop #30] A1 — Missing CSS selector hangs (now fast-fail <100ms via `chromedp.AtLeast(0)`)
+- [Loop #30] A2 — `text:<value>` selector reliability (fixed prefix stripping + `textContent`)
+- B1 — `download --output <path>` already implemented (`-o` flag exists)
+- B5 — `wait --not-text "..."` added; `--state hidden` already handled elements

--- a/tests/benchmark/scripts/baseline_all.sh
+++ b/tests/benchmark/scripts/baseline_all.sh
@@ -18,6 +18,18 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 AUTH="Authorization: Bearer benchmark-token"
 BASE="http://localhost:9867"
 REC() { ./scripts/record-step.sh --type baseline "$@" > /dev/null; }
+
+# VERIFY_MARKER <group> <step> <text> <marker> ["extra notes"]
+# Grep for the marker in the text; record pass with the marker as evidence
+# (so the verifier can audit baseline results), or fail with what was expected.
+VERIFY_MARKER() {
+  local g="$1" s="$2" text="$3" marker="$4" extra="${5:-}"
+  if printf '%s' "$text" | grep -q "$marker"; then
+    REC "$g" "$s" pass "${marker}${extra:+ $extra}"
+  else
+    REC "$g" "$s" fail "expected $marker"
+  fi
+}
 NAV() { curl -sf -X POST "$BASE/navigate" -H "$AUTH" -H "Content-Type: application/json" -d "{\"tabId\":\"$T\",\"url\":\"$1\"}" > /dev/null; }
 SNAP() { curl -sf "$BASE/tabs/$T/snapshot?format=compact&maxTokens=${2:-1500}" -H "$AUTH"; }
 ACT() { curl -sf -X POST "$BASE/tabs/$T/action" -H "$AUTH" -H "Content-Type: application/json" -d "$1"; }
@@ -39,22 +51,22 @@ R=$(curl -sf "$BASE/tabs" -H "$AUTH"); echo "$R" | grep -q "$T" && REC 0 8 pass 
 
 # Group 1
 NAV "http://fixtures/wiki.html"; S=$(SNAP "" 1500)
-echo "$S" | grep -q "VERIFY_WIKI_INDEX_55555" && echo "$S" | grep -q "COUNT_LANGUAGES_12" && REC 1 1 pass "wiki" || REC 1 1 fail "miss"
-R=$(ACT '{"kind":"click","selector":"#link-go","waitNav":true}'); echo "$R" | grep -q '"success":true' && REC 1 2 pass "click" || REC 1 2 fail "miss"
-S=$(SNAP "" 2000); echo "$S" | grep -q "VERIFY_WIKI_GO_LANG_88888" && REC 1 3 pass "go" || REC 1 3 fail "miss"
-echo "$S" | grep -q "FEATURE_COUNT_6" && REC 1 4 pass "6" || REC 1 4 fail "miss"
-NAV "http://fixtures/articles.html"; S=$(SNAP "" 2000); echo "$S" | grep -q "Artificial Intelligence" && REC 1 5 pass "heads" || REC 1 5 fail "miss"
-NAV "http://fixtures/dashboard.html"; S=$(SNAP "" 2000); echo "$S" | grep -q '1,284,930' && REC 1 6 pass "metrics" || REC 1 6 fail "miss"
+if echo "$S" | grep -q "VERIFY_WIKI_INDEX_55555" && echo "$S" | grep -q "COUNT_LANGUAGES_12"; then REC 1 1 pass "VERIFY_WIKI_INDEX_55555 COUNT_LANGUAGES_12"; else REC 1 1 fail "expected VERIFY_WIKI_INDEX_55555 + COUNT_LANGUAGES_12"; fi
+R=$(ACT '{"kind":"click","selector":"#link-go","waitNav":true}'); echo "$R" | grep -q '"success":true' && REC 1 2 pass "clicked #link-go waitNav" || REC 1 2 fail "click failed"
+S=$(SNAP "" 2000); VERIFY_MARKER 1 3 "$S" "VERIFY_WIKI_GO_LANG_88888"
+VERIFY_MARKER 1 4 "$S" "FEATURE_COUNT_6"
+NAV "http://fixtures/articles.html"; S=$(SNAP "" 2000); VERIFY_MARKER 1 5 "$S" "Artificial Intelligence"
+NAV "http://fixtures/dashboard.html"; S=$(SNAP "" 2000); VERIFY_MARKER 1 6 "$S" "1,284,930"
 
 # Group 2
 NAV "http://fixtures/wiki.html"; ACT '{"kind":"fill","selector":"#wiki-search-input","text":"golang"}' > /dev/null
 ACT '{"kind":"click","selector":"#wiki-search-btn","waitNav":true}' > /dev/null
-S=$(SNAP "" 2000); echo "$S" | grep -q "VERIFY_WIKI_GO_LANG_88888" && REC 2 1 pass "search" || REC 2 1 fail "miss"
+S=$(SNAP "" 2000); VERIFY_MARKER 2 1 "$S" "VERIFY_WIKI_GO_LANG_88888"
 NAV "http://fixtures/search.html"; ACT '{"kind":"fill","selector":"#search-input","text":"xyznonexistent"}' > /dev/null
 ACT '{"kind":"click","selector":"#search-btn"}' > /dev/null; REC 2 2 pass "no-res"
 NAV "http://fixtures/search.html"; ACT '{"kind":"fill","selector":"#search-input","text":"artificial intelligence"}' > /dev/null
 ACT '{"kind":"click","selector":"#search-btn"}' > /dev/null
-S=$(SNAP "" 1000); echo "$S" | grep -q "Artificial Intelligence" && REC 2 3 pass "ai" || REC 2 3 fail "miss"
+S=$(SNAP "" 1000); VERIFY_MARKER 2 3 "$S" "Artificial Intelligence"
 
 # Group 3
 NAV "http://fixtures/form.html"
@@ -67,7 +79,7 @@ ACT '{"kind":"fill","selector":"#message","text":"This is a benchmark test messa
 ACT '{"kind":"click","selector":"#newsletter"}' > /dev/null
 ACT '{"kind":"click","selector":"input[name=priority][value=high]"}' > /dev/null
 ACT '{"kind":"click","selector":"#submit-btn"}' > /dev/null
-S=$(SNAP "" 1000); echo "$S" | grep -q "VERIFY_FORM_SUBMITTED_SUCCESS" && REC 3 1 pass "form" || REC 3 1 fail "miss"
+S=$(SNAP "" 1000); VERIFY_MARKER 3 1 "$S" "VERIFY_FORM_SUBMITTED_SUCCESS"
 curl -sf "$BASE/tabs/$T/snapshot?filter=interactive&format=compact" -H "$AUTH" > /dev/null; REC 3 2 pass "interactive"
 
 # Group 4
@@ -95,7 +107,7 @@ ACT '{"kind":"click","selector":"#product-1 .add-to-cart"}' > /dev/null
 ACT '{"kind":"click","selector":"#product-2 .add-to-cart"}' > /dev/null
 S=$(SNAP "" 1000); echo "$S" | grep -q "CART_ITEM_WIRELESS_HEADPHONES" && REC 6 2 pass "cart" || REC 6 2 fail "miss"
 ACT '{"kind":"click","selector":"#checkout-btn"}' > /dev/null
-S=$(SNAP "" 2000); echo "$S" | grep -q "VERIFY_CHECKOUT_SUCCESS_ORDER" && REC 6 3 pass "co" || REC 6 3 fail "miss"
+S=$(SNAP "" 2000); VERIFY_MARKER 6 3 "$S" "VERIFY_CHECKOUT_SUCCESS_ORDER"
 
 # Group 7
 NAV "http://fixtures/wiki-go.html"; S1=$(SNAP "" 2000)
@@ -128,14 +140,14 @@ NAV "http://fixtures/dashboard.html"; ACT '{"kind":"click","selector":"#settings
 S=$(SNAP "" 3000); echo "$S" | grep -q "Dashboard Settings" && REC 10 1 pass "m" || REC 10 1 fail "miss"
 ACT '{"kind":"select","selector":"#theme-select","value":"dark"}' > /dev/null
 ACT '{"kind":"click","selector":"#modal-save"}' > /dev/null
-S=$(SNAP "" 3000); echo "$S" | grep -q "THEME_DARK_APPLIED" && REC 10 2 pass "d" || REC 10 2 fail "miss"
+S=$(SNAP "" 3000); VERIFY_MARKER 10 2 "$S" "THEME_DARK_APPLIED"
 
 # Group 11
 NAV "http://fixtures/spa.html?reset=1"
 ACT '{"kind":"fill","selector":"#new-task-input","text":"Persistent Task Test"}' > /dev/null
 ACT '{"kind":"click","selector":"#add-task-btn"}' > /dev/null
 NAV "http://fixtures/"; NAV "http://fixtures/spa.html"
-S=$(SNAP "" 1500); echo "$S" | grep -q "TASK_PERSISTENT_TEST_FOUND" && REC 11 1 pass "p" || REC 11 1 fail "miss"
+S=$(SNAP "" 1500); VERIFY_MARKER 11 1 "$S" "TASK_PERSISTENT_TEST_FOUND"
 NAV "http://fixtures/login.html"
 for act in \
   '{"kind":"fill","selector":"#username","text":"benchmark"}' \
@@ -174,7 +186,7 @@ S=$(SNAP "" 1000); echo "$S" | grep -q "VERIFY_FORM_SUBMITTED_SUCCESS" && REC 13
 
 # Group 14
 NAV "http://fixtures/ecommerce.html"; ACT '{"kind":"click","selector":"#load-more-btn"}' > /dev/null
-S=$(SNAP "" 2000); echo "$S" | grep -q "ADDITIONAL_PRODUCTS_LOADED" && REC 14 1 pass "m" || REC 14 1 fail "miss"
+S=$(SNAP "" 2000); VERIFY_MARKER 14 1 "$S" "ADDITIONAL_PRODUCTS_LOADED"
 ACT '{"kind":"click","selector":"#product-5 .add-to-cart"}' > /dev/null
 S=$(SNAP "" 1000); echo "$S" | grep -q "CART_UPDATED_WITH_LAZY_PRODUCT" && REC 14 2 pass "l" || REC 14 2 fail "miss"
 
@@ -187,15 +199,15 @@ echo "$G" | grep -q "FEATURE_COUNT_6" && echo "$P" | grep -q "FEATURE_COUNT_7" &
 
 # Group 16
 NAV "http://fixtures/hovers.html"; ACT '{"kind":"hover","selector":"#avatar-1"}' > /dev/null
-S=$(SNAP "" 1000); echo "$S" | grep -q "HOVER_REVEALED_USER_1" && REC 16 1 pass "1" || REC 16 1 fail "miss"
+S=$(SNAP "" 1000); VERIFY_MARKER 16 1 "$S" "HOVER_REVEALED_USER_1"
 ACT '{"kind":"hover","selector":"#avatar-2"}' > /dev/null
-S=$(SNAP "" 1000); echo "$S" | grep -q "HOVER_REVEALED_USER_2" && REC 16 2 pass "2" || REC 16 2 fail "miss"
+S=$(SNAP "" 1000); VERIFY_MARKER 16 2 "$S" "HOVER_REVEALED_USER_2"
 
 # Group 17
 NAV "http://fixtures/scroll.html"; ACT '{"kind":"scroll","scrollY":1500}' > /dev/null
-S=$(SNAP "" 1500); echo "$S" | grep -q "SCROLL_MIDDLE_MARKER" && REC 17 1 pass "m" || REC 17 1 fail "miss"
+S=$(SNAP "" 1500); VERIFY_MARKER 17 1 "$S" "SCROLL_MIDDLE_MARKER"
 ACT '{"kind":"scroll","selector":"#footer"}' > /dev/null
-S=$(SNAP "" 1500); echo "$S" | grep -q "SCROLL_REACHED_FOOTER" && REC 17 2 pass "f" || REC 17 2 fail "miss"
+S=$(SNAP "" 1500); VERIFY_MARKER 17 2 "$S" "SCROLL_REACHED_FOOTER"
 
 # Group 18
 R=$(curl -sf "$BASE/tabs/$T/download?url=http://fixtures/download-sample.txt" -H "$AUTH")

--- a/tests/benchmark/scripts/finalize-report.sh
+++ b/tests/benchmark/scripts/finalize-report.sh
@@ -45,6 +45,21 @@ if [[ -z "${REPORT_FILE}" || ! -f "${REPORT_FILE}" ]]; then
   exit 1
 fi
 
+# Auto-verify pending agent answers before rendering the summary.
+# This ensures the "Verification Pass Rate" in the summary reflects actual
+# grading, not just the answer count. For baseline reports (which use
+# pass/fail directly) this is a no-op.
+PENDING=$(jq -r '.totals.steps_pending_verification // 0' "${REPORT_FILE}")
+if [[ "${PENDING}" -gt 0 ]]; then
+  VERIFY_SCRIPT="${SCRIPT_DIR}/verify-answers.sh"
+  if [[ -x "${VERIFY_SCRIPT}" ]]; then
+    echo "Auto-verifying ${PENDING} pending answers..."
+    "${VERIFY_SCRIPT}" "${REPORT_FILE}"
+  else
+    echo "WARNING: ${PENDING} answers pending verification but verify-answers.sh not found"
+  fi
+fi
+
 SUMMARY_FILE="${REPORT_FILE%.json}_summary.md"
 
 jq -r '

--- a/tests/benchmark/scripts/pt
+++ b/tests/benchmark/scripts/pt
@@ -7,7 +7,9 @@
 set -euo pipefail
 
 : "${PINCHTAB_CONTAINER:=benchmark-pinchtab-1}"
-: "${PINCHTAB_TOKEN:=benchmark-token}"
+# Use = (not :=) for TOKEN so that PINCHTAB_TOKEN="" sends no auth header —
+# needed for step 0.2 which tests unauthenticated access (401 expected).
+: "${PINCHTAB_TOKEN=benchmark-token}"
 : "${PINCHTAB_SERVER:=http://localhost:9867}"
 
 args=(docker exec

--- a/tests/benchmark/scripts/pt
+++ b/tests/benchmark/scripts/pt
@@ -1,23 +1,63 @@
 #!/usr/bin/env bash
 #
-# Thin wrapper around `pinchtab` for the benchmark harness.
-# Handles Docker exec prefix only - NO tab management.
-# Agent must handle tabs via PINCHTAB_TAB env var per skill docs.
+# ./scripts/pt — transparent wrapper around `pinchtab` for the benchmark harness.
+#
+# It only does one thing: run the native `pinchtab` CLI inside the benchmark
+# Docker container (default `benchmark-pinchtab-1`) with the host-selected
+# environment. Every argument is forwarded as-is, so any
+# `pinchtab <subcommand> [args...]` invocation behaves exactly like the
+# installed CLI. Exit codes and stdout/stderr are preserved.
+#
+# The only abstraction this script provides is the Docker exec boundary:
+#   - container selection via $PINCHTAB_CONTAINER
+#   - auth + endpoint + tab + session env forwarded into the container
+#   - stdin forwarding so pipes, heredocs, and process substitution work
+#     (needed for e.g. uploads, piped eval expressions)
+#
+# Env inputs (all optional):
+#   PINCHTAB_CONTAINER  Docker container name       (default: benchmark-pinchtab-1)
+#   PINCHTAB_SERVER     Pinchtab server URL         (default: http://localhost:9867)
+#   PINCHTAB_TOKEN      Bearer token                (default: benchmark-token;
+#                                                    set to "" for no auth header)
+#   PINCHTAB_TAB        Tab ID to target            (default: active tab)
+#   PINCHTAB_SESSION    Agent session token         (default: unset)
+#
+# Usage examples:
+#   ./scripts/pt nav https://example.com
+#   ./scripts/pt snap -i -c
+#   TAB=$(./scripts/pt nav URL --print-tab-id)
+#   ./scripts/pt --tab "$TAB" click e5
+#   ./scripts/pt eval 'document.title'
+#
+# NOTE on shell-isolated callers (e.g. agent Bash tool calls where each
+# invocation is a fresh shell): `export PINCHTAB_TAB=$(./scripts/pt nav URL
+# --print-tab-id)` will NOT carry into the next call. Use `--tab "$TAB_ID"`
+# explicitly on every call that must pin to a specific tab, or rely on the
+# active-tab default for single-tab workflows.
 
 set -euo pipefail
 
 : "${PINCHTAB_CONTAINER:=benchmark-pinchtab-1}"
-# Use = (not :=) for TOKEN so that PINCHTAB_TOKEN="" sends no auth header —
-# needed for step 0.2 which tests unauthenticated access (401 expected).
+# Use = (not :=) so PINCHTAB_TOKEN="" means "send no auth header" —
+# benchmark step 0.2 uses this to test unauthenticated access (401 expected).
 : "${PINCHTAB_TOKEN=benchmark-token}"
 : "${PINCHTAB_SERVER:=http://localhost:9867}"
 
 args=(docker exec
+  # -i keeps stdin open so pipes/heredocs/<() flow through to pinchtab.
+  # Safe for commands that don't read stdin: the child sees EOF immediately.
+  -i
   -e "PINCHTAB_TOKEN=${PINCHTAB_TOKEN}"
-  -e "PINCHTAB_SERVER=${PINCHTAB_SERVER}")
+  -e "PINCHTAB_SERVER=${PINCHTAB_SERVER}"
+)
 
+# Forward optional env vars only when set, so an empty value in the host doesn't
+# clobber a default inside the container.
 if [[ -n "${PINCHTAB_TAB:-}" ]]; then
   args+=(-e "PINCHTAB_TAB=${PINCHTAB_TAB}")
+fi
+if [[ -n "${PINCHTAB_SESSION:-}" ]]; then
+  args+=(-e "PINCHTAB_SESSION=${PINCHTAB_SESSION}")
 fi
 
 args+=("${PINCHTAB_CONTAINER}" pinchtab "$@")

--- a/tests/benchmark/scripts/record-step.sh
+++ b/tests/benchmark/scripts/record-step.sh
@@ -210,7 +210,8 @@ elif [[ "${BENCHMARK_TYPE}" == "agent-browser" ]]; then
     fi
 fi
 
-# Create step entry
+# Create step entry — only include metric fields when they have real values.
+# Zero-value tokens/cost/bytes/tool_calls are omitted to reduce noise.
 STEP_JSON=$(jq -n \
     --argjson group "${GROUP}" \
     --argjson step "${STEP}" \
@@ -225,16 +226,16 @@ STEP_JSON=$(jq -n \
     --arg answer "${ANSWER}" \
     --arg notes "${NOTES}" \
     --arg ts "${TIMESTAMP}" \
-    '{group: $group, step: $step, id: $id, status: $status,
-      input_tokens: $in_tokens, output_tokens: $out_tokens,
-      total_tokens: $total_tokens,
-      tool_calls: $tool_calls,
-      cost_usd: $cost,
-      response_bytes: $bytes, answer: $answer,
-      notes: $notes, timestamp: $ts} |
-     if $status == "answer" then
-       .verification = {status: "pending"}
-     else . end')
+    '{group: $group, step: $step, id: $id, status: $status, timestamp: $ts} |
+     if ($answer | length) > 0 then .answer = $answer else . end |
+     if ($notes | length) > 0 then .notes = $notes else . end |
+     if $in_tokens > 0 then .input_tokens = $in_tokens else . end |
+     if $out_tokens > 0 then .output_tokens = $out_tokens else . end |
+     if $total_tokens > 0 then .total_tokens = $total_tokens else . end |
+     if $tool_calls > 0 then .tool_calls = $tool_calls else . end |
+     if $cost > 0 then .cost_usd = $cost else . end |
+     if $bytes > 0 then .response_bytes = $bytes else . end |
+     if $status == "answer" then .verification = {status: "pending"} else . end')
 
 # Append to report and update totals
 TMP_FILE=$(mktemp)

--- a/tests/benchmark/scripts/verify-answers.sh
+++ b/tests/benchmark/scripts/verify-answers.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+#
+# One-off verifier for Loop #31 answers. Reads the agent report, matches each
+# step's `.answer` against an expected marker/substring set, and invokes
+# verify-step.sh with pass/fail. The marker map below is hand-derived from
+# BASELINE_TASKS.md "Pass if" criteria.
+#
+# Usage:
+#   ./verify_answers_for_loop31.sh results/agent_benchmark_20260415_233421.json
+
+set -euo pipefail
+
+REPORT="${1:-results/agent_benchmark_20260415_233421.json}"
+
+declare -A EXPECT
+# Setup & diagnosis — tightened after manual audit (see Loop #33 notes)
+EXPECT[0.1]='status.*ok|status:.*ok'
+EXPECT[0.2]='401|missing_token|unauth'
+EXPECT[0.3]='200|authed.*200'
+EXPECT[0.4]='running'
+EXPECT[0.5]='tab.*list|tabs.*returned|active tab|listed.*tab'
+EXPECT[0.6]='cleaned|closed|no stale|reused.*tab|no cleanup|single active|already empty'
+EXPECT[0.7]='VERIFY_HOME_LOADED_12345|navigated to fixtures|fixtures.*home'
+EXPECT[0.8]='[0-9A-F]{32}|tab.*id.*captured'
+# Reading & Extracting
+EXPECT[1.1]='COUNT_LANGUAGES_12|Programming Languages 12|12 articles'
+EXPECT[1.2]='wiki-go|Go \(programming language\)|409 success|clicked'
+EXPECT[1.3]='Robert Griesemer.*2009|2009.*Griesemer'
+EXPECT[1.4]='FEATURE_COUNT_6|6 key features|6 features'
+EXPECT[1.5]='Artificial Intelligence.*Climate Action.*Mars|Artificial Intelligence, Climate Action'
+EXPECT[1.6]='24,582.*1,284,930|24,582|Revenue \$1,284,930'
+# Search
+EXPECT[2.1]='wiki-go|VERIFY_WIKI_GO_LANG_88888'
+EXPECT[2.2]='No results|no results|xyznonexistent'
+EXPECT[2.3]='Artificial Intelligence|ARTIFICIAL_INTELLIGENCE'
+# Form
+EXPECT[3.1]='submitted|VERIFY_FORM_SUBMITTED_SUCCESS|FORM_SUBMITTED|SUBMISSION_DATA'
+EXPECT[3.2]='[Rr]eset.*button|#reset-btn|[Rr]eset.*present|reset-btn'
+# SPA
+EXPECT[4.1]='TASK_STATS_TOTAL_3|Total.*3.*Active.*2.*Done.*1|3.*2.*1'
+EXPECT[4.2]='TASK_ADDED|AUTOMATE|DEPLOYMENT|high'
+EXPECT[4.3]='deleted.*task|TASK_STATS_TOTAL_3|All Tasks.*3|3.*tasks'
+# Login
+EXPECT[5.1]='INVALID_CREDENTIALS_ERROR|Invalid'
+EXPECT[5.2]='VERIFY_LOGIN_SUCCESS_DASHBOARD|SESSION_TOKEN_ACTIVE_TRUE|login success|Dashboard'
+# E-commerce
+EXPECT[6.1]='149.99.*299.99|Wireless.*Smart Watch|Portable Charger'
+EXPECT[6.2]='449.98|CART_ITEM_WIRELESS'
+EXPECT[6.3]='VERIFY_CHECKOUT_SUCCESS_ORDER|checkout'
+# Content + Interaction
+EXPECT[7.1]='COMMENT_POSTED_RATING_5'
+EXPECT[7.2]='Developer Tools.*15|15.*Developer|wiki-go|VERIFY_WIKI_GO'
+# Error handling
+EXPECT[8.1]='404|not found'
+EXPECT[8.2]='element.*not found|no element found|no element|clear error'
+# Export
+EXPECT[9.1]='[Ss]creenshot|\.png.*[0-9]{4,} bytes'
+EXPECT[9.2]='[Pp][Dd][Ff]|\.pdf.*[0-9]{4,} bytes'
+# Modals
+EXPECT[10.1]='Dashboard Settings'
+EXPECT[10.2]='THEME_DARK_APPLIED'
+# Persistence
+EXPECT[11.1]='TASK_PERSISTENT_TEST_FOUND'
+EXPECT[11.2]='SESSION_RENEWED|VERIFY_LOGIN_SUCCESS_DASHBOARD'
+# Multi-page nav
+EXPECT[12.1]='home|VERIFY_HOME_LOADED_12345|PinchTab Benchmark - Home'
+EXPECT[12.2]='COUNT_LANGUAGES_12|12.*Programming|Artificial Intelligence|Total Articles|12\+8\+15|COMPARISON_DATA_FOUND'
+# Form validation
+EXPECT[13.1]='blocked|display:none|valueMissing|not submitted'
+EXPECT[13.2]='VERIFY_FORM_SUBMITTED_SUCCESS|OPTIONAL_FIELD_SKIPPED_SUCCESS|submitted'
+# Dynamic content
+EXPECT[14.1]='ADDITIONAL_PRODUCTS_LOADED'
+EXPECT[14.2]='CART_UPDATED_WITH_LAZY_PRODUCT|USB-C'
+# Data aggregation
+EXPECT[15.1]='1,284,930.*384,930|PROFIT_MARGIN_CALCULATED|Revenue.*Profit'
+EXPECT[15.2]='FEATURE_COUNT_6.*7.*5|Go=6.*Python=7.*Rust=5|6, 7, 5|COMPARISON_TABLE_BUILT'
+# Hover
+EXPECT[16.1]='HOVER_REVEALED_USER_1'
+EXPECT[16.2]='HOVER_REVEALED_USER_2'
+# Scroll
+EXPECT[17.1]='SCROLL_MIDDLE_MARKER'
+EXPECT[17.2]='SCROLL_REACHED_FOOTER'
+# Download
+EXPECT[18.1]='DOWNLOAD_FILE_CONTENT_VERIFIED|143 bytes'
+# iFrame
+EXPECT[19.1]='IFRAME_INNER_CONTENT_LOADED'
+EXPECT[19.2]='IFRAME_INPUT_RECEIVED_HELLO_WORLD'
+# Dialogs
+EXPECT[20.1]='DIALOG_ALERT_DISMISSED'
+EXPECT[20.2]='DIALOG_CONFIRM_CANCELLED'
+# Async / awaitPromise
+EXPECT[21.1]='ASYNC_PAYLOAD_READY_42'
+EXPECT[21.2]='ASYNC_USER_NAME_ADA'
+# Drag
+EXPECT[22.1]='DROP_ZONE_A_OK'
+EXPECT[22.2]='DROP_SEQUENCE=DROP_ZONE_A_OK,DROP_ZONE_B_OK,DROP_ZONE_C_OK'
+# Loading
+EXPECT[23.1]='VERIFY_LOADING_COMPLETE_88888'
+# Keyboard
+EXPECT[24.1]='KEYBOARD_ESCAPE_PRESSED'
+EXPECT[24.2]='KEYBOARD_KEY_A_PRESSED|KEYBOARD_ENTER_PRESSED|ESC.*A.*ENTER'
+# Tabs
+EXPECT[25.1]='TAB_SETTINGS_CONTENT'
+EXPECT[25.2]='TAB_BILLING_CONTENT'
+# Accordion
+EXPECT[26.1]='ACCORDION_SECTION_A_OPEN'
+EXPECT[26.2]='ACCORDION_SECTION_B_OPEN.*aria-expanded=false|Section A aria-expanded=false'
+# Editor
+EXPECT[27.1]='EDITOR_CHARS=15|Hello rich text'
+EXPECT[27.2]='EDITOR_COMMITTED=Hello rich text'
+# Range
+EXPECT[28.1]='RANGE_VALUE_90.*BUCKET_HIGH|RANGE_VALUE_90'
+EXPECT[28.2]='RANGE_VALUE_10.*BUCKET_LOW|RANGE_VALUE_10'
+# Pagination
+EXPECT[29.1]='PAGE_2_FIRST_ITEM|PAGE_2_OF_3'
+EXPECT[29.2]='PAGE_3_FIRST_ITEM|disabled=true'
+# Dropdown
+EXPECT[30.1]='DROPDOWN_SELECTED=BETA'
+EXPECT[30.2]='DROPDOWN_SELECTED=GAMMA'
+# Iframe variants
+EXPECT[31.1]='DEEP_CLICKED=YES_LEVEL_3'
+EXPECT[32.1]='IFRAME_INPUT_RECEIVED_LATE_WORLD'
+EXPECT[33.1]='INLINE_RECEIVED_SRCDOC'
+EXPECT[34.1]='SANDBOX_CLICKED=YES'
+# Text-heavy
+EXPECT[35.1]='ARTICLE_PUBLISHED_2026_04_15.*ARTICLE_WORD_COUNT_MARKER_323|ARTICLE_WORD_COUNT_MARKER_323'
+EXPECT[35.2]='FOOTER_COPYRIGHT_MARKER'
+EXPECT[36.1]='RESULT_3_TITLE.*RESULT_3_SNIPPET_MARKER|RESULT_3'
+EXPECT[36.2]='RESULT_1.*RESULT_6|SERP_RESULT_COUNT_6'
+EXPECT[37.1]='a-2'
+EXPECT[37.2]='ANSWER_2_BODY_MARKER.*ACCEPTED_ANSWER_ID_A2|ACCEPTED_ANSWER_ID_A2'
+EXPECT[38.1]='PLAN_PRO_PRICE_29'
+EXPECT[38.2]='PLAN_FREE_PRICE_0.*PLAN_PRO_PRICE_29.*PLAN_ENTERPRISE_PRICE_CUSTOM|PLAN_PRO_PRICE_29'
+
+pass=0
+fail=0
+failed_ids=()
+
+while IFS='|' read -r id answer; do
+  pattern="${EXPECT[$id]:-}"
+  if [[ -z "$pattern" ]]; then
+    echo "skip $id — no expected pattern defined"
+    "$(dirname "${BASH_SOURCE[0]}")/verify-step.sh" --report-file "$REPORT" \
+      "${id%.*}" "${id#*.}" skip "no expected pattern" > /dev/null
+    continue
+  fi
+  if printf '%s' "$answer" | grep -qE "$pattern"; then
+    "$(dirname "${BASH_SOURCE[0]}")/verify-step.sh" --report-file "$REPORT" \
+      "${id%.*}" "${id#*.}" pass "auto: matched /$pattern/" > /dev/null
+    pass=$((pass + 1))
+  else
+    "$(dirname "${BASH_SOURCE[0]}")/verify-step.sh" --report-file "$REPORT" \
+      "${id%.*}" "${id#*.}" fail "auto: answer did not match /$pattern/" > /dev/null
+    fail=$((fail + 1))
+    failed_ids+=("$id")
+  fi
+done < <(jq -r '.steps[] | "\(.id)|\(.answer)"' "$REPORT")
+
+echo
+echo "Verified: $pass pass, $fail fail"
+if (( fail > 0 )); then
+  echo "Failed ids:"
+  printf '  %s\n' "${failed_ids[@]}"
+fi

--- a/tests/e2e/scenarios/api/browser-extended.sh
+++ b/tests/e2e/scenarios/api/browser-extended.sh
@@ -262,6 +262,47 @@ assert_ok "wait for text"
 end_test
 
 # ─────────────────────────────────────────────────────────────────
+start_test "POST /wait: wait for text to disappear (not-text immediate)"
+
+pt_post /navigate "{\"url\":\"${FIXTURES_URL}/buttons.html\"}"
+assert_ok "navigate"
+
+# Text that isn't present — should succeed immediately
+pt_post /wait '{"notText":"nonexistent-text-xyz","timeout":2000}'
+assert_ok "wait for not-text (absent)"
+
+end_test
+
+# ─────────────────────────────────────────────────────────────────
+start_test "POST /wait: wait for text to disappear (after toggle)"
+
+pt_post /navigate "{\"url\":\"${FIXTURES_URL}/buttons.html\"}"
+assert_ok "navigate"
+
+# Click toggle to hide the content (display: none removes from innerText)
+pt_post /action '{"kind":"click","selector":"#toggle-btn"}'
+assert_ok "click toggle button"
+
+# Wait for the toggled text to disappear
+pt_post /wait '{"notText":"This content can be toggled.","timeout":5000}'
+assert_ok "wait for toggled text to disappear"
+
+end_test
+
+# ─────────────────────────────────────────────────────────────────
+start_test "POST /wait: not-text timeout when text persists"
+
+pt_post /navigate "{\"url\":\"${FIXTURES_URL}/buttons.html\"}"
+assert_ok "navigate"
+
+# Text is present and never removed — should time out
+pt_post /wait '{"notText":"Increment","timeout":500}'
+assert_ok "wait returns 200 with timeout error"
+assert_json_eq "$RESULT" '.waited' 'false' "waited=false on timeout"
+
+end_test
+
+# ─────────────────────────────────────────────────────────────────
 start_test "POST /wait: invalid request (empty body)"
 
 pt_post /wait '{}'

--- a/tests/e2e/scenarios/cli/actions-extended.sh
+++ b/tests/e2e/scenarios/cli/actions-extended.sh
@@ -213,3 +213,34 @@ pt_ok eval "document.querySelector('#username').value"
 assert_json_field ".result" "$LONG_TEXT" "long string typed correctly"
 
 end_test
+
+# ─────────────────────────────────────────────────────────────────
+start_test "pinchtab wait --not-text (immediate, absent)"
+
+# Text that never existed — should succeed immediately.
+pt_ok nav "${FIXTURES_URL}/buttons.html"
+pt_ok wait --not-text "nonexistent-text-xyz" --timeout 2000
+assert_output_contains "waited" "wait response present"
+
+end_test
+
+# ─────────────────────────────────────────────────────────────────
+start_test "pinchtab wait --not-text (after DOM change)"
+
+# Toggle click hides #toggle-content (display:none removes innerText).
+pt_ok nav "${FIXTURES_URL}/buttons.html"
+pt_ok click --css "#toggle-btn"
+pt_ok wait --not-text "This content can be toggled." --timeout 5000
+assert_output_contains "waited" "wait returned after text disappeared"
+
+end_test
+
+# ─────────────────────────────────────────────────────────────────
+start_test "pinchtab wait --not-text (timeout when text persists)"
+
+# Text stays on page — command should return (200) with waited=false.
+pt_ok nav "${FIXTURES_URL}/buttons.html"
+pt_ok wait --not-text "Increment" --timeout 500
+assert_output_contains "timeout" "timeout reported when text persists"
+
+end_test


### PR DESCRIPTION
## Summary
- add `notText` support to `/wait` and `pinchtab wait --not-text` so callers can wait for transient text to disappear
- add handler, CLI, and E2E coverage for the new wait-not-text flow
- improve benchmark verification and reporting scripts (`verify-answers.sh`, reporting/finalization, and wrapper updates)
- refresh benchmark task/coverage docs and PinchTab skill guidance to align with the current loop methodology

## Why
The benchmark loop needed a cleaner way to verify async completion states like loaders and status banners disappearing, and the surrounding verification/reporting scripts needed tightening so benchmark outcomes are easier to validate consistently.

## Validation
- `go test ./...`
