### PR TITLE
fix(actions): fail fast when clicks trigger blocking dialogs

### DIFF
--- a/internal/bridge/action_pointer.go
+++ b/internal/bridge/action_pointer.go
@@ -95,34 +95,86 @@ func (b *Bridge) actionClick(ctx context.Context, req ActionRequest) (map[string
 		armedDialog = true
 	}
 
-	var err error
-	if req.Selector != "" {
-		// For submit buttons, use requestSubmit() to fire constraint validation,
-		// JS submit handlers, and actual submission in one shot (issue #411).
-		submitted, subErr := submitFormIfButton(ctx, req.Selector)
-		if subErr != nil {
-			slog.Debug("submitFormIfButton failed, falling back to CDP click",
-				"selector", req.Selector, "error", subErr)
-		} else if submitted {
-			if req.WaitNav {
-				_ = chromedp.Run(ctx, chromedp.Sleep(b.Config.WaitNavDelay))
-			}
-			return map[string]any{"clicked": true, "submitted": true}, nil
-		}
-		node, nodeErr := firstNodeBySelector(ctx, req.Selector)
-		if nodeErr != nil {
-			return nil, nodeErr
-		}
-		err = ClickByNodeID(ctx, int64(node.BackendNodeID))
-	} else if req.NodeID > 0 {
-		err = ClickByNodeID(ctx, req.NodeID)
-	} else if req.HasXY {
-		err = ClickByCoordinate(ctx, req.X, req.Y)
+	// If no dialog-action was provided, detect blocking dialogs early and fail fast.
+	detectDialog := !armedDialog && req.TabID != "" && dm != nil
+	var clickCtx context.Context
+	var clickCancel context.CancelFunc
+	if detectDialog {
+		clickCtx, clickCancel = context.WithCancel(ctx)
+		defer clickCancel()
 	} else {
-		return nil, fmt.Errorf("need selector, ref, nodeId, or x/y coordinates")
+		clickCtx = ctx
 	}
-	if err != nil {
-		return nil, err
+
+	// Channel to receive click result
+	type clickResult struct {
+		err error
+	}
+	resultCh := make(chan clickResult, 1)
+
+	// Run click in goroutine so we can poll for dialogs
+	go func() {
+		var err error
+		if req.Selector != "" {
+			// For submit buttons, use requestSubmit() to fire constraint validation,
+			// JS submit handlers, and actual submission in one shot (issue #411).
+			submitted, subErr := submitFormIfButton(clickCtx, req.Selector)
+			if subErr != nil {
+				slog.Debug("submitFormIfButton failed, falling back to CDP click",
+					"selector", req.Selector, "error", subErr)
+			} else if submitted {
+				resultCh <- clickResult{err: nil}
+				return
+			}
+			node, nodeErr := firstNodeBySelector(clickCtx, req.Selector)
+			if nodeErr != nil {
+				resultCh <- clickResult{err: nodeErr}
+				return
+			}
+			err = ClickByNodeID(clickCtx, int64(node.BackendNodeID))
+		} else if req.NodeID > 0 {
+			err = ClickByNodeID(clickCtx, req.NodeID)
+		} else if req.HasXY {
+			err = ClickByCoordinate(clickCtx, req.X, req.Y)
+		} else {
+			resultCh <- clickResult{err: fmt.Errorf("need selector, ref, nodeId, or x/y coordinates")}
+			return
+		}
+		resultCh <- clickResult{err: err}
+	}()
+
+	// Poll for blocking dialogs while click is running
+	if detectDialog {
+		ticker := time.NewTicker(dialogAutoHandlePollInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case result := <-resultCh:
+				if result.err != nil {
+					return nil, result.err
+				}
+				if req.WaitNav {
+					_ = chromedp.Run(ctx, chromedp.Sleep(b.Config.WaitNavDelay))
+				}
+				return map[string]any{"clicked": true}, nil
+			case <-ticker.C:
+				if pending := dm.GetPending(req.TabID); pending != nil {
+					clickCancel()
+					return nil, &ErrDialogBlocking{
+						DialogType:    pending.Type,
+						DialogMessage: pending.Message,
+					}
+				}
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		}
+	}
+
+	// Wait for click result (dialog-action was provided or no tab ID)
+	result := <-resultCh
+	if result.err != nil {
+		return nil, result.err
 	}
 	if armedDialog {
 		waitForArmedDialogSettle(dm, req.TabID, dialogAutoHandleTimeout)

--- a/internal/bridge/errors.go
+++ b/internal/bridge/errors.go
@@ -13,3 +13,14 @@ type TabLimitError struct {
 func (e *TabLimitError) Error() string {
 	return fmt.Sprintf("tab limit reached (%d/%d)", e.Current, e.Max)
 }
+
+// ErrDialogBlocking is returned when a click action is blocked by a
+// JavaScript dialog (alert/confirm/prompt) and no --dialog-action was provided.
+type ErrDialogBlocking struct {
+	DialogType    string
+	DialogMessage string
+}
+
+func (e *ErrDialogBlocking) Error() string {
+	return fmt.Sprintf("click blocked by JavaScript dialog (%s: %q) — use --dialog-action accept|dismiss", e.DialogType, e.DialogMessage)
+}

--- a/internal/handlers/actions.go
+++ b/internal/handlers/actions.go
@@ -364,6 +364,27 @@ func (h *Handlers) HandleAction(w http.ResponseWriter, r *http.Request) {
 			httpx.ErrorCode(w, http.StatusForbidden, "idpi_blocked", actionErr.Error(), false, nil)
 			return
 		}
+		var dialogErr *bridge.ErrDialogBlocking
+		if errors.As(actionErr, &dialogErr) {
+			httpx.ErrorCode(w, 500, "dialog_blocking", actionErr.Error(), false, map[string]any{
+				"suggestion":     "use --dialog-action accept or --dialog-action dismiss",
+				"dialog_type":    dialogErr.DialogType,
+				"dialog_message": dialogErr.DialogMessage,
+			})
+			return
+		}
+		if isClickTimeoutWithPendingDialog(actionErr, req.Kind, resolvedTabID, h.Bridge) {
+			dm := h.Bridge.GetDialogManager()
+			dialogState := dm.GetPending(resolvedTabID)
+			msg := fmt.Sprintf("action %s timed out; a JavaScript dialog is blocking (%s: %q)",
+				req.Kind, dialogState.Type, dialogState.Message)
+			httpx.ErrorCode(w, 500, "dialog_blocking", msg, false, map[string]any{
+				"suggestion":     "use --dialog-action accept or --dialog-action dismiss",
+				"dialog_type":    dialogState.Type,
+				"dialog_message": dialogState.Message,
+			})
+			return
+		}
 		httpx.ErrorCode(w, 500, "action_failed", fmt.Sprintf("action %s: %v", req.Kind, actionErr), true, nil)
 		return
 	}
@@ -745,9 +766,20 @@ func (h *Handlers) handleActionsBatch(w http.ResponseWriter, r *http.Request, re
 		tCancel()
 
 		if err != nil {
+			errMsg := fmt.Sprintf("action %s: %v", action.Kind, err)
+			var dialogErr *bridge.ErrDialogBlocking
+			if errors.As(err, &dialogErr) {
+				errMsg = err.Error()
+			} else if isClickTimeoutWithPendingDialog(err, action.Kind, resolvedTabID, h.Bridge) {
+				dm := h.Bridge.GetDialogManager()
+				if ds := dm.GetPending(resolvedTabID); ds != nil {
+					errMsg = fmt.Sprintf("action %s timed out; a JavaScript dialog is blocking (%s: %q) — use --dialog-action accept|dismiss",
+						action.Kind, ds.Type, ds.Message)
+				}
+			}
 			results = append(results, actionResult{
 				Index: i, Success: false,
-				Error: fmt.Sprintf("action %s: %v", action.Kind, err),
+				Error: errMsg,
 			})
 			if req.StopOnError {
 				break
@@ -1025,7 +1057,18 @@ func (h *Handlers) HandleMacro(w http.ResponseWriter, r *http.Request) {
 		}
 		cancel()
 		if err != nil {
-			results = append(results, actionResult{Index: i, Success: false, Error: err.Error()})
+			errMsg := err.Error()
+			var dialogErr *bridge.ErrDialogBlocking
+			if errors.As(err, &dialogErr) {
+				// Error message is already formatted by ErrDialogBlocking.Error()
+			} else if isClickTimeoutWithPendingDialog(err, step.Kind, resolvedTabID, h.Bridge) {
+				dm := h.Bridge.GetDialogManager()
+				if ds := dm.GetPending(resolvedTabID); ds != nil {
+					errMsg = fmt.Sprintf("action %s timed out; a JavaScript dialog is blocking (%s: %q) — use --dialog-action accept|dismiss",
+						step.Kind, ds.Type, ds.Message)
+				}
+			}
+			results = append(results, actionResult{Index: i, Success: false, Error: errMsg})
 			if req.StopOnError {
 				break
 			}
@@ -1209,4 +1252,22 @@ func (h *Handlers) refreshRefCache(ctx context.Context, tabID string) {
 		Targets: bridge.RefTargetsFromNodes(flat),
 		Nodes:   flat,
 	})
+}
+
+func isClickTimeoutWithPendingDialog(err error, kind, tabID string, b bridge.BridgeAPI) bool {
+	if err == nil || tabID == "" {
+		return false
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	kind = bridge.CanonicalActionKind(kind)
+	if kind != bridge.ActionClick && kind != bridge.ActionDoubleClick {
+		return false
+	}
+	dm := b.GetDialogManager()
+	if dm == nil {
+		return false
+	}
+	return dm.GetPending(tabID) != nil
 }

--- a/internal/handlers/dialog_test.go
+++ b/internal/handlers/dialog_test.go
@@ -2,7 +2,9 @@ package handlers
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"fmt"
 	"net/http/httptest"
 	"testing"
 
@@ -144,5 +146,87 @@ func TestDialogManagerFromMockBridge(t *testing.T) {
 	got := dm.GetPending("tab1")
 	if got == nil || got.Type != "alert" {
 		t.Errorf("expected alert dialog, got %+v", got)
+	}
+}
+
+func TestIsClickTimeoutWithPendingDialog(t *testing.T) {
+	mb := &mockBridge{}
+	dm := mb.GetDialogManager()
+
+	tests := []struct {
+		name     string
+		err      error
+		kind     string
+		tabID    string
+		pending  *bridge.DialogState
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			kind:     "click",
+			tabID:    "tab1",
+			expected: false,
+		},
+		{
+			name:     "non-timeout error",
+			err:      fmt.Errorf("some other error"),
+			kind:     "click",
+			tabID:    "tab1",
+			expected: false,
+		},
+		{
+			name:     "timeout but no pending dialog",
+			err:      context.DeadlineExceeded,
+			kind:     "click",
+			tabID:    "tab1",
+			expected: false,
+		},
+		{
+			name:     "timeout with pending dialog on click",
+			err:      context.DeadlineExceeded,
+			kind:     "click",
+			tabID:    "tab1",
+			pending:  &bridge.DialogState{Type: "alert", Message: "Hello"},
+			expected: true,
+		},
+		{
+			name:     "timeout with pending dialog on doubleclick",
+			err:      context.DeadlineExceeded,
+			kind:     "dblclick",
+			tabID:    "tab1",
+			pending:  &bridge.DialogState{Type: "confirm", Message: "Are you sure?"},
+			expected: true,
+		},
+		{
+			name:     "timeout with pending dialog on type action",
+			err:      context.DeadlineExceeded,
+			kind:     "type",
+			tabID:    "tab1",
+			pending:  &bridge.DialogState{Type: "alert", Message: "Hello"},
+			expected: false,
+		},
+		{
+			name:     "timeout with empty tab ID",
+			err:      context.DeadlineExceeded,
+			kind:     "click",
+			tabID:    "",
+			pending:  &bridge.DialogState{Type: "alert", Message: "Hello"},
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dm.ClearPending(tc.tabID)
+			if tc.pending != nil && tc.tabID != "" {
+				dm.SetPending(tc.tabID, tc.pending)
+			}
+
+			got := isClickTimeoutWithPendingDialog(tc.err, tc.kind, tc.tabID, mb)
+			if got != tc.expected {
+				t.Errorf("isClickTimeoutWithPendingDialog() = %v, want %v", got, tc.expected)
+			}
+		})
 	}
 }

--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -27,6 +27,7 @@ type mockBridge struct {
 	frameScopes      map[string]bridge.FrameScope
 	ensureChromeErr  error
 	ensureChromeCall int
+	dialogManager    *bridge.DialogManager
 }
 
 func (m *mockBridge) TabContext(tabID string) (context.Context, string, error) {
@@ -105,7 +106,10 @@ func (m *mockBridge) NetworkMonitor() *bridge.NetworkMonitor {
 }
 
 func (m *mockBridge) GetDialogManager() *bridge.DialogManager {
-	return bridge.NewDialogManager()
+	if m.dialogManager == nil {
+		m.dialogManager = bridge.NewDialogManager()
+	}
+	return m.dialogManager
 }
 
 func (m *mockBridge) GetConsoleLogs(tabID string, limit int) []bridge.LogEntry {

--- a/tests/e2e/fixtures/buttons.html
+++ b/tests/e2e/fixtures/buttons.html
@@ -36,6 +36,14 @@
     </div>
   </section>
 
+  <section id="dialog-section">
+    <h2>JavaScript Dialogs</h2>
+    <button id="trigger-alert">Trigger Alert</button>
+    <button id="trigger-confirm">Trigger Confirm</button>
+    <button id="trigger-prompt">Trigger Prompt</button>
+    <div id="dialog-result" style="padding: 10px; margin-top: 10px;"></div>
+  </section>
+
   <script>
     let count = 0;
     const countEl = document.getElementById('count');
@@ -62,6 +70,21 @@
 
     document.getElementById('show-message').addEventListener('click', () => {
       document.getElementById('message').style.display = 'block';
+    });
+
+    document.getElementById('trigger-alert').addEventListener('click', () => {
+      alert('E2E_ALERT_MESSAGE');
+      document.getElementById('dialog-result').textContent = 'ALERT_DISMISSED';
+    });
+
+    document.getElementById('trigger-confirm').addEventListener('click', () => {
+      const result = confirm('E2E_CONFIRM_MESSAGE');
+      document.getElementById('dialog-result').textContent = result ? 'CONFIRM_ACCEPTED' : 'CONFIRM_DISMISSED';
+    });
+
+    document.getElementById('trigger-prompt').addEventListener('click', () => {
+      const result = prompt('E2E_PROMPT_MESSAGE', 'default');
+      document.getElementById('dialog-result').textContent = result !== null ? 'PROMPT_VALUE_' + result : 'PROMPT_CANCELLED';
     });
   </script>
 </body>

--- a/tests/e2e/scenarios/api/actions-extended.sh
+++ b/tests/e2e/scenarios/api/actions-extended.sh
@@ -584,3 +584,137 @@ pt_post /dialog "{\"action\":\"accept\",\"tabId\":\"${TAB_ID}\",\"text\":\"my re
 assert_http_status "400" "accept with text format valid (no pending dialog)"
 
 end_test
+
+# ─────────────────────────────────────────────────────────────────
+# JavaScript dialog handling via click --dialog-action
+# ─────────────────────────────────────────────────────────────────
+
+start_test "click alert without dialogAction: fast-fail with dialog_blocking error"
+
+pt_post /navigate "{\"url\":\"${FIXTURES_URL}/buttons.html\"}"
+assert_ok "navigate to buttons"
+sleep 0.5
+
+pt_get /snapshot
+ALERT_REF=$(echo "$RESULT" | jq -r '[.nodes[] | select(.name == "Trigger Alert")][0].ref // empty')
+
+# Click without dialogAction should fail fast with dialog_blocking error
+START_TIME=$(date +%s%3N 2>/dev/null || python3 -c 'import time; print(int(time.time()*1000))')
+pt_post /action "{\"kind\":\"click\",\"ref\":\"${ALERT_REF}\"}"
+END_TIME=$(date +%s%3N 2>/dev/null || python3 -c 'import time; print(int(time.time()*1000))')
+
+assert_not_ok "click without dialogAction fails"
+assert_json_eq "$RESULT" '.code' 'dialog_blocking' "error code is dialog_blocking"
+
+# Verify fast-fail: should complete in under 2 seconds (not 30s timeout)
+ELAPSED=$((END_TIME - START_TIME))
+if [ "$ELAPSED" -gt 2000 ]; then
+  echo "FAIL: click took ${ELAPSED}ms, expected fast-fail under 2000ms"
+  exit 1
+fi
+echo "PASS: fast-fail in ${ELAPSED}ms"
+
+# Clean up: dismiss the pending dialog
+pt_post /dialog '{"action":"dismiss"}'
+
+end_test
+
+# ─────────────────────────────────────────────────────────────────
+start_test "click alert with dialogAction accept: dialog dismissed"
+
+pt_post /navigate "{\"url\":\"${FIXTURES_URL}/buttons.html\"}"
+assert_ok "navigate to buttons"
+sleep 0.5
+
+pt_get /snapshot
+ALERT_REF=$(echo "$RESULT" | jq -r '[.nodes[] | select(.name == "Trigger Alert")][0].ref // empty')
+
+pt_post /action "{\"kind\":\"click\",\"ref\":\"${ALERT_REF}\",\"dialogAction\":\"accept\"}"
+assert_ok "click with dialogAction accept"
+
+# Verify the click handler completed (alert was dismissed)
+pt_post /evaluate -d '{"expression":"document.getElementById(\"dialog-result\").textContent"}'
+assert_ok "evaluate dialog result"
+assert_json_eq "$RESULT" '.result' 'ALERT_DISMISSED' "alert was dismissed and handler completed"
+
+end_test
+
+# ─────────────────────────────────────────────────────────────────
+start_test "click confirm with dialogAction dismiss: confirm cancelled"
+
+pt_post /navigate "{\"url\":\"${FIXTURES_URL}/buttons.html\"}"
+assert_ok "navigate to buttons"
+sleep 0.5
+
+pt_get /snapshot
+CONFIRM_REF=$(echo "$RESULT" | jq -r '[.nodes[] | select(.name == "Trigger Confirm")][0].ref // empty')
+
+pt_post /action "{\"kind\":\"click\",\"ref\":\"${CONFIRM_REF}\",\"dialogAction\":\"dismiss\"}"
+assert_ok "click with dialogAction dismiss"
+
+# Verify confirm returned false (dismissed)
+pt_post /evaluate -d '{"expression":"document.getElementById(\"dialog-result\").textContent"}'
+assert_ok "evaluate dialog result"
+assert_json_eq "$RESULT" '.result' 'CONFIRM_DISMISSED' "confirm was dismissed"
+
+end_test
+
+# ─────────────────────────────────────────────────────────────────
+start_test "click confirm with dialogAction accept: confirm accepted"
+
+pt_post /navigate "{\"url\":\"${FIXTURES_URL}/buttons.html\"}"
+assert_ok "navigate to buttons"
+sleep 0.5
+
+pt_get /snapshot
+CONFIRM_REF=$(echo "$RESULT" | jq -r '[.nodes[] | select(.name == "Trigger Confirm")][0].ref // empty')
+
+pt_post /action "{\"kind\":\"click\",\"ref\":\"${CONFIRM_REF}\",\"dialogAction\":\"accept\"}"
+assert_ok "click with dialogAction accept"
+
+# Verify confirm returned true (accepted)
+pt_post /evaluate -d '{"expression":"document.getElementById(\"dialog-result\").textContent"}'
+assert_ok "evaluate dialog result"
+assert_json_eq "$RESULT" '.result' 'CONFIRM_ACCEPTED' "confirm was accepted"
+
+end_test
+
+# ─────────────────────────────────────────────────────────────────
+start_test "click prompt with dialogAction accept and text: prompt value returned"
+
+pt_post /navigate "{\"url\":\"${FIXTURES_URL}/buttons.html\"}"
+assert_ok "navigate to buttons"
+sleep 0.5
+
+pt_get /snapshot
+PROMPT_REF=$(echo "$RESULT" | jq -r '[.nodes[] | select(.name == "Trigger Prompt")][0].ref // empty')
+
+pt_post /action "{\"kind\":\"click\",\"ref\":\"${PROMPT_REF}\",\"dialogAction\":\"accept\",\"dialogText\":\"e2e_input\"}"
+assert_ok "click with dialogAction accept and dialogText"
+
+# Verify prompt returned the provided text
+pt_post /evaluate -d '{"expression":"document.getElementById(\"dialog-result\").textContent"}'
+assert_ok "evaluate dialog result"
+assert_json_eq "$RESULT" '.result' 'PROMPT_VALUE_e2e_input' "prompt returned provided text"
+
+end_test
+
+# ─────────────────────────────────────────────────────────────────
+start_test "click prompt with dialogAction dismiss: prompt cancelled"
+
+pt_post /navigate "{\"url\":\"${FIXTURES_URL}/buttons.html\"}"
+assert_ok "navigate to buttons"
+sleep 0.5
+
+pt_get /snapshot
+PROMPT_REF=$(echo "$RESULT" | jq -r '[.nodes[] | select(.name == "Trigger Prompt")][0].ref // empty')
+
+pt_post /action "{\"kind\":\"click\",\"ref\":\"${PROMPT_REF}\",\"dialogAction\":\"dismiss\"}"
+assert_ok "click with dialogAction dismiss"
+
+# Verify prompt returned null (cancelled)
+pt_post /evaluate -d '{"expression":"document.getElementById(\"dialog-result\").textContent"}'
+assert_ok "evaluate dialog result"
+assert_json_eq "$RESULT" '.result' 'PROMPT_CANCELLED' "prompt was cancelled"
+
+end_test


### PR DESCRIPTION
## Summary
- detect blocking JavaScript dialogs during click execution and fail fast with an explicit actionable error when no `dialogAction` was provided
- preserve the existing one-shot auto-handle path when `dialogAction` is supplied
- add a dedicated dialog-blocking bridge error type and expand handler/bridge/dialog tests around the new fast-fail path
- add E2E coverage for dialog-triggering click scenarios

## Why
Clicks that opened native JS dialogs could otherwise degrade into vague timeouts or confusing follow-up failures when callers forgot to supply dialog handling. This branch makes that failure mode explicit and actionable without changing the existing auto-handle behavior for callers that opt in.

## Validation
- `go test ./...`
