### PR TITLE
fix(skill): add Codex to bundled skill sync targets

### DIFF
--- a/npm/scripts/sync-skills.js
+++ b/npm/scripts/sync-skills.js
@@ -45,6 +45,8 @@ function getTargetSkillDirs() {
     path.join(home, '.cursor', 'skills', SKILL_NAME),
     // Windsurf
     path.join(home, '.windsurf', 'skills', SKILL_NAME),
+    // Codex
+    path.join(home, '.codex', 'skills', SKILL_NAME),
   ];
 
   return candidates.filter((dir) => {


### PR DESCRIPTION
## Summary
- add `~/.codex/skills/pinchtab` to bundled skill target detection
- keep skill syncing limited to environments where the parent skill directory already exists
- automatically extend npm postinstall, `pinchtab skill update`, and `pinchtab skill list` to include Codex via the shared target detection helper

## Why
Bundled skill sync already supports Claude/OpenClaw/Cursor/Windsurf, but was missing Codex. This branch adds Codex support so the packaged `pinchtab` skill can stay aligned across install/update flows in the same way as the other supported agent directories.

Closes #494.

## Validation
- small npm-side helper change only
- `pinchtab skill update` / `pinchtab skill list` share the same updated target detection helper
