### PR TITLE
feat(autosolver): add challenge detection, jschallenge, and auto-trigger flow

### DIFF
--- a/cmd/pinchtab/cmd_cli_browser_nav.go
+++ b/cmd/pinchtab/cmd_cli_browser_nav.go
@@ -105,38 +105,43 @@ var tabCloseCmd = &cobra.Command{
 }
 
 var tabHandoffCmd = &cobra.Command{
-	Use:   "handoff <id>",
+	Use:   "handoff [id]",
 	Short: "Pause tab automation for human handoff",
-	Long:  "Mark a tab as paused_handoff so action routes block until resumed or timeout expires.",
-	Args:  cobra.ExactArgs(1),
+	Long:  "Mark a tab as paused_handoff so action routes block until resumed or timeout expires. Defaults to the current tab (PINCHTAB_TAB or state file).",
+	Args:  cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		reason, _ := cmd.Flags().GetString("reason")
 		timeoutMS, _ := cmd.Flags().GetInt("timeout-ms")
+		tabID := resolveTabArg(args)
 		runCLI(func(rt cliRuntime) {
-			browseractions.TabHandoff(rt.client, rt.base, rt.token, args[0], reason, timeoutMS, cmd)
+			browseractions.TabHandoff(rt.client, rt.base, rt.token, tabID, reason, timeoutMS, cmd)
 		})
 	},
 }
 
 var tabResumeCmd = &cobra.Command{
-	Use:   "resume <id>",
+	Use:   "resume [id]",
 	Short: "Resume a paused_handoff tab",
-	Args:  cobra.ExactArgs(1),
+	Long:  "Resume automation on a paused tab. Defaults to the current tab (PINCHTAB_TAB or state file).",
+	Args:  cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		status, _ := cmd.Flags().GetString("status")
+		tabID := resolveTabArg(args)
 		runCLI(func(rt cliRuntime) {
-			browseractions.TabResume(rt.client, rt.base, rt.token, args[0], status, cmd)
+			browseractions.TabResume(rt.client, rt.base, rt.token, tabID, status, cmd)
 		})
 	},
 }
 
 var tabHandoffStatusCmd = &cobra.Command{
-	Use:   "handoff-status <id>",
+	Use:   "handoff-status [id]",
 	Short: "Show handoff status for a tab",
-	Args:  cobra.ExactArgs(1),
+	Long:  "Show handoff status. Defaults to the current tab (PINCHTAB_TAB or state file).",
+	Args:  cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		tabID := resolveTabArg(args)
 		runCLI(func(rt cliRuntime) {
-			browseractions.TabHandoffStatus(rt.client, rt.base, rt.token, args[0], cmd)
+			browseractions.TabHandoffStatus(rt.client, rt.base, rt.token, tabID, cmd)
 		})
 	},
 }

--- a/cmd/pinchtab/cmd_cli_register.go
+++ b/cmd/pinchtab/cmd_cli_register.go
@@ -57,8 +57,17 @@ func registerBrowserCommands() {
 		cacheCmd,
 		storageCmd,
 		stateCmd,
+		tabHandoffCmd,
+		tabResumeCmd,
+		tabHandoffStatusCmd,
 	)
 
+	// Register handoff/resume/handoff-status as subcommands of `tab` too so
+	// `pinchtab tab handoff <id>` keeps working alongside the top-level
+	// `pinchtab handoff`. The commands carry GroupID="browser" (set by
+	// setCommandGroup above) — add the same group to tabsCmd so cobra
+	// accepts them without panicking.
+	tabsCmd.AddGroup(&cobra.Group{ID: "browser", Title: "Browser"})
 	tabsCmd.AddCommand(tabNewCmd, tabCloseCmd, tabHandoffCmd, tabResumeCmd, tabHandoffStatusCmd)
 	clipboardCmd.AddCommand(clipboardReadCmd, clipboardWriteCmd, clipboardCopyCmd, clipboardPasteCmd)
 	keyboardCmd.AddCommand(keyboardTypeCmd, keyboardInsertTextCmd)
@@ -109,6 +118,9 @@ func registerBrowserCommands() {
 		cacheCmd,
 		storageCmd,
 		stateCmd,
+		tabHandoffCmd,
+		tabResumeCmd,
+		tabHandoffStatusCmd,
 	)
 }
 
@@ -379,6 +391,18 @@ func addRootCommands(cmds ...*cobra.Command) {
 //
 // Explicit --tab still wins (cobra flag precedence). If neither env var nor
 // state file is set, the server picks the active tab as before.
+// resolveTabArg returns the tab ID from args[0] when present, otherwise falls
+// back to $PINCHTAB_TAB then the persisted state file written by `nav`.
+func resolveTabArg(args []string) string {
+	if len(args) > 0 && args[0] != "" {
+		return args[0]
+	}
+	if env := os.Getenv("PINCHTAB_TAB"); env != "" {
+		return env
+	}
+	return readTabStateFile()
+}
+
 func addTabFlag(cmds ...*cobra.Command) {
 	defaultTab := os.Getenv("PINCHTAB_TAB")
 	if defaultTab == "" {

--- a/cmd/pinchtab/cmd_cli_test.go
+++ b/cmd/pinchtab/cmd_cli_test.go
@@ -66,11 +66,17 @@ func TestDragCommandRegistered(t *testing.T) {
 }
 
 func TestTabHandoffCommandsRegistered(t *testing.T) {
+	for _, name := range []string{"handoff [id]", "resume [id]", "handoff-status [id]"} {
+		if findCommand(rootCmd, name) == nil {
+			t.Fatalf("expected top-level command %q to be registered", name)
+		}
+	}
+
 	tabCmd := findCommand(rootCmd, "tab [id]")
 	if tabCmd == nil {
 		t.Fatal("expected tab command to be registered")
 	}
-	for _, name := range []string{"handoff", "resume", "handoff-status"} {
+	for _, name := range []string{"handoff [id]", "resume [id]", "handoff-status [id]"} {
 		if findCommand(tabCmd, name) == nil {
 			t.Fatalf("expected tab subcommand %q to be registered", name)
 		}

--- a/cmd/pinchtab/cmd_server.go
+++ b/cmd/pinchtab/cmd_server.go
@@ -1,6 +1,11 @@
 package main
 
 import (
+	"fmt"
+	"os"
+
+	"github.com/pinchtab/pinchtab/internal/cli"
+	"github.com/pinchtab/pinchtab/internal/config/workflow"
 	"github.com/pinchtab/pinchtab/internal/server"
 	"github.com/spf13/cobra"
 )
@@ -10,7 +15,17 @@ var serverCmd = &cobra.Command{
 	Short: "Start server",
 	Run: func(cmd *cobra.Command, args []string) {
 		maybeRunWizard()
+
+		if yolo, _ := cmd.Flags().GetBool("yolo"); yolo {
+			if _, _, _, err := workflow.ApplyGuardsDownPreset(); err != nil {
+				fmt.Fprintln(os.Stderr, cli.StyleStderr(cli.ErrorStyle, fmt.Sprintf("--yolo: %v", err)))
+				os.Exit(1)
+			}
+			fmt.Fprintln(os.Stderr, cli.StyleStderr(cli.WarningStyle, "YOLO mode: guards down"))
+		}
+
 		cfg := loadConfig()
+
 		if headed, _ := cmd.Flags().GetBool("headed"); headed {
 			cfg.Headless = false
 			cfg.HeadlessSet = true
@@ -24,7 +39,8 @@ var serverCmd = &cobra.Command{
 
 func init() {
 	serverCmd.GroupID = "primary"
-	serverCmd.Flags().StringArray("extension", nil, "Load browser extension (repeatable)")
-	serverCmd.Flags().Bool("headed", false, "Start default instance in headed mode")
+	serverCmd.Flags().StringArrayP("extension", "e", nil, "Load browser extension (repeatable)")
+	serverCmd.Flags().BoolP("headed", "H", false, "Start default instance in headed mode")
+	serverCmd.Flags().BoolP("yolo", "y", false, "Apply guards down preset (enables evaluate, macro, download)")
 	rootCmd.AddCommand(serverCmd)
 }

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -8,7 +8,7 @@ import {
   useNavigate,
 } from "react-router-dom";
 import { ActivityPage, AgentsPage } from "./activities";
-import { NavBar } from "./components/molecules";
+import { HandoffNotifications, NavBar } from "./components/molecules";
 import { LoginPage, MonitoringPage, ProfilesPage, SettingsPage } from "./pages";
 import * as api from "./services/api";
 import {
@@ -252,6 +252,7 @@ function AppContent() {
           {INSECURE_DASHBOARD_TRANSPORT_WARNING}
         </div>
       )}
+      <HandoffNotifications />
       <main className="dashboard-grid flex-1 overflow-hidden">
         <Routes>
           <Route

--- a/dashboard/src/activities/ActivityItemLine.tsx
+++ b/dashboard/src/activities/ActivityItemLine.tsx
@@ -8,6 +8,8 @@ import {
   IconPointer,
   IconScreenShare,
 } from "../components/atoms/Icon";
+import { useState } from "react";
+import { resumeTab } from "../services/api";
 import { activityStatusVariant } from "./helpers";
 import type { ActivityFilters, DashboardActivityEvent } from "./types";
 import CopyIdPill from "./CopyIdPill";
@@ -106,6 +108,7 @@ interface Props {
   showTab?: boolean;
   copyTabId?: boolean;
   sessionLabel?: string;
+  inHandoff?: boolean;
   onFilterChange?: (key: keyof ActivityFilters, value: string) => void;
 }
 
@@ -114,9 +117,25 @@ export default function ActivityItemLine({
   showTab = true,
   copyTabId = false,
   sessionLabel,
+  inHandoff = false,
   onFilterChange,
 }: Props) {
   const variant = activityStatusVariant(event.status);
+  const [resuming, setResuming] = useState(false);
+  const [resumeError, setResumeError] = useState("");
+
+  const showResumeButton = inHandoff && Boolean(event.tabId);
+  const handleResume = async () => {
+    if (!event.tabId || resuming) return;
+    setResuming(true);
+    setResumeError("");
+    try {
+      await resumeTab(event.tabId);
+    } catch (err) {
+      setResumeError(err instanceof Error ? err.message : "Resume failed");
+      setResuming(false);
+    }
+  };
 
   return (
     <div className="flex items-center gap-2.5 px-4 py-2 text-sm transition-colors hover:bg-white/2">
@@ -128,9 +147,31 @@ export default function ActivityItemLine({
         {formatTime(event.timestamp)}
       </span>
 
+      {inHandoff && (
+        <span
+          aria-label="tab paused for human handoff"
+          title="Tab is paused for human handoff"
+          className="inline-block h-2 w-2 shrink-0 rounded-full bg-red-500 ring-2 ring-bg-surface"
+        />
+      )}
+
       <span className="min-w-0 flex-1 truncate text-text-primary">
         {eventDescription(event)}
       </span>
+
+      {showResumeButton && (
+        <button
+          type="button"
+          onClick={handleResume}
+          disabled={resuming}
+          title={
+            resumeError || "Resume automation after manual challenge solve"
+          }
+          className="shrink-0 rounded-sm border border-warning/40 bg-warning/10 px-2 py-0.5 text-[0.68rem] text-warning transition-colors hover:bg-warning/20 disabled:opacity-50"
+        >
+          {resuming ? "Resuming…" : "Resolve challenge"}
+        </button>
+      )}
 
       {sessionLabel && (
         <span className="truncate rounded-sm border border-border-subtle bg-white/3 px-1.5 py-0.5 text-[0.68rem] text-text-muted">

--- a/dashboard/src/activities/AgentActivityWorkspace.tsx
+++ b/dashboard/src/activities/AgentActivityWorkspace.tsx
@@ -10,6 +10,7 @@ import {
   defaultActivityFilters,
   sameActivityFilters,
 } from "./helpers";
+import { computeHandoffTabs, deriveHandoffIndex } from "./handoffState";
 import type { ActivityFilters, DashboardActivityEvent } from "./types";
 
 type WorkspaceTab = "agents" | "activities";
@@ -185,8 +186,14 @@ export default function AgentActivityWorkspace({
   useAgentEventStore = false,
   clearToInitialFilters = false,
 }: Props) {
-  const { instances, profiles, agents, agentEventsById, hydrateAgentEvents } =
-    useAppStore();
+  const {
+    instances,
+    profiles,
+    agents,
+    agentEventsById,
+    hydrateAgentEvents,
+    events: liveEvents,
+  } = useAppStore();
   const normalizedHiddenSources = useMemo(
     () => [...hiddenSources],
     [hiddenSources],
@@ -397,6 +404,26 @@ export default function AgentActivityWorkspace({
     }
     return Array.from(ids).sort();
   }, [catalogEvents]);
+
+  // Handoff detection runs against the union of polled catalog events and the
+  // live SSE-driven store events so the sidebar dots update in real time, not
+  // only when filters change and catalogEvents re-fetches.
+  const handoffEventPool = useMemo(() => {
+    const combined: DashboardActivityEvent[] = [...catalogEvents];
+    for (const live of liveEvents) {
+      combined.push(toDashboardActivityEvent(live));
+    }
+    return combined;
+  }, [catalogEvents, liveEvents]);
+
+  const handoffTabs = useMemo(
+    () => computeHandoffTabs(handoffEventPool),
+    [handoffEventPool],
+  );
+  const { sessionsWithHandoff, agentsWithHandoff } = useMemo(
+    () => deriveHandoffIndex(handoffEventPool, handoffTabs),
+    [handoffEventPool, handoffTabs],
+  );
 
   const visibleEvents = useMemo(
     () =>
@@ -755,6 +782,8 @@ export default function AgentActivityWorkspace({
         activeAgentId={filters.agentId}
         filters={filters}
         sessions={derivedSessions}
+        sessionsWithHandoff={sessionsWithHandoff}
+        agentsWithHandoff={agentsWithHandoff}
         showAllAgentsOption={showAllAgentsOption}
         showAgentFilter={showAgentFilter}
         profiles={profiles}
@@ -798,6 +827,8 @@ export default function AgentActivityWorkspace({
         error={error}
         loading={activityLoading || agentLoading}
         copyTabId={copyTabId}
+        handoffTabs={handoffTabs}
+        activeSessionId={filters.sessionId}
         onFilterChange={updateFilter}
       />
     </div>

--- a/dashboard/src/activities/AgentStreamPanel.tsx
+++ b/dashboard/src/activities/AgentStreamPanel.tsx
@@ -2,6 +2,7 @@ import { useLayoutEffect, useRef } from "react";
 import { EmptyState } from "../components/atoms";
 import type { Session } from "../services/api";
 import ActivityItemLine from "./ActivityItemLine";
+import { isHandoffEvent } from "./handoffState";
 import type { ActivityFilters, DashboardActivityEvent } from "./types";
 
 interface AgentStreamPanelProps {
@@ -10,6 +11,8 @@ interface AgentStreamPanelProps {
   error: string;
   loading: boolean;
   copyTabId?: boolean;
+  handoffTabs?: Set<string>;
+  activeSessionId?: string;
   onFilterChange: (key: keyof ActivityFilters, value: string) => void;
 }
 
@@ -19,6 +22,8 @@ export default function AgentStreamPanel({
   error,
   loading,
   copyTabId = false,
+  handoffTabs,
+  activeSessionId,
   onFilterChange,
 }: AgentStreamPanelProps) {
   const sessionLabels = new Map(
@@ -76,20 +81,53 @@ export default function AgentStreamPanel({
           />
         ) : (
           <div className="divide-y divide-border-subtle/70">
-            {events.map((event, index) => (
-              <ActivityItemLine
-                key={`${event.requestId || event.timestamp}-${index}`}
-                event={event}
-                showTab
-                copyTabId={copyTabId}
-                sessionLabel={
-                  event.sessionId
-                    ? sessionLabels.get(event.sessionId)
-                    : "anonymous"
+            {(() => {
+              // Find the most recent handoff event per tab (by timestamp desc)
+              const mostRecentHandoffByTab = new Map<string, string>();
+              for (let i = events.length - 1; i >= 0; i--) {
+                const ev = events[i];
+                if (
+                  isHandoffEvent(ev) &&
+                  ev.tabId &&
+                  handoffTabs?.has(ev.tabId) &&
+                  !mostRecentHandoffByTab.has(ev.tabId)
+                ) {
+                  mostRecentHandoffByTab.set(
+                    ev.tabId,
+                    ev.requestId || ev.timestamp,
+                  );
                 }
-                onFilterChange={onFilterChange}
-              />
-            ))}
+              }
+
+              return events.map((event, index) => {
+                const suppressSessionLabel =
+                  Boolean(activeSessionId) &&
+                  event.sessionId === activeSessionId;
+                // Only show badge on the MOST RECENT handoff event per tab
+                const eventKey = event.requestId || event.timestamp;
+                const inHandoff =
+                  isHandoffEvent(event) &&
+                  Boolean(event.tabId && handoffTabs?.has(event.tabId)) &&
+                  mostRecentHandoffByTab.get(event.tabId!) === eventKey;
+                return (
+                  <ActivityItemLine
+                    key={`${eventKey}-${index}`}
+                    event={event}
+                    showTab
+                    copyTabId={copyTabId}
+                    sessionLabel={
+                      suppressSessionLabel
+                        ? undefined
+                        : event.sessionId
+                          ? sessionLabels.get(event.sessionId)
+                          : "anonymous"
+                    }
+                    inHandoff={inHandoff}
+                    onFilterChange={onFilterChange}
+                  />
+                );
+              });
+            })()}
           </div>
         )}
       </div>

--- a/dashboard/src/activities/AgentWorkspaceSidebar.tsx
+++ b/dashboard/src/activities/AgentWorkspaceSidebar.tsx
@@ -16,6 +16,8 @@ interface AgentWorkspaceSidebarProps {
   activeAgentId: string;
   filters: ActivityFilters;
   sessions: Session[];
+  sessionsWithHandoff?: Set<string>;
+  agentsWithHandoff?: Set<string>;
   showAllAgentsOption?: boolean;
   showAgentFilter?: boolean;
   profiles: Profile[];
@@ -39,6 +41,8 @@ export default function AgentWorkspaceSidebar({
   activeAgentId,
   filters,
   sessions,
+  sessionsWithHandoff,
+  agentsWithHandoff,
   showAllAgentsOption = true,
   showAgentFilter = true,
   profiles,
@@ -140,6 +144,8 @@ export default function AgentWorkspaceSidebar({
                 selected={activeAgentId === agent.id}
                 sessions={sessionsByAgent.get(agent.id) || []}
                 activeSessionId={filters.sessionId}
+                hasHandoff={agentsWithHandoff?.has(agent.id) ?? false}
+                sessionsWithHandoff={sessionsWithHandoff}
                 onClick={() => onSelectAgent(agent.id)}
                 onSelectSession={onSelectSession}
               />

--- a/dashboard/src/activities/handoffState.ts
+++ b/dashboard/src/activities/handoffState.ts
@@ -1,0 +1,73 @@
+import type { DashboardActivityEvent } from "./types";
+
+// Returns true for POST {tab}/handoff events (the pause action).
+export function isHandoffEvent(event: DashboardActivityEvent): boolean {
+  return (
+    event.method === "POST" &&
+    event.path.endsWith("/handoff") &&
+    Boolean(event.tabId)
+  );
+}
+
+// Returns true for POST {tab}/resume events (the unpause action).
+export function isResumeEvent(event: DashboardActivityEvent): boolean {
+  return (
+    event.method === "POST" &&
+    event.path.endsWith("/resume") &&
+    Boolean(event.tabId)
+  );
+}
+
+// computeHandoffTabs walks events in chronological order and returns the set
+// of tabIds whose most recent handoff/resume signal is a pause. A tab goes
+// into the set on POST .../handoff and leaves it on POST .../resume.
+export function computeHandoffTabs(
+  events: DashboardActivityEvent[],
+): Set<string> {
+  const paused = new Set<string>();
+
+  const sorted = [...events].sort(
+    (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime(),
+  );
+
+  for (const event of sorted) {
+    if (!event.tabId) continue;
+    if (isHandoffEvent(event) && event.status >= 200 && event.status < 300) {
+      paused.add(event.tabId);
+    } else if (
+      isResumeEvent(event) &&
+      event.status >= 200 &&
+      event.status < 300
+    ) {
+      paused.delete(event.tabId);
+    }
+  }
+
+  return paused;
+}
+
+// deriveSessionAgentIndex builds two sets:
+//  - sessionsWithHandoff: sessions that touched any currently-paused tab
+//  - agentsWithHandoff:   agents that touched any currently-paused tab
+//
+// We look across all events (not just handoff/resume) so a session is flagged
+// as long as it produced traffic on a tab that is now in handoff.
+export function deriveHandoffIndex(
+  events: DashboardActivityEvent[],
+  handoffTabs: Set<string>,
+): { sessionsWithHandoff: Set<string>; agentsWithHandoff: Set<string> } {
+  const sessionsWithHandoff = new Set<string>();
+  const agentsWithHandoff = new Set<string>();
+
+  if (handoffTabs.size === 0) {
+    return { sessionsWithHandoff, agentsWithHandoff };
+  }
+
+  for (const event of events) {
+    if (!event.tabId || !handoffTabs.has(event.tabId)) continue;
+    if (event.sessionId) sessionsWithHandoff.add(event.sessionId);
+    if (event.agentId) agentsWithHandoff.add(event.agentId);
+  }
+
+  return { sessionsWithHandoff, agentsWithHandoff };
+}

--- a/dashboard/src/components/molecules/AgentItem.tsx
+++ b/dashboard/src/components/molecules/AgentItem.tsx
@@ -7,8 +7,19 @@ interface Props {
   selected: boolean;
   sessions: Session[];
   activeSessionId?: string;
+  hasHandoff?: boolean;
+  sessionsWithHandoff?: Set<string>;
   onClick: () => void;
   onSelectSession: (sessionId: string) => void;
+}
+
+function HandoffDot() {
+  return (
+    <span
+      aria-label="tab paused for human handoff"
+      className="inline-block h-2 w-2 shrink-0 rounded-full bg-red-500 ring-2 ring-bg-surface"
+    />
+  );
 }
 
 function timeAgo(date: string): string {
@@ -40,6 +51,8 @@ export default function AgentItem({
   selected,
   sessions,
   activeSessionId,
+  hasHandoff = false,
+  sessionsWithHandoff,
   onClick,
   onSelectSession,
 }: Props) {
@@ -56,10 +69,11 @@ export default function AgentItem({
         <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-primary">
           <IconRobot />
         </div>
-        <div className="min-w-0 flex-1">
+        <div className="min-w-0 flex-1 flex items-center gap-2">
           <span className="truncate text-sm font-medium">
             {agent.name || agent.id}
           </span>
+          {hasHandoff && <HandoffDot />}
         </div>
         <span className="dashboard-mono text-[0.65rem] text-text-muted">
           {timeAgo(agent.lastActivity || agent.connectedAt)}
@@ -70,6 +84,8 @@ export default function AgentItem({
         <div className="ml-5 border-l border-border-subtle">
           {sessions.map((session) => {
             const isActive = activeSessionId === session.id;
+            const sessionHasHandoff =
+              sessionsWithHandoff?.has(session.id) ?? false;
             return (
               <button
                 key={session.id}
@@ -84,6 +100,7 @@ export default function AgentItem({
                 <span className="min-w-0 flex-1 truncate text-xs font-medium">
                   {sessionDisplayName(session)}
                 </span>
+                {sessionHasHandoff && <HandoffDot />}
               </button>
             );
           })}

--- a/dashboard/src/components/molecules/HandoffNotifications.tsx
+++ b/dashboard/src/components/molecules/HandoffNotifications.tsx
@@ -1,0 +1,68 @@
+import { useAppStore } from "../../stores/useAppStore";
+import { resumeTab } from "../../services/api";
+
+export default function HandoffNotifications() {
+  const notifications = useAppStore((state) => state.handoffNotifications);
+  const dismiss = useAppStore((state) => state.dismissHandoffNotification);
+
+  if (notifications.length === 0) {
+    return null;
+  }
+
+  const handleResume = async (tabId: string) => {
+    try {
+      await resumeTab(tabId);
+      dismiss(tabId);
+    } catch (err) {
+      console.error("Failed to resume tab", err);
+    }
+  };
+
+  return (
+    <div className="fixed bottom-4 right-4 z-50 flex w-96 max-w-full flex-col gap-2">
+      {notifications.map((n) => (
+        <div
+          key={n.tabId}
+          className="rounded-sm border border-warning/50 bg-warning/10 p-3 text-sm shadow-lg"
+        >
+          <div className="mb-1 flex items-start justify-between gap-2">
+            <div className="font-semibold text-warning">
+              Human intervention required
+            </div>
+            <button
+              type="button"
+              onClick={() => dismiss(n.tabId)}
+              className="text-text-muted hover:text-text-primary"
+              aria-label="Dismiss notification"
+            >
+              ×
+            </button>
+          </div>
+          <div className="mb-1 text-text-primary">
+            <code className="text-xs">{n.tabId}</code>
+            {n.title && <span className="ml-2 text-text-muted">{n.title}</span>}
+          </div>
+          <div className="mb-2 text-text-secondary">
+            <span className="text-text-muted">Reason:</span>{" "}
+            <code className="text-xs">{n.reason}</code>
+            {n.source && (
+              <span className="ml-2 text-text-muted">via {n.source}</span>
+            )}
+          </div>
+          {n.hint && (
+            <div className="mb-2 text-xs text-text-muted">{n.hint}</div>
+          )}
+          <div className="flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={() => handleResume(n.tabId)}
+              className="rounded-sm border border-border-subtle px-3 py-1 text-xs text-text-primary transition-all duration-150 hover:border-primary/30 hover:bg-bg-elevated"
+            >
+              Resume
+            </button>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/dashboard/src/components/molecules/index.ts
+++ b/dashboard/src/components/molecules/index.ts
@@ -11,3 +11,4 @@ export { default as AgentItem } from "./AgentItem";
 export { default as ActivityLine } from "../../activities/ActivityLine";
 export { default as TabsChart } from "./TabsChart";
 export { default as ServerSummary } from "./ServerSummary";
+export { default as HandoffNotifications } from "./HandoffNotifications";

--- a/dashboard/src/pages/MonitoringPage.tsx
+++ b/dashboard/src/pages/MonitoringPage.tsx
@@ -20,7 +20,13 @@ export default function MonitoringPage() {
     selectedMonitoringInstanceId,
     setSelectedMonitoringInstanceId,
     setInstances,
+    handoffNotifications,
   } = useAppStore();
+
+  const handoffTabs = useMemo(
+    () => new Set(handoffNotifications.map((n) => n.tabId)),
+    [handoffNotifications],
+  );
   const navigate = useNavigate();
   const selectedId = selectedMonitoringInstanceId;
   const setSelectedId = setSelectedMonitoringInstanceId;
@@ -308,6 +314,7 @@ export default function MonitoringPage() {
                     <InstanceTabsPanel
                       tabs={selectedTabs}
                       instanceId={selectedId || undefined}
+                      handoffTabs={handoffTabs}
                     />
                   ) : (
                     <div className="flex flex-1 items-center justify-center px-6">

--- a/dashboard/src/pages/settings/AutoSolverSettingsSection.tsx
+++ b/dashboard/src/pages/settings/AutoSolverSettingsSection.tsx
@@ -46,6 +46,60 @@ export function AutoSolverSettingsSection({
         </label>
       </SettingRow>
       <SettingRow
+        label="Auto trigger"
+        description="Automatically run autosolver after supported navigation and action requests."
+      >
+        <label className="flex items-center justify-end gap-3 text-sm text-text-secondary">
+          <input
+            type="checkbox"
+            checked={backendConfig.autoSolver.autoTrigger}
+            onChange={(e) =>
+              updateBackendSection("autoSolver", {
+                autoTrigger: e.target.checked,
+              })
+            }
+            className="h-4 w-4"
+          />
+          {backendConfig.autoSolver.autoTrigger ? "Enabled" : "Disabled"}
+        </label>
+      </SettingRow>
+      <SettingRow
+        label="Trigger on navigate"
+        description="Run autosolver checks after successful navigation calls."
+      >
+        <label className="flex items-center justify-end gap-3 text-sm text-text-secondary">
+          <input
+            type="checkbox"
+            checked={backendConfig.autoSolver.triggerOnNavigate}
+            onChange={(e) =>
+              updateBackendSection("autoSolver", {
+                triggerOnNavigate: e.target.checked,
+              })
+            }
+            className="h-4 w-4"
+          />
+          {backendConfig.autoSolver.triggerOnNavigate ? "Enabled" : "Disabled"}
+        </label>
+      </SettingRow>
+      <SettingRow
+        label="Trigger on action"
+        description="Run autosolver checks after successful action calls."
+      >
+        <label className="flex items-center justify-end gap-3 text-sm text-text-secondary">
+          <input
+            type="checkbox"
+            checked={backendConfig.autoSolver.triggerOnAction}
+            onChange={(e) =>
+              updateBackendSection("autoSolver", {
+                triggerOnAction: e.target.checked,
+              })
+            }
+            className="h-4 w-4"
+          />
+          {backendConfig.autoSolver.triggerOnAction ? "Enabled" : "Disabled"}
+        </label>
+      </SettingRow>
+      <SettingRow
         label="Max attempts"
         description="Maximum autosolver retries before the pipeline gives up."
       >
@@ -62,8 +116,56 @@ export function AutoSolverSettingsSection({
         />
       </SettingRow>
       <SettingRow
+        label="Solver timeout (sec)"
+        description="Per-solver timeout for each attempt."
+      >
+        <input
+          type="number"
+          min={1}
+          value={backendConfig.autoSolver.solverTimeoutSec}
+          onChange={(e) =>
+            updateBackendSection("autoSolver", {
+              solverTimeoutSec: Number(e.target.value),
+            })
+          }
+          className={fieldClass}
+        />
+      </SettingRow>
+      <SettingRow
+        label="Retry base delay (ms)"
+        description="Base retry backoff delay between autosolver attempts."
+      >
+        <input
+          type="number"
+          min={0}
+          value={backendConfig.autoSolver.retryBaseDelayMs}
+          onChange={(e) =>
+            updateBackendSection("autoSolver", {
+              retryBaseDelayMs: Number(e.target.value),
+            })
+          }
+          className={fieldClass}
+        />
+      </SettingRow>
+      <SettingRow
+        label="Retry max delay (ms)"
+        description="Maximum retry backoff delay cap between autosolver attempts."
+      >
+        <input
+          type="number"
+          min={0}
+          value={backendConfig.autoSolver.retryMaxDelayMs}
+          onChange={(e) =>
+            updateBackendSection("autoSolver", {
+              retryMaxDelayMs: Number(e.target.value),
+            })
+          }
+          className={fieldClass}
+        />
+      </SettingRow>
+      <SettingRow
         label="Solvers"
-        description="Comma-separated ordered list of solver names to try."
+        description="Comma-separated ordered list of solver names to try. Use GET /solvers or GET /config/autosolver to confirm runtime-available names."
       >
         <input
           value={listToCsv(backendConfig.autoSolver.solvers)}
@@ -109,7 +211,7 @@ export function AutoSolverSettingsSection({
       </SettingRow>
       <SettingRow
         label="External provider keys"
-        description="Capsolver and 2Captcha credentials are not shown in the dashboard and must be managed in the config file."
+        description="Capsolver and 2Captcha credentials are not shown in the dashboard and must be managed in the config file. Those providers appear in runtime solver lists only when keys are configured."
       >
         <div className="rounded-sm border border-warning/25 bg-warning/10 px-3 py-2 text-xs leading-5 text-warning">
           Open the config file above and set{" "}

--- a/dashboard/src/profiles/ProfileDetailsPanel.tsx
+++ b/dashboard/src/profiles/ProfileDetailsPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import InstanceLogsPanel from "./InstanceLogsPanel";
 import ProfileMetaInfoPanel from "./ProfileMetaInfoPanel";
 import ProfileBasicInfoPanel from "./ProfileBasicInfoPanel";
@@ -8,6 +8,7 @@ import { InstanceTabsPanel } from "../tabs";
 import { TabsLayout, EmptyView } from "../components/molecules";
 import type { Profile, Instance, InstanceTab } from "../generated/types";
 import * as api from "../services/api";
+import { useAppStore } from "../stores/useAppStore";
 
 interface Props {
   profile: Profile | null;
@@ -31,6 +32,12 @@ export default function ProfileDetailsPanel({
   const [activeTab, setActiveTab] = useState<TabId>("profile");
   const [tabs, setTabs] = useState<InstanceTab[]>([]);
   const [formValues, setFormValues] = useState({ name: "", useWhen: "" });
+  const { handoffNotifications } = useAppStore();
+
+  const handoffTabs = useMemo(
+    () => new Set(handoffNotifications.map((n) => n.tabId)),
+    [handoffNotifications],
+  );
 
   const isRunning = instance?.status === "running";
 
@@ -137,6 +144,7 @@ export default function ProfileDetailsPanel({
               <InstanceTabsPanel
                 tabs={tabs}
                 instanceId={instance?.id}
+                handoffTabs={handoffTabs}
                 emptyMessage={
                   isRunning ? "No tabs open." : "Instance not running."
                 }

--- a/dashboard/src/services/api.ts
+++ b/dashboard/src/services/api.ts
@@ -266,6 +266,17 @@ export async function closeTab(tabId: string): Promise<void> {
   await request(`/tabs/${encodeURIComponent(tabId)}/close`, { method: "POST" });
 }
 
+export async function resumeTab(
+  tabId: string,
+  status = "human_completed",
+): Promise<void> {
+  await request(`/tabs/${encodeURIComponent(tabId)}/resume`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ status }),
+  });
+}
+
 export interface ConsoleLogEntry {
   timestamp: string;
   level: string;
@@ -507,9 +518,27 @@ export async function saveBackendConfig(
 }
 
 // SSE Events — endpoint is /api/events
+export interface HandoffPayload {
+  tabId?: string;
+  status?: string;
+  reason?: string;
+  source?: string;
+  hint?: string;
+  requestedAt?: string;
+  resumedAt?: string;
+  timeoutMs?: number;
+  url?: string;
+  title?: string;
+}
+
 export interface SystemEvent {
-  type: "instance.started" | "instance.stopped" | "instance.error";
-  instance?: Instance;
+  type:
+    | "instance.started"
+    | "instance.stopped"
+    | "instance.error"
+    | "tab.handoff"
+    | "tab.resume";
+  instance?: Instance | HandoffPayload;
 }
 
 export function activityEventSource(event: ActivityEvent): string {

--- a/dashboard/src/services/dashboardRealtime.ts
+++ b/dashboard/src/services/dashboardRealtime.ts
@@ -66,7 +66,37 @@ function startDashboardRealtime(includeMemory: boolean) {
         state.setAgents(mergeAgents(state.agents, agents));
       },
       onSystem: (event) => {
-        console.log("System event:", event);
+        const state = useAppStore.getState();
+        if (event.type === "tab.handoff") {
+          const payload = (event.instance ?? {}) as Record<string, unknown>;
+          const tabId =
+            typeof payload.tabId === "string" ? payload.tabId : null;
+          if (!tabId) {
+            return;
+          }
+          state.addHandoffNotification({
+            tabId,
+            reason:
+              typeof payload.reason === "string"
+                ? payload.reason
+                : "manual_handoff",
+            hint: typeof payload.hint === "string" ? payload.hint : undefined,
+            source:
+              typeof payload.source === "string" ? payload.source : undefined,
+            url: typeof payload.url === "string" ? payload.url : undefined,
+            title:
+              typeof payload.title === "string" ? payload.title : undefined,
+            receivedAt: Date.now(),
+          });
+          return;
+        }
+        if (event.type === "tab.resume") {
+          const payload = (event.instance ?? {}) as Record<string, unknown>;
+          if (typeof payload.tabId === "string") {
+            state.dismissHandoffNotification(payload.tabId);
+          }
+          return;
+        }
       },
       onActivity: (event) => {
         if (!isClientActivityEvent(event)) {

--- a/dashboard/src/stores/useAppStore.ts
+++ b/dashboard/src/stores/useAppStore.ts
@@ -27,6 +27,16 @@ export interface ServerDataPoint {
   rateBucketHosts: number;
 }
 
+export interface HandoffNotification {
+  tabId: string;
+  reason: string;
+  hint?: string;
+  source?: string;
+  url?: string;
+  title?: string;
+  receivedAt: number;
+}
+
 interface AppState {
   // Profiles
   profiles: Profile[];
@@ -81,6 +91,12 @@ interface AppState {
   // Server info
   serverInfo: DashboardServerInfo | null;
   setServerInfo: (info: DashboardServerInfo | null) => void;
+
+  // Handoff notifications (tabs paused for human-in-the-loop)
+  handoffNotifications: HandoffNotification[];
+  addHandoffNotification: (notification: HandoffNotification) => void;
+  dismissHandoffNotification: (tabId: string) => void;
+  clearHandoffNotifications: () => void;
 
   // Monitoring UI
   monitoringSidebarCollapsed: boolean;
@@ -418,6 +434,23 @@ export const useAppStore = create<AppState>((set) => ({
   // Server info
   serverInfo: null,
   setServerInfo: (serverInfo) => set({ serverInfo }),
+
+  // Handoff notifications
+  handoffNotifications: [],
+  addHandoffNotification: (notification) =>
+    set((state) => {
+      const filtered = state.handoffNotifications.filter(
+        (n) => n.tabId !== notification.tabId,
+      );
+      return { handoffNotifications: [...filtered, notification] };
+    }),
+  dismissHandoffNotification: (tabId) =>
+    set((state) => ({
+      handoffNotifications: state.handoffNotifications.filter(
+        (n) => n.tabId !== tabId,
+      ),
+    })),
+  clearHandoffNotifications: () => set({ handoffNotifications: [] }),
 
   // Monitoring UI
   monitoringSidebarCollapsed: true,

--- a/dashboard/src/tabs/InstanceTabsPanel.tsx
+++ b/dashboard/src/tabs/InstanceTabsPanel.tsx
@@ -11,6 +11,7 @@ interface Props {
   tabs: InstanceTab[];
   emptyMessage?: string;
   instanceId?: string;
+  handoffTabs?: Set<string>;
 }
 
 function sameIds(left: string[], right: string[]): boolean {
@@ -24,6 +25,7 @@ export default function InstanceTabsPanel({
   tabs,
   emptyMessage = "No tabs open",
   instanceId,
+  handoffTabs,
 }: Props) {
   const [selectedTabId, setSelectedTabId] = useState<string | null>(null);
   const [selectionPinned, setSelectionPinned] = useState(false);
@@ -130,6 +132,7 @@ export default function InstanceTabsPanel({
           pinnedTabId={selectionPinned ? selectedTabId : null}
           telemetryActive={showTelemetry}
           newTabsCount={newTabsCount}
+          handoffTabs={handoffTabs}
           onSelect={(id) => {
             setAcknowledgedTabIds(currentTabIds);
             setSelectedTabId(id);

--- a/dashboard/src/tabs/TabBar.tsx
+++ b/dashboard/src/tabs/TabBar.tsx
@@ -7,11 +7,22 @@ interface Props {
   pinnedTabId?: string | null;
   telemetryActive?: boolean;
   newTabsCount?: number;
+  handoffTabs?: Set<string>;
   onSelect: (id: string) => void;
   onTogglePinned?: (id: string) => void;
   onTabClosed?: () => void;
   onToggleTelemetry?: () => void;
   onSetTelemetry?: (active: boolean) => void;
+}
+
+function HandoffDot() {
+  return (
+    <span
+      aria-label="tab paused for human handoff"
+      title="Tab is paused for human handoff"
+      className="inline-block h-2 w-2 shrink-0 rounded-full bg-red-500 ring-2 ring-bg-surface"
+    />
+  );
 }
 
 function PinIcon({ pinned }: { pinned: boolean }) {
@@ -39,6 +50,7 @@ export default function TabBar({
   pinnedTabId,
   telemetryActive,
   newTabsCount = 0,
+  handoffTabs,
   onSelect,
   onTogglePinned,
   onTabClosed,
@@ -61,6 +73,7 @@ export default function TabBar({
       {tabs.map((tab) => {
         const isSelected = tab.id === selectedTabId && !telemetryActive;
         const isPinned = tab.id === pinnedTabId;
+        const isInHandoff = handoffTabs?.has(tab.id) ?? false;
         const title = tab.title || "Untitled";
 
         return (
@@ -76,9 +89,10 @@ export default function TabBar({
               type="button"
               onClick={() => onSelect(tab.id)}
               title={`${title}\n${tab.url}`}
-              className="min-w-0 flex-1 truncate text-left"
+              className="min-w-0 flex-1 truncate text-left flex items-center gap-1.5"
             >
               <span className="truncate text-xs font-medium">{title}</span>
+              {isInHandoff && <HandoffDot />}
             </button>
             {onTogglePinned && (
               <button

--- a/dashboard/src/types/index.ts
+++ b/dashboard/src/types/index.ts
@@ -180,7 +180,13 @@ export interface BackendTimeoutsConfig {
 
 export interface BackendAutoSolverConfig {
   enabled: boolean;
+  autoTrigger: boolean;
+  triggerOnNavigate: boolean;
+  triggerOnAction: boolean;
   maxAttempts: number;
+  solverTimeoutSec: number;
+  retryBaseDelayMs: number;
+  retryMaxDelayMs: number;
   solvers: string[];
   llmProvider: string;
   llmFallback: boolean;
@@ -309,8 +315,14 @@ export const defaultBackendConfig: BackendConfig = {
   },
   autoSolver: {
     enabled: false,
+    autoTrigger: true,
+    triggerOnNavigate: true,
+    triggerOnAction: true,
     maxAttempts: 8,
-    solvers: ["cloudflare", "semantic"],
+    solverTimeoutSec: 30,
+    retryBaseDelayMs: 500,
+    retryMaxDelayMs: 10000,
+    solvers: ["cloudflare", "semantic", "capsolver", "twocaptcha"],
     llmProvider: "",
     llmFallback: false,
   },

--- a/docs/architecture/autosolver.md
+++ b/docs/architecture/autosolver.md
@@ -27,8 +27,8 @@ The AutoSolver system provides modular, semantic-first browser automation for Pi
 │  ┌──────────┐    ┌──────────┐    ┌──────────────┐   │
 │  │ Registry │───▶│Core Loop │───▶│ Fallback     │   │
 │  │ (solvers)│    │(detect + │    │ Chain:       │   │
-│  └──────────┘    │ dispatch)│    │ built-in →   │   │
-│                  └────┬─────┘    │ semantic →   │   │
+│  └──────────┘    │ dispatch)│    │ semantic →   │   │
+│                  └────┬─────┘    │ rule-based → │   │
 │                       │          │ external →   │   │
 │                       ▼          │ LLM          │   │
 │              ┌────────────────┐  └──────────────┘   │
@@ -56,10 +56,12 @@ internal/autosolver/
 ├── interfaces.go          # Page, ActionExecutor, Solver, SemanticEngine, LLMProvider
 ├── types.go               # Result, Intent, Config, enums
 ├── autosolver.go          # Core orchestrator with fallback chain
+├── challenge_detection.go # Shared challenge classification (title/URL/HTML)
 ├── heuristics.go          # Title-based intent detection fallback
 ├── registry.go            # Instance-level solver registry with priority ordering
-├── autosolver_test.go     # Core loop tests (7 test cases)
-├── registry_test.go       # Registry tests (8 test cases)
+├── autosolver_test.go     # Core loop tests
+├── challenge_detection_test.go
+├── registry_test.go
 ├── adapters/
 │   └── pinchtab.go        # Bridge adapter (ONLY chromedp import)
 ├── semantic/
@@ -72,6 +74,8 @@ internal/autosolver/
 │   └── trim.go            # HTML trimming for token efficiency
 └── solvers/
     ├── cloudflare.go      # Cloudflare Turnstile (new interface, no chromedp)
+    ├── jschallenge.go     # Generic JavaScript challenge/interstitial solver
+    ├── jschallenge_test.go
     └── legacy.go          # Compatibility shim for existing solver.Solver
 ```
 
@@ -132,16 +136,16 @@ The core loop executes this chain per attempt:
 ```
 1. Detect intent (semantic engine → title heuristics)
 2. If intent = normal → return solved
-3. Find matching solvers (CanHandle = true, sorted by priority)
-4. Try each solver:
-   a. Built-in (cloudflare, priority 10)
-   b. External (capsolver priority 200, twocaptcha priority 210)
-5. If all fail AND LLM enabled:
+3. Try semantic-first action planning (`/find` + self-healing)
+4. If still unresolved, find matching solvers (CanHandle = true)
+5. Execute solvers in configured order (`autoSolver.solvers`), falling back to
+    priority order when configuration does not match available solvers
+6. If all fail AND LLM enabled:
    a. Trim HTML to ~4KB
    b. Build structured prompt with attempt history
    c. Execute LLM-suggested action
-6. Retry with exponential backoff (500ms → 10s cap)
-7. Stop after MaxAttempts (default: 8)
+7. Retry with exponential backoff (500ms → 10s cap)
+8. Stop after MaxAttempts (default: 8)
 ```
 
 ## Configuration
@@ -152,7 +156,13 @@ The core loop executes this chain per attempt:
 {
   "autoSolver": {
     "enabled": true,
+    "autoTrigger": true,
+    "triggerOnNavigate": true,
+    "triggerOnAction": true,
     "maxAttempts": 8,
+    "solverTimeoutSec": 30,
+    "retryBaseDelayMs": 500,
+    "retryMaxDelayMs": 10000,
     "solvers": ["cloudflare", "semantic", "capsolver", "twocaptcha"],
     "llmProvider": "openai",
     "llmFallback": false,
@@ -230,4 +240,4 @@ if result.Solved {
 
 ## Backward Compatibility
 
-The existing `internal/solver` package (PR #395) is **not modified**. The `CloudflareSolver` in `bridge/cloudflare.go` continues to work as-is. A `LegacyAdapter` shim (`solvers/legacy.go`) wraps old `solver.Solver` implementations to work with the new `autosolver.Solver` interface.
+The existing `internal/solver` package (PR #395) is still present for compatibility, but challenge APIs are now backed by `internal/autosolver`. The `CloudflareSolver` in `bridge/cloudflare.go` remains available, and a `LegacyAdapter` shim (`solvers/legacy.go`) can wrap legacy `solver.Solver` implementations into the new `autosolver.Solver` interface.

--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -104,10 +104,11 @@ Notes:
 
 - these routes are tab-scoped only
 - `POST /tabs/{id}/handoff` marks the tab as `paused_handoff` and records a reason
-- `GET /tabs/{id}/handoff` returns the current handoff state, or `active` when no handoff is set (includes `expiresAt` and `timeoutMs` when timeout is configured)
+- `GET /tabs/{id}/handoff` returns the current handoff state, or `active` when no handoff is set
 - `POST /tabs/{id}/resume` clears the handoff state and can carry resume metadata for the caller
-- action execution routes (`/action`, `/actions`, `/macro`) reject paused tabs with `409 tab_paused_handoff`
-- CLI wrappers are available: `pinchtab tab handoff`, `pinchtab tab handoff-status`, and `pinchtab tab resume`
+- current behavior is advisory only: handoff state is not yet a hard block on subsequent automation requests
+- treat the current implementation as temporary coordination state, not as a security boundary
+- there is currently no dedicated CLI wrapper for handoff or resume; use the HTTP API
 
 ## Tab Locking
 
@@ -436,20 +437,46 @@ Console and error routes use query parameters:
 
 ```text
 GET  /solvers
+GET  /config/autosolver
 POST /solve
 POST /solve/{name}
 POST /tabs/{id}/solve
 POST /tabs/{id}/solve/{name}
 ```
 
-The solver framework auto-detects and resolves browser challenges (Cloudflare Turnstile, etc.). See [Solve reference](./reference/solve.md) for details.
+The autosolver framework auto-detects and resolves browser challenges (Cloudflare Turnstile, CAPTCHAs, interstitials, etc.). See [Solve reference](./reference/solve.md) for details.
 
 Solve body fields:
 
 - `solver` optional solver name (auto-detect when omitted)
 - `tabId` optional
-- `maxAttempts` optional (default: 3)
-- `timeout` optional in ms (default: 30000)
+- `maxAttempts` optional (defaults to `autoSolver.maxAttempts`, default `8`)
+- `timeout` optional in ms (auto-estimated when omitted, minimum `30000`)
+
+`GET /config/autosolver` returns effective autosolver runtime settings and the
+currently available solver list.
+
+Example response:
+
+```json
+{
+	"enabled": true,
+	"autoTrigger": true,
+	"triggerOnNavigate": true,
+	"triggerOnAction": true,
+	"maxAttempts": 8,
+	"solverTimeoutSec": 30,
+	"retryBaseDelayMs": 500,
+	"retryMaxDelayMs": 10000,
+	"solvers": ["cloudflare", "semantic", "jschallenge"],
+	"llmProvider": "",
+	"llmFallback": false
+}
+```
+
+Notes:
+
+- `capsolver` and `twocaptcha` appear in `solvers` only when their API keys are configured.
 
 ## Profiles And Instances
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -93,6 +93,29 @@ pinchtab network              # GET  200  https://...
 | `pinchtab security` | Open the interactive security overview |
 | `pinchtab completion <shell>` | Generate shell completion scripts |
 
+### Server Flags
+
+```bash
+pinchtab server [flags]
+```
+
+| Flag | Short | Purpose |
+| --- | --- | --- |
+| `--yolo` | `-y` | Apply guards down preset (enables evaluate, macro, download) |
+| `--headed` | `-H` | Start browser instances in headed (visible) mode |
+| `--extension <path>` | `-e` | Load browser extension (repeatable) |
+
+Examples:
+
+```bash
+pinchtab server -y                  # guards down for local dev
+pinchtab server -H                  # visible browser for debugging
+pinchtab server -yH                 # both combined
+pinchtab server -e ./my-extension   # load extension
+```
+
+**Note:** Use `--headed` only when you need visual feedback (debugging, manual testing). Headless mode is more resource-efficient for automation.
+
 ## Browser Commands
 
 The browser control surface is top-level. `tab` is only for list/focus/new/close.

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -231,7 +231,13 @@ Current nested file-config shape:
   },
   "autoSolver": {
     "enabled": false,
+    "autoTrigger": true,
+    "triggerOnNavigate": true,
+    "triggerOnAction": true,
     "maxAttempts": 8,
+    "solverTimeoutSec": 30,
+    "retryBaseDelayMs": 500,
+    "retryMaxDelayMs": 10000,
     "solvers": ["cloudflare", "semantic", "capsolver", "twocaptcha"],
     "llmProvider": "",
     "llmFallback": false,
@@ -271,6 +277,19 @@ Current nested file-config shape:
 
 `autoSolver.external` is config-file-only. Capsolver and 2Captcha credentials
 are stored there.
+
+### Semantic Flow Environment Variables
+
+The semantic-first autosolver flow can consume optional environment variables
+for login/signup/form-filling steps:
+
+- `PINCHTAB_AUTOSOLVER_LOGIN_USER` or `PINCHTAB_AUTOSOLVER_LOGIN_EMAIL`: login username/email value
+- `PINCHTAB_AUTOSOLVER_LOGIN_PASS` or `PINCHTAB_AUTOSOLVER_LOGIN_PASSWORD`: login password value
+- `PINCHTAB_AUTOSOLVER_SIGNUP_NAME`: signup full-name value
+- `PINCHTAB_AUTOSOLVER_SIGNUP_EMAIL`: signup email value
+- `PINCHTAB_AUTOSOLVER_SIGNUP_PASSWORD`: signup password value
+- `PINCHTAB_AUTOSOLVER_FORM_FIELD1`: generic form field value (step 1)
+- `PINCHTAB_AUTOSOLVER_FORM_FIELD2` or `PINCHTAB_AUTOSOLVER_FORM_EMAIL`: generic form field/email value (step 2)
 
 The dashboard Settings page exposes the non-secret AutoSolver settings and
 shows the active config file path. Provider keys remain managed directly in the

--- a/docs/reference/solve.md
+++ b/docs/reference/solve.md
@@ -2,7 +2,7 @@
 
 Detect and solve browser challenges (Cloudflare Turnstile, CAPTCHAs, interstitials, etc.) on the current page.
 
-PinchTab ships with a pluggable **solver framework**. Each solver targets a specific provider (e.g. Cloudflare). Solvers are registered at startup and can be invoked explicitly by name or discovered automatically.
+These endpoints are powered by the `internal/autosolver` pipeline. In auto mode, PinchTab runs semantic intent detection first, then tries configured solvers in order, and optionally falls back to LLM when enabled.
 
 ## Endpoints
 
@@ -22,13 +22,15 @@ curl http://localhost:9867/solvers
 
 ```json
 {
-  "solvers": ["cloudflare"]
+  "solvers": ["cloudflare", "semantic", "jschallenge"]
 }
 ```
 
+`capsolver` and `twocaptcha` are included when their API keys are configured.
+
 ## Auto-Detect Solve
 
-When no `solver` field is provided, PinchTab tries each registered solver in order. The first one whose `CanHandle` returns true is used.
+When no `solver` field is provided, PinchTab runs the autosolver chain using the configured order (`autoSolver.solvers`).
 
 ```bash
 curl -X POST http://localhost:9867/solve \
@@ -68,8 +70,8 @@ curl -X POST http://localhost:9867/tabs/{tabId}/solve \
 |--------------|--------|---------|------------------------------------------|
 | `tabId`      | string | —       | Tab ID (optional, uses default tab)      |
 | `solver`     | string | —       | Solver name (optional, auto-detect)      |
-| `maxAttempts`| int    | 3       | Maximum solve attempts                   |
-| `timeout`    | float  | 30000   | Overall timeout in milliseconds          |
+| `maxAttempts`| int    | config (`autoSolver.maxAttempts`, default 8) | Maximum solve attempts |
+| `timeout`    | float  | auto-estimated (minimum 30000) | Overall timeout in milliseconds |
 
 ## Response
 
@@ -77,12 +79,10 @@ curl -X POST http://localhost:9867/tabs/{tabId}/solve \
 {
   "tabId": "DEADBEEF",
   "solver": "cloudflare",
-  "solved": false,
-  "challengeType": "managed",
+  "solved": true,
+  "challengeType": "turnstile",
   "attempts": 1,
-  "title": "Just a moment...",
-  "needsHumanHandoff": true,
-  "handoffReason": "challenge_requires_manual_intervention"
+  "title": "thuisbezorgd.nl"
 }
 ```
 
@@ -91,11 +91,9 @@ curl -X POST http://localhost:9867/tabs/{tabId}/solve \
 | `tabId`         | string | Tab the solve ran on                           |
 | `solver`        | string | Which solver handled the challenge             |
 | `solved`        | bool   | Whether the challenge was resolved             |
-| `challengeType` | string | Challenge variant (e.g. `managed`, `embedded`) |
+| `challengeType` | string | Challenge variant (`turnstile`, `recaptcha-v2`, `hcaptcha`) or broad intent (`captcha`, `blocked`) |
 | `attempts`      | int    | Number of attempts made                        |
 | `title`         | string | Final page title                               |
-| `needsHumanHandoff` | bool | Whether manual intervention is required to continue |
-| `handoffReason` | string | Reason for handoff (`challenge_requires_manual_intervention`, `credentials_required`, or empty when not needed) |
 
 ## Error Responses
 
@@ -107,6 +105,14 @@ curl -X POST http://localhost:9867/tabs/{tabId}/solve \
 | 500  | CDP/Chrome error                       |
 
 ## Built-In Solvers
+
+### Semantic (`semantic`)
+
+Semantic-first solver that uses `/find`-style matching and multi-step action planning for challenge and flow resolution.
+
+### JS Challenge (`jschallenge`)
+
+Generic JavaScript anti-bot/interstitial solver that waits, probes common verification controls, and polls for challenge resolution.
 
 ### Cloudflare (`cloudflare`)
 
@@ -127,35 +133,38 @@ Handles Cloudflare Turnstile and interstitial challenges.
 
 **Stealth requirement**: The Cloudflare solver works best with `stealthLevel: "full"` in the PinchTab config. Cloudflare evaluates browser fingerprints (CDP detection, WebGL, canvas, navigator properties) before and after the checkbox interaction. Without full stealth, the solver may click correctly but the challenge can still fail fingerprint verification. Check stealth status with `GET /stealth/status`.
 
+### External Solvers
+
+- `capsolver` (requires `autoSolver.external.capsolverKey`)
+- `twocaptcha` (requires `autoSolver.external.twoCaptchaKey`)
+
 ## Writing a Custom Solver
 
-Implement the `solver.Solver` interface and register it during `init()`:
+Implement the `autosolver.Solver` interface and register it where the autosolver registry is constructed:
 
 ```go
 package mygateway
 
 import (
     "context"
-    "github.com/pinchtab/pinchtab/internal/solver"
+  "github.com/pinchtab/pinchtab/internal/autosolver"
 )
-
-func init() {
-    solver.MustRegister("mygateway", &MyGatewaySolver{})
-}
 
 type MyGatewaySolver struct{}
 
 func (s *MyGatewaySolver) Name() string { return "mygateway" }
 
-func (s *MyGatewaySolver) CanHandle(ctx context.Context) (bool, error) {
+func (s *MyGatewaySolver) Priority() int { return 150 }
+
+func (s *MyGatewaySolver) CanHandle(ctx context.Context, page autosolver.Page) (bool, error) {
     // Check page markers (title, DOM elements, etc.)
     return false, nil
 }
 
-func (s *MyGatewaySolver) Solve(ctx context.Context, opts solver.Options) (*solver.Result, error) {
+func (s *MyGatewaySolver) Solve(ctx context.Context, page autosolver.Page, exec autosolver.ActionExecutor) (*autosolver.Result, error) {
     // Detect, interact, and resolve the challenge.
-    return &solver.Result{Solver: "mygateway", Solved: true}, nil
+  return &autosolver.Result{SolverUsed: "mygateway", Solved: true}, nil
 }
 ```
 
-The solver has access to the full chromedp context for CDP operations.
+Then add it to the handler autosolver registry setup.

--- a/internal/autosolver/adapters/pinchtab.go
+++ b/internal/autosolver/adapters/pinchtab.go
@@ -13,15 +13,20 @@ import (
 	"github.com/pinchtab/pinchtab/internal/bridge"
 )
 
+var (
+	_ autosolver.Page           = (*PinchtabPage)(nil)
+	_ autosolver.ActionExecutor = (*PinchtabExecutor)(nil)
+)
+
 // PinchtabPage implements autosolver.Page by wrapping a chromedp tab context.
 type PinchtabPage struct {
 	ctx   context.Context
 	tabID string
-	b     *bridge.Bridge
+	b     bridge.BridgeAPI
 }
 
 // NewPinchtabPage creates a Page backed by a Pinchtab bridge tab.
-func NewPinchtabPage(ctx context.Context, tabID string, b *bridge.Bridge) *PinchtabPage {
+func NewPinchtabPage(ctx context.Context, tabID string, b bridge.BridgeAPI) *PinchtabPage {
 	return &PinchtabPage{ctx: ctx, tabID: tabID, b: b}
 }
 
@@ -61,11 +66,11 @@ func (p *PinchtabPage) Screenshot() ([]byte, error) {
 type PinchtabExecutor struct {
 	ctx   context.Context
 	tabID string
-	b     *bridge.Bridge
+	b     bridge.BridgeAPI
 }
 
 // NewPinchtabExecutor creates an ActionExecutor backed by a Pinchtab bridge.
-func NewPinchtabExecutor(ctx context.Context, tabID string, b *bridge.Bridge) *PinchtabExecutor {
+func NewPinchtabExecutor(ctx context.Context, tabID string, b bridge.BridgeAPI) *PinchtabExecutor {
 	return &PinchtabExecutor{ctx: ctx, tabID: tabID, b: b}
 }
 
@@ -94,7 +99,7 @@ func (e *PinchtabExecutor) Navigate(ctx context.Context, url string) error {
 
 // NewFromBridge creates both a Page and ActionExecutor from a Bridge
 // and tab ID. This is the primary factory for integration with Pinchtab.
-func NewFromBridge(b *bridge.Bridge, tabID string) (autosolver.Page, autosolver.ActionExecutor, error) {
+func NewFromBridge(b bridge.BridgeAPI, tabID string) (autosolver.Page, autosolver.ActionExecutor, error) {
 	tabCtx, resolvedID, err := b.TabContext(tabID)
 	if err != nil {
 		return nil, nil, fmt.Errorf("resolve tab %q: %w", tabID, err)

--- a/internal/autosolver/autosolver.go
+++ b/internal/autosolver/autosolver.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
+	"sort"
 	"time"
 )
 
 // AutoSolver orchestrates the challenge-detection and solving pipeline.
-// It uses a fallback chain: built-in solvers → semantic engine → external
-// solvers → LLM provider, trying each layer before moving to the next.
+// It uses a fallback chain: semantic engine (/find + self-healing) ->
+// rule-based solvers -> external solvers -> LLM provider.
 type AutoSolver struct {
 	registry *Registry
 	semantic SemanticEngine
@@ -38,9 +40,10 @@ func (as *AutoSolver) Registry() *Registry {
 // Steps:
 //  1. Detect intent via semantic engine (or title-based heuristics)
 //  2. If no challenge detected, return immediately
-//  3. Try matching solvers in priority order
-//  4. If all fail and LLM is enabled, try LLM fallback
-//  5. Return result with full attempt history
+//  3. Try semantic-first action (/find + self-healing)
+//  4. If semantic fails, try matching solvers in priority order
+//  5. If all fail and LLM is enabled, try LLM fallback
+//  6. Return result with full attempt history
 func (as *AutoSolver) Solve(ctx context.Context, page Page, executor ActionExecutor) (*Result, error) {
 	start := time.Now()
 	result := &Result{
@@ -63,7 +66,7 @@ func (as *AutoSolver) Solve(ctx context.Context, page Page, executor ActionExecu
 	}
 	result.Intent = intent.Type
 
-	// No challenge — nothing to solve.
+	// No challenge - nothing to solve.
 	if intent.Type == IntentNormal {
 		result.Solved = true
 		result.TotalDuration = time.Since(start)
@@ -105,8 +108,32 @@ func (as *AutoSolver) Solve(ctx context.Context, page Page, executor ActionExecu
 			}
 		}
 
+		// Try semantic-first action before any rule-based solver.
+		solved, entry := as.trySemantic(ctx, page, executor, intent)
+		if entry != nil {
+			result.History = append(result.History, *entry)
+		}
+		if solved {
+			result.Solved = true
+			result.SolverUsed = entry.Solver
+			result.FinalTitle = page.Title()
+			result.FinalURL = page.URL()
+			result.TotalDuration = time.Since(start)
+			slog.Info("autosolver_success",
+				"solver", entry.Solver,
+				"attempts", result.Attempts,
+				"duration_ms", result.TotalDuration.Milliseconds(),
+				"url", page.URL())
+			slog.Info("autosolver_done",
+				"solved", true,
+				"solver", entry.Solver,
+				"attempts", result.Attempts,
+				"duration_ms", result.TotalDuration.Milliseconds())
+			return result, nil
+		}
+
 		// Try registered solvers in priority order.
-		solved, entry := as.trySolvers(ctx, page, executor)
+		solved, entry = as.trySolvers(ctx, page, executor)
 		if entry != nil {
 			result.History = append(result.History, *entry)
 		}
@@ -131,7 +158,7 @@ func (as *AutoSolver) Solve(ctx context.Context, page Page, executor ActionExecu
 
 		// Try LLM fallback if enabled and all solvers failed.
 		if as.config.LLMFallback && as.llm != nil {
-			solved, entry := as.tryLLM(ctx, page, executor, result.History)
+			solved, entry = as.tryLLM(ctx, page, executor, result.History)
 			if entry != nil {
 				result.History = append(result.History, *entry)
 			}
@@ -190,7 +217,44 @@ func (as *AutoSolver) trySolvers(ctx context.Context, page Page, executor Action
 		}
 	}
 
-	for _, s := range solvers {
+	orderedSolvers := solvers
+	if len(as.config.Solvers) > 0 {
+		byName := make(map[string]Solver, len(solvers))
+		for _, s := range solvers {
+			byName[s.Name()] = s
+		}
+
+		filtered := make([]Solver, 0, len(as.config.Solvers))
+		missing := make([]string, 0, len(as.config.Solvers))
+		for _, name := range as.config.Solvers {
+			if s, ok := byName[name]; ok {
+				filtered = append(filtered, s)
+				continue
+			}
+			missing = append(missing, name)
+		}
+
+		// If config names don't match available solvers, preserve default behavior.
+		if len(filtered) > 0 {
+			if len(missing) > 0 {
+				slog.Debug("autosolver: some configured solvers unavailable; using matched subset",
+					"configured", as.config.Solvers,
+					"missing", missing)
+			}
+			orderedSolvers = filtered
+		} else {
+			available := make([]string, 0, len(byName))
+			for name := range byName {
+				available = append(available, name)
+			}
+			sort.Strings(available)
+			slog.Debug("autosolver: configured solver order not found, using priority order",
+				"configured", as.config.Solvers,
+				"available", available)
+		}
+	}
+
+	for _, s := range orderedSolvers {
 		solverCtx, cancel := context.WithTimeout(ctx, as.config.SolverTimeout)
 		solverStart := time.Now()
 
@@ -231,10 +295,427 @@ func (as *AutoSolver) trySolvers(ctx context.Context, page Page, executor Action
 	}
 
 	return false, &AttemptEntry{
-		Solver: solvers[len(solvers)-1].Name(),
+		Solver: orderedSolvers[len(orderedSolvers)-1].Name(),
 		Status: StatusFailed,
 		Error:  "all matching solvers failed",
 	}
+}
+
+// trySemantic executes semantic /find-driven action planning first.
+// For high-level intents it runs a small multi-step semantic flow.
+func (as *AutoSolver) trySemantic(ctx context.Context, page Page, executor ActionExecutor, intent *Intent) (bool, *AttemptEntry) {
+	entry := &AttemptEntry{Solver: "semantic"}
+	semanticStart := time.Now()
+
+	if as.semantic == nil {
+		entry.Status = StatusSkipped
+		entry.Error = "semantic engine not configured"
+		entry.Duration = time.Since(semanticStart)
+		return false, entry
+	}
+
+	semanticCtx, cancel := context.WithTimeout(ctx, as.config.SolverTimeout)
+	defer cancel()
+
+	initialIntentType := intentTypeOf(intent)
+	stepBudget := semanticStepBudget(initialIntentType)
+	if stepBudget < 1 {
+		stepBudget = 1
+	}
+
+	currentIntent := intent
+	actionsExecuted := 0
+
+	for step := 0; step < stepBudget; step++ {
+		if step > 0 {
+			nextIntent, detectErr := as.detectIntent(semanticCtx, page)
+			if detectErr != nil {
+				slog.Debug("autosolver: semantic step intent refresh failed",
+					"step", step+1,
+					"error", detectErr)
+			} else {
+				currentIntent = nextIntent
+			}
+		}
+
+		if intentTypeOf(currentIntent) == IntentNormal {
+			entry.Status = StatusSolved
+			entry.Duration = time.Since(semanticStart)
+			return true, entry
+		}
+
+		suggested, err := as.semantic.SuggestAction(semanticCtx, page, currentIntent)
+		if err != nil {
+			entry.Status = StatusFailed
+			entry.Error = fmt.Sprintf("semantic suggest action: %v", err)
+			entry.Duration = time.Since(semanticStart)
+			return false, entry
+		}
+
+		planned := as.planSemanticAction(currentIntent, step, suggested)
+		action, err := as.prepareSemanticAction(semanticCtx, page, currentIntent, step, planned)
+		if err != nil {
+			slog.Debug("autosolver: semantic action preparation failed",
+				"step", step+1,
+				"intent", intentTypeOf(currentIntent),
+				"error", err)
+			entry.Status = StatusFailed
+			entry.Error = fmt.Sprintf("prepare semantic action: %v", err)
+			entry.Duration = time.Since(semanticStart)
+			return false, entry
+		}
+
+		if err := executeSuggestedAction(semanticCtx, executor, action); err != nil {
+			healedAction, healErr := as.selfHealSemanticAction(semanticCtx, page, currentIntent, step, action)
+			if healErr != nil {
+				entry.Status = StatusFailed
+				entry.Error = fmt.Sprintf("execute semantic action: %v; self-heal failed: %v", err, healErr)
+				entry.Duration = time.Since(semanticStart)
+				return false, entry
+			}
+
+			if err := executeSuggestedAction(semanticCtx, executor, healedAction); err != nil {
+				entry.Status = StatusFailed
+				entry.Error = fmt.Sprintf("execute semantic self-heal action: %v", err)
+				entry.Duration = time.Since(semanticStart)
+				return false, entry
+			}
+		}
+
+		actionsExecuted++
+
+		postIntent, detectErr := as.detectIntent(semanticCtx, page)
+		if detectErr != nil {
+			slog.Debug("autosolver: semantic post-step intent detection failed",
+				"step", step+1,
+				"error", detectErr)
+		} else {
+			currentIntent = postIntent
+			if currentIntent.Type == IntentNormal {
+				entry.Status = StatusSolved
+				entry.Duration = time.Since(semanticStart)
+				return true, entry
+			}
+		}
+	}
+
+	if isHighLevelIntent(initialIntentType) && actionsExecuted > 0 {
+		entry.Status = StatusSolved
+		entry.Duration = time.Since(semanticStart)
+		return true, entry
+	}
+
+	entry.Status = StatusFailed
+	entry.Error = fmt.Sprintf("semantic flow exhausted for intent %q", initialIntentType)
+	entry.Duration = time.Since(semanticStart)
+	return false, entry
+}
+
+type semanticFlowStep struct {
+	Query   string
+	Action  ActionType
+	EnvKeys []string
+}
+
+func (as *AutoSolver) planSemanticAction(intent *Intent, step int, suggested *SuggestedAction) *SuggestedAction {
+	planned := &SuggestedAction{Action: ActionNone}
+	if suggested != nil {
+		copy := *suggested
+		planned = &copy
+	}
+
+	intentType := intentTypeOf(intent)
+	flowStep := semanticFlowStepForIntent(intentType, step)
+
+	if planned.Action == ActionNone || isHighLevelIntent(intentType) {
+		planned.Action = flowStep.Action
+	}
+
+	if planned.Text == "" && planned.Action == ActionType_ {
+		planned.Text = firstNonEmptyEnv(flowStep.EnvKeys...)
+	}
+
+	if planned.Reason == "" {
+		planned.Reason = fmt.Sprintf("semantic flow step %d", step+1)
+	}
+
+	return planned
+}
+
+func (as *AutoSolver) prepareSemanticAction(ctx context.Context, page Page, intent *Intent, step int, action *SuggestedAction) (*SuggestedAction, error) {
+	if action == nil {
+		return nil, fmt.Errorf("nil action")
+	}
+
+	resolved := *action
+	flowStep := semanticFlowStepForIntent(intentTypeOf(intent), step)
+
+	shouldResolveTarget := isHighLevelIntent(intentTypeOf(intent)) || actionNeedsTarget(&resolved)
+	if shouldResolveTarget {
+		match, err := as.semantic.FindElement(ctx, page, flowStep.Query)
+		if err != nil {
+			return nil, fmt.Errorf("semantic find element query %q: %w", flowStep.Query, err)
+		}
+		if match != nil {
+			if match.Selector != "" {
+				resolved.Selector = match.Selector
+			} else if match.Ref != "" {
+				resolved.Selector = match.Ref
+			}
+			if match.X != 0 || match.Y != 0 {
+				resolved.X = match.X
+				resolved.Y = match.Y
+			}
+		} else if actionNeedsTarget(&resolved) {
+			return nil, fmt.Errorf("semantic find returned no match for query %q", flowStep.Query)
+		}
+	}
+
+	if resolved.Action == ActionType_ && resolved.Text == "" {
+		resolved.Text = firstNonEmptyEnv(flowStep.EnvKeys...)
+		if resolved.Text == "" {
+			resolved.Action = ActionClick
+		}
+	}
+
+	if resolved.Action == ActionClick && resolved.Selector == "" && resolved.X == 0 && resolved.Y == 0 {
+		return nil, fmt.Errorf("semantic action requires selector or coordinates for query %q", flowStep.Query)
+	}
+
+	return &resolved, nil
+}
+
+func (as *AutoSolver) selfHealSemanticAction(ctx context.Context, page Page, intent *Intent, step int, original *SuggestedAction) (*SuggestedAction, error) {
+	if original == nil {
+		return nil, fmt.Errorf("nil action")
+	}
+
+	flowStep := semanticFlowStepForIntent(intentTypeOf(intent), step)
+	match, err := as.semantic.FindElement(ctx, page, flowStep.Query)
+	if err != nil {
+		return nil, fmt.Errorf("semantic self-heal find query %q: %w", flowStep.Query, err)
+	}
+	if match == nil {
+		return nil, fmt.Errorf("semantic self-heal returned no match for query %q", flowStep.Query)
+	}
+
+	healed := *original
+	if match.Selector != "" {
+		healed.Selector = match.Selector
+	} else if match.Ref != "" {
+		healed.Selector = match.Ref
+	}
+	if match.X != 0 || match.Y != 0 {
+		healed.X = match.X
+		healed.Y = match.Y
+	}
+
+	if healed.Action == ActionType_ && healed.Text == "" {
+		healed.Text = firstNonEmptyEnv(flowStep.EnvKeys...)
+		if healed.Text == "" {
+			healed.Action = ActionClick
+		}
+	}
+
+	if healed.Action == ActionClick && healed.Selector == "" && healed.X == 0 && healed.Y == 0 {
+		return nil, fmt.Errorf("semantic self-heal match for query %q had no actionable selector or coordinates", flowStep.Query)
+	}
+
+	return &healed, nil
+}
+
+func intentTypeOf(intent *Intent) IntentType {
+	if intent == nil {
+		return IntentUnknown
+	}
+	return intent.Type
+}
+
+func isHighLevelIntent(intentType IntentType) bool {
+	switch intentType {
+	case IntentLogin, IntentSignup, IntentForm, IntentOnboarding, IntentNavigation:
+		return true
+	default:
+		return false
+	}
+}
+
+func semanticStepBudget(intentType IntentType) int {
+	switch intentType {
+	case IntentLogin:
+		return 3
+	case IntentSignup:
+		return 4
+	case IntentForm:
+		return 3
+	case IntentOnboarding, IntentNavigation:
+		return 3
+	case IntentCaptcha, IntentBlocked:
+		return 2
+	default:
+		return 1
+	}
+}
+
+func semanticFlowStepForIntent(intentType IntentType, step int) semanticFlowStep {
+	steps := []semanticFlowStep{{Query: "primary continue submit button", Action: ActionClick}}
+
+	switch intentType {
+	case IntentCaptcha:
+		steps = []semanticFlowStep{
+			{Query: "captcha checkbox verify button challenge widget", Action: ActionClick},
+			{Query: "verification challenge status text", Action: ActionWait},
+		}
+	case IntentBlocked:
+		steps = []semanticFlowStep{
+			{Query: "verify continue button", Action: ActionClick},
+			{Query: "body", Action: ActionWait},
+		}
+	case IntentLogin:
+		steps = []semanticFlowStep{
+			{Query: "username email input field", Action: ActionType_, EnvKeys: []string{"PINCHTAB_AUTOSOLVER_LOGIN_USER", "PINCHTAB_AUTOSOLVER_LOGIN_EMAIL"}},
+			{Query: "password input field", Action: ActionType_, EnvKeys: []string{"PINCHTAB_AUTOSOLVER_LOGIN_PASS", "PINCHTAB_AUTOSOLVER_LOGIN_PASSWORD"}},
+			{Query: "login submit sign in button", Action: ActionClick},
+		}
+	case IntentSignup:
+		steps = []semanticFlowStep{
+			{Query: "name full name input field", Action: ActionType_, EnvKeys: []string{"PINCHTAB_AUTOSOLVER_SIGNUP_NAME"}},
+			{Query: "email input field", Action: ActionType_, EnvKeys: []string{"PINCHTAB_AUTOSOLVER_SIGNUP_EMAIL"}},
+			{Query: "password create password input field", Action: ActionType_, EnvKeys: []string{"PINCHTAB_AUTOSOLVER_SIGNUP_PASSWORD"}},
+			{Query: "sign up register create account submit button", Action: ActionClick},
+		}
+	case IntentForm:
+		steps = []semanticFlowStep{
+			{Query: "first required input field", Action: ActionType_, EnvKeys: []string{"PINCHTAB_AUTOSOLVER_FORM_FIELD1"}},
+			{Query: "second required input field", Action: ActionType_, EnvKeys: []string{"PINCHTAB_AUTOSOLVER_FORM_FIELD2", "PINCHTAB_AUTOSOLVER_FORM_EMAIL"}},
+			{Query: "primary submit button", Action: ActionClick},
+		}
+	case IntentOnboarding:
+		steps = []semanticFlowStep{
+			{Query: "next continue button", Action: ActionClick},
+			{Query: "skip button", Action: ActionClick},
+			{Query: "done finish submit button", Action: ActionClick},
+		}
+	case IntentNavigation:
+		steps = []semanticFlowStep{
+			{Query: "primary navigation link", Action: ActionClick},
+			{Query: "continue next button", Action: ActionClick},
+			{Query: "submit confirm button", Action: ActionClick},
+		}
+	}
+
+	if step < 0 {
+		step = 0
+	}
+	if step >= len(steps) {
+		step = len(steps) - 1
+	}
+
+	return steps[step]
+}
+
+func firstNonEmptyEnv(keys ...string) string {
+	for _, key := range keys {
+		if v := os.Getenv(key); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func actionNeedsTarget(action *SuggestedAction) bool {
+	if action == nil {
+		return false
+	}
+
+	switch action.Action {
+	case ActionClick:
+		return action.Selector == "" && action.X == 0 && action.Y == 0
+	case ActionType_:
+		return action.Selector == "" && action.X == 0 && action.Y == 0
+	default:
+		return false
+	}
+}
+
+func executeSuggestedAction(ctx context.Context, executor ActionExecutor, action *SuggestedAction) error {
+	if action == nil {
+		return fmt.Errorf("nil action")
+	}
+
+	switch action.Action {
+	case ActionClick:
+		if action.Selector != "" {
+			x, y, err := resolveSelectorCenter(ctx, executor, action.Selector)
+			if err != nil {
+				return err
+			}
+			return executor.Click(ctx, x, y)
+		}
+		if action.X != 0 || action.Y != 0 {
+			return executor.Click(ctx, action.X, action.Y)
+		}
+		return fmt.Errorf("click action requires selector or coordinates")
+
+	case ActionType_:
+		if action.Selector != "" {
+			x, y, err := resolveSelectorCenter(ctx, executor, action.Selector)
+			if err != nil {
+				return err
+			}
+			if err := executor.Click(ctx, x, y); err != nil {
+				return err
+			}
+		} else if action.X != 0 || action.Y != 0 {
+			if err := executor.Click(ctx, action.X, action.Y); err != nil {
+				return err
+			}
+		}
+		return executor.Type(ctx, action.Text)
+
+	case ActionNavigate:
+		return executor.Navigate(ctx, action.URL)
+
+	case ActionWait:
+		selector := action.Selector
+		if selector == "" {
+			selector = "body"
+		}
+		return executor.WaitFor(ctx, selector, 5*time.Second)
+
+	case ActionEvaluate:
+		if action.Expr == "" {
+			return fmt.Errorf("evaluate action requires expr")
+		}
+		var out interface{}
+		return executor.Evaluate(ctx, action.Expr, &out)
+
+	case ActionNone:
+		return nil
+
+	default:
+		return fmt.Errorf("unsupported action: %s", action.Action)
+	}
+}
+
+func resolveSelectorCenter(ctx context.Context, executor ActionExecutor, selector string) (float64, float64, error) {
+	var coords struct {
+		X float64 `json:"x"`
+		Y float64 `json:"y"`
+	}
+
+	expr := fmt.Sprintf(`(() => {
+		const el = document.querySelector(%q);
+		if (!el) return null;
+		const r = el.getBoundingClientRect();
+		return {x: r.x + r.width/2, y: r.y + r.height/2};
+	})()`, selector)
+
+	if err := executor.Evaluate(ctx, expr, &coords); err != nil {
+		return 0, 0, fmt.Errorf("resolve selector %q: %w", selector, err)
+	}
+
+	return coords.X, coords.Y, nil
 }
 
 // tryLLM builds a trimmed request and asks the LLM for the next action.
@@ -291,21 +772,11 @@ func executeAction(ctx context.Context, executor ActionExecutor, resp *LLMRespon
 	switch resp.Action {
 	case ActionClick:
 		if resp.Selector != "" {
-			// Resolve selector to coordinates via evaluate.
-			var coords struct {
-				X float64 `json:"x"`
-				Y float64 `json:"y"`
+			x, y, err := resolveSelectorCenter(ctx, executor, resp.Selector)
+			if err != nil {
+				return err
 			}
-			expr := fmt.Sprintf(`(() => {
-				const el = document.querySelector(%q);
-				if (!el) return null;
-				const r = el.getBoundingClientRect();
-				return {x: r.x + r.width/2, y: r.y + r.height/2};
-			})()`, resp.Selector)
-			if err := executor.Evaluate(ctx, expr, &coords); err != nil {
-				return fmt.Errorf("resolve selector %q: %w", resp.Selector, err)
-			}
-			return executor.Click(ctx, coords.X, coords.Y)
+			return executor.Click(ctx, x, y)
 		}
 		return fmt.Errorf("click action requires selector")
 

--- a/internal/autosolver/autosolver_test.go
+++ b/internal/autosolver/autosolver_test.go
@@ -24,6 +24,9 @@ type mockExecutor struct {
 	clickCalled    int
 	typeCalled     int
 	navigateCalled int
+	evaluateCalled int
+	waitCalled     int
+	evaluateErr    error
 }
 
 func (m *mockExecutor) Click(_ context.Context, _, _ float64) error {
@@ -34,19 +37,26 @@ func (m *mockExecutor) Type(_ context.Context, _ string) error {
 	m.typeCalled++
 	return nil
 }
-func (m *mockExecutor) WaitFor(_ context.Context, _ string, _ time.Duration) error { return nil }
-func (m *mockExecutor) Evaluate(_ context.Context, _ string, _ interface{}) error  { return nil }
+func (m *mockExecutor) WaitFor(_ context.Context, _ string, _ time.Duration) error {
+	m.waitCalled++
+	return nil
+}
+func (m *mockExecutor) Evaluate(_ context.Context, _ string, _ interface{}) error {
+	m.evaluateCalled++
+	return m.evaluateErr
+}
 func (m *mockExecutor) Navigate(_ context.Context, _ string) error {
 	m.navigateCalled++
 	return nil
 }
 
 type mockSolver struct {
-	name      string
-	priority  int
-	canHandle bool
-	solved    bool
-	err       error
+	name       string
+	priority   int
+	canHandle  bool
+	solved     bool
+	err        error
+	solveCalls int
 }
 
 func (m *mockSolver) Name() string  { return m.name }
@@ -55,6 +65,7 @@ func (m *mockSolver) CanHandle(_ context.Context, _ Page) (bool, error) {
 	return m.canHandle, nil
 }
 func (m *mockSolver) Solve(_ context.Context, _ Page, _ ActionExecutor) (*Result, error) {
+	m.solveCalls++
 	if m.err != nil {
 		return &Result{Error: m.err.Error()}, m.err
 	}
@@ -62,18 +73,55 @@ func (m *mockSolver) Solve(_ context.Context, _ Page, _ ActionExecutor) (*Result
 }
 
 type mockSemantic struct {
-	intent *Intent
-	err    error
+	intent       *Intent
+	err          error
+	detectSeq    []*Intent
+	detectCalls  int
+	findMatch    *ElementMatch
+	findSeq      []*ElementMatch
+	findErr      error
+	action       *SuggestedAction
+	actionSeq    []*SuggestedAction
+	actionErr    error
+	findCalls    int
+	findQueries  []string
+	suggestCalls int
 }
 
 func (m *mockSemantic) DetectIntent(_ context.Context, _ Page) (*Intent, error) {
+	if len(m.detectSeq) > 0 {
+		idx := m.detectCalls
+		if idx >= len(m.detectSeq) {
+			idx = len(m.detectSeq) - 1
+		}
+		m.detectCalls++
+		return m.detectSeq[idx], m.err
+	}
+	m.detectCalls++
 	return m.intent, m.err
 }
-func (m *mockSemantic) FindElement(_ context.Context, _ Page, _ string) (*ElementMatch, error) {
-	return nil, nil
+func (m *mockSemantic) FindElement(_ context.Context, _ Page, query string) (*ElementMatch, error) {
+	m.findCalls++
+	m.findQueries = append(m.findQueries, query)
+	if len(m.findSeq) > 0 {
+		idx := m.findCalls - 1
+		if idx >= len(m.findSeq) {
+			idx = len(m.findSeq) - 1
+		}
+		return m.findSeq[idx], m.findErr
+	}
+	return m.findMatch, m.findErr
 }
 func (m *mockSemantic) SuggestAction(_ context.Context, _ Page, _ *Intent) (*SuggestedAction, error) {
-	return nil, nil
+	m.suggestCalls++
+	if len(m.actionSeq) > 0 {
+		idx := m.suggestCalls - 1
+		if idx >= len(m.actionSeq) {
+			idx = len(m.actionSeq) - 1
+		}
+		return m.actionSeq[idx], m.actionErr
+	}
+	return m.action, m.actionErr
 }
 
 type mockLLM struct {
@@ -144,6 +192,245 @@ func TestSolve_SemanticDetection(t *testing.T) {
 	}
 	if result.Intent != IntentCaptcha {
 		t.Errorf("expected intent Captcha, got %s", result.Intent)
+	}
+}
+
+func TestSolve_SemanticFirst_SuccessSkipsRuleSolvers(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.MaxAttempts = 1
+
+	semantic := &mockSemantic{
+		detectSeq: []*Intent{
+			{Type: IntentCaptcha, Confidence: 0.9},
+			{Type: IntentNormal, Confidence: 0.9},
+		},
+		action: &SuggestedAction{
+			Action:   ActionClick,
+			Selector: "#verify-button",
+		},
+	}
+
+	solver := &mockSolver{
+		name:      "rule-solver",
+		priority:  10,
+		canHandle: true,
+		solved:    true,
+	}
+
+	as := New(cfg, semantic, nil)
+	as.Registry().MustRegister(solver)
+
+	page := &mockPage{title: "Challenge Page", url: "https://example.com"}
+	executor := &mockExecutor{}
+
+	result, err := as.Solve(context.Background(), page, executor)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Solved {
+		t.Error("expected Solved=true")
+	}
+	if result.SolverUsed != "semantic" {
+		t.Errorf("expected solver 'semantic', got %q", result.SolverUsed)
+	}
+	if solver.solveCalls != 0 {
+		t.Errorf("expected rule solver not to run, got %d calls", solver.solveCalls)
+	}
+	if semantic.suggestCalls == 0 {
+		t.Error("expected semantic SuggestAction to be called")
+	}
+}
+
+func TestSolve_SemanticFirst_FailureFallsBackToRuleSolvers(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.MaxAttempts = 1
+
+	semantic := &mockSemantic{
+		detectSeq: []*Intent{
+			{Type: IntentCaptcha, Confidence: 0.9},
+			{Type: IntentCaptcha, Confidence: 0.8},
+		},
+		action: &SuggestedAction{
+			Action:   ActionClick,
+			Selector: "#verify-button",
+		},
+	}
+
+	solver := &mockSolver{
+		name:      "rule-solver",
+		priority:  10,
+		canHandle: true,
+		solved:    true,
+	}
+
+	as := New(cfg, semantic, nil)
+	as.Registry().MustRegister(solver)
+
+	page := &mockPage{title: "Challenge Page", url: "https://example.com"}
+	executor := &mockExecutor{}
+
+	result, err := as.Solve(context.Background(), page, executor)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Solved {
+		t.Error("expected Solved=true via rule solver fallback")
+	}
+	if result.SolverUsed != "rule-solver" {
+		t.Errorf("expected solver 'rule-solver', got %q", result.SolverUsed)
+	}
+	if solver.solveCalls == 0 {
+		t.Error("expected rule solver to run after semantic failure")
+	}
+	if len(result.History) == 0 {
+		t.Fatal("expected non-empty attempt history")
+	}
+	if result.History[0].Solver != "semantic" {
+		t.Errorf("expected first attempt to be semantic, got %q", result.History[0].Solver)
+	}
+	if result.History[0].Status != StatusFailed {
+		t.Errorf("expected semantic attempt to fail before fallback, got %q", result.History[0].Status)
+	}
+}
+
+func TestSolve_SemanticHighLevel_LoginFlow(t *testing.T) {
+	t.Setenv("PINCHTAB_AUTOSOLVER_LOGIN_USER", "user@example.com")
+	t.Setenv("PINCHTAB_AUTOSOLVER_LOGIN_PASSWORD", "secret")
+
+	cfg := DefaultConfig()
+	cfg.MaxAttempts = 1
+
+	semantic := &mockSemantic{
+		detectSeq: []*Intent{
+			{Type: IntentLogin, Confidence: 0.9},
+			{Type: IntentLogin, Confidence: 0.9},
+			{Type: IntentLogin, Confidence: 0.9},
+			{Type: IntentLogin, Confidence: 0.9},
+		},
+		findMatch: &ElementMatch{Selector: "#login-field"},
+	}
+
+	solver := &mockSolver{
+		name:      "rule-solver",
+		priority:  10,
+		canHandle: true,
+		solved:    true,
+	}
+
+	as := New(cfg, semantic, nil)
+	as.Registry().MustRegister(solver)
+
+	page := &mockPage{title: "Sign in", url: "https://example.com/login"}
+	executor := &mockExecutor{}
+
+	result, err := as.Solve(context.Background(), page, executor)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Solved {
+		t.Error("expected Solved=true")
+	}
+	if result.SolverUsed != "semantic" {
+		t.Errorf("expected solver 'semantic', got %q", result.SolverUsed)
+	}
+	if solver.solveCalls != 0 {
+		t.Errorf("expected rule solver not to run, got %d calls", solver.solveCalls)
+	}
+	if semantic.findCalls < 3 {
+		t.Errorf("expected semantic /find to run on multiple flow steps, got %d calls", semantic.findCalls)
+	}
+	if executor.typeCalled < 2 {
+		t.Errorf("expected form-filling type actions, got %d", executor.typeCalled)
+	}
+}
+
+func TestSolve_SemanticHighLevel_LoginFallbackWhenFindFails(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.MaxAttempts = 1
+
+	semantic := &mockSemantic{
+		detectSeq: []*Intent{{Type: IntentLogin, Confidence: 0.9}},
+		findMatch: nil,
+	}
+
+	solver := &mockSolver{
+		name:      "rule-solver",
+		priority:  10,
+		canHandle: true,
+		solved:    true,
+	}
+
+	as := New(cfg, semantic, nil)
+	as.Registry().MustRegister(solver)
+
+	page := &mockPage{title: "Sign in", url: "https://example.com/login"}
+	executor := &mockExecutor{}
+
+	result, err := as.Solve(context.Background(), page, executor)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Solved {
+		t.Error("expected Solved=true via rule solver fallback")
+	}
+	if result.SolverUsed != "rule-solver" {
+		t.Errorf("expected solver 'rule-solver', got %q", result.SolverUsed)
+	}
+	if semantic.findCalls == 0 {
+		t.Error("expected semantic /find attempt before fallback")
+	}
+	if len(result.History) == 0 {
+		t.Fatal("expected non-empty attempt history")
+	}
+	if result.History[0].Solver != "semantic" {
+		t.Errorf("expected first history entry to be semantic, got %q", result.History[0].Solver)
+	}
+}
+
+func TestSolve_SemanticSelfHealFailureFallsBackToRuleSolvers(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.MaxAttempts = 1
+
+	semantic := &mockSemantic{
+		detectSeq: []*Intent{{Type: IntentCaptcha, Confidence: 0.9}},
+		action: &SuggestedAction{
+			Action:   ActionClick,
+			Selector: "#verify",
+		},
+		findMatch: &ElementMatch{Selector: "#verify"},
+	}
+
+	solver := &mockSolver{
+		name:      "rule-solver",
+		priority:  10,
+		canHandle: true,
+		solved:    true,
+	}
+
+	as := New(cfg, semantic, nil)
+	as.Registry().MustRegister(solver)
+
+	page := &mockPage{title: "Challenge Page", url: "https://example.com"}
+	executor := &mockExecutor{evaluateErr: fmt.Errorf("selector lookup failed")}
+
+	result, err := as.Solve(context.Background(), page, executor)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Solved {
+		t.Error("expected solve success via rule solver fallback")
+	}
+	if result.SolverUsed != "rule-solver" {
+		t.Errorf("expected solver 'rule-solver', got %q", result.SolverUsed)
+	}
+	if len(result.History) == 0 || result.History[0].Solver != "semantic" {
+		t.Fatalf("expected semantic attempt in history, got %+v", result.History)
+	}
+	if result.History[0].Status != StatusFailed {
+		t.Fatalf("expected semantic attempt to fail, got %q", result.History[0].Status)
+	}
+	if solver.solveCalls == 0 {
+		t.Fatal("expected rule solver to run after semantic self-heal failure")
 	}
 }
 
@@ -328,11 +615,94 @@ func TestSolve_PriorityOrdering(t *testing.T) {
 	}
 }
 
+func TestSolve_UsesConfiguredSolverOrder(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.MaxAttempts = 1
+	cfg.RetryBaseDelay = time.Millisecond
+	cfg.Solvers = []string{"third", "first", "second"}
+
+	var solveOrder []string
+	makeSolver := func(name string, priority int, solved bool) Solver {
+		return &trackingSolver{
+			name:      name,
+			priority:  priority,
+			canHandle: true,
+			solved:    solved,
+			order:     &solveOrder,
+		}
+	}
+
+	as := New(cfg, nil, nil)
+	as.Registry().MustRegister(makeSolver("first", 10, false))
+	as.Registry().MustRegister(makeSolver("second", 20, false))
+	as.Registry().MustRegister(makeSolver("third", 30, true))
+
+	page := &mockPage{title: "Just a moment...", url: "https://example.com"}
+	executor := &mockExecutor{}
+
+	result, err := as.Solve(context.Background(), page, executor)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Solved {
+		t.Fatal("expected solve success from configured first solver")
+	}
+	if result.SolverUsed != "third" {
+		t.Fatalf("expected solver 'third', got %q", result.SolverUsed)
+	}
+	if len(solveOrder) != 1 {
+		t.Fatalf("expected exactly one solver call, got %d (%v)", len(solveOrder), solveOrder)
+	}
+	if solveOrder[0] != "third" {
+		t.Fatalf("expected configured solver order to try 'third' first, got %q", solveOrder[0])
+	}
+}
+
+func TestSolve_ConfiguredSolverOrderFallbackWhenNoConfiguredNamesMatch(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.MaxAttempts = 1
+	cfg.RetryBaseDelay = time.Millisecond
+	cfg.Solvers = []string{"missing-one", "missing-two"}
+
+	var solveOrder []string
+	makeSolver := func(name string, priority int, solved bool) Solver {
+		return &trackingSolver{
+			name:      name,
+			priority:  priority,
+			canHandle: true,
+			solved:    solved,
+			order:     &solveOrder,
+		}
+	}
+
+	as := New(cfg, nil, nil)
+	as.Registry().MustRegister(makeSolver("first", 10, true))
+	as.Registry().MustRegister(makeSolver("second", 20, false))
+
+	page := &mockPage{title: "Just a moment...", url: "https://example.com"}
+	executor := &mockExecutor{}
+
+	result, err := as.Solve(context.Background(), page, executor)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Solved {
+		t.Fatal("expected solve success from priority-order fallback")
+	}
+	if len(solveOrder) != 1 {
+		t.Fatalf("expected one solver attempt, got %d (%v)", len(solveOrder), solveOrder)
+	}
+	if solveOrder[0] != "first" {
+		t.Fatalf("expected fallback to priority order starting with 'first', got %q", solveOrder[0])
+	}
+}
+
 // trackingSolver records the order in which Solve is called.
 type trackingSolver struct {
 	name      string
 	priority  int
 	canHandle bool
+	solved    bool
 	order     *[]string
 }
 
@@ -343,5 +713,5 @@ func (s *trackingSolver) CanHandle(_ context.Context, _ Page) (bool, error) {
 }
 func (s *trackingSolver) Solve(_ context.Context, _ Page, _ ActionExecutor) (*Result, error) {
 	*s.order = append(*s.order, s.name)
-	return &Result{Solved: false}, nil
+	return &Result{Solved: s.solved}, nil
 }

--- a/internal/autosolver/challenge_detection.go
+++ b/internal/autosolver/challenge_detection.go
@@ -1,0 +1,165 @@
+package autosolver
+
+import "strings"
+
+// DetectChallengeIntent classifies known challenge pages using title, URL,
+// and HTML markers. It returns nil when no challenge signal is found.
+func DetectChallengeIntent(title, url, html string) *Intent {
+	lowerTitle := strings.ToLower(title)
+	lowerURL := strings.ToLower(url)
+	lowerHTML := strings.ToLower(html)
+	v3 := isRecaptchaV3Challenge(lowerURL, lowerHTML)
+
+	if isTurnstileChallenge(lowerTitle, lowerURL, lowerHTML) {
+		return &Intent{
+			Type:          IntentCaptcha,
+			Confidence:    0.95,
+			ChallengeType: "turnstile",
+			Details:       "cloudflare turnstile challenge detected",
+		}
+	}
+
+	if v3 {
+		return &Intent{
+			Type:          IntentCaptcha,
+			Confidence:    0.9,
+			ChallengeType: "recaptcha-v3",
+			Details:       "reCAPTCHA v3 challenge detected",
+		}
+	}
+
+	if !v3 && isRecaptchaV2Challenge(lowerURL, lowerHTML) {
+		return &Intent{
+			Type:          IntentCaptcha,
+			Confidence:    0.9,
+			ChallengeType: "recaptcha-v2",
+			Details:       "reCAPTCHA v2 challenge detected",
+		}
+	}
+
+	if isHCaptchaChallenge(lowerURL, lowerHTML) {
+		return &Intent{
+			Type:          IntentCaptcha,
+			Confidence:    0.9,
+			ChallengeType: "hcaptcha",
+			Details:       "hCaptcha challenge detected",
+		}
+	}
+
+	if isCustomJSChallenge(lowerTitle, lowerURL, lowerHTML) {
+		return &Intent{
+			Type:          IntentBlocked,
+			Confidence:    0.85,
+			ChallengeType: "custom-js",
+			Details:       "custom JavaScript anti-bot challenge detected",
+		}
+	}
+
+	if containsAny(lowerTitle, "captcha", "verify you are human", "i am not a robot") ||
+		containsAny(lowerURL, "captcha", "recaptcha", "hcaptcha", "turnstile") ||
+		containsAny(lowerHTML, "captcha", "verify you are human", "i am not a robot") {
+		return &Intent{
+			Type:          IntentCaptcha,
+			Confidence:    0.7,
+			ChallengeType: "captcha-generic",
+			Details:       "generic captcha challenge detected",
+		}
+	}
+
+	return nil
+}
+
+func isTurnstileChallenge(title, url, html string) bool {
+	return containsAny(title,
+		"just a moment",
+		"attention required",
+		"checking your browser",
+	) || containsAny(url,
+		"cdn-cgi/challenge-platform",
+		"/cdn-cgi/challenge",
+	) || containsAny(html,
+		"challenges.cloudflare.com/turnstile",
+		"cf-turnstile",
+		"turnstile.render(",
+	)
+}
+
+func isRecaptchaV3Challenge(url, html string) bool {
+	return containsAny(html,
+		"grecaptcha.execute(",
+		"grecaptcha.enterprise.execute(",
+		"recaptcha/api.js?render=",
+		"recaptcha/enterprise.js?render=",
+	)
+}
+
+func isRecaptchaV2Challenge(url, html string) bool {
+	return containsAny(url,
+		"recaptcha",
+		"google.com/recaptcha",
+	) || containsAny(html,
+		"g-recaptcha",
+		"recaptcha-checkbox",
+		"api2/anchor",
+		"google.com/recaptcha/api.js",
+	)
+}
+
+func isHCaptchaChallenge(url, html string) bool {
+	return containsAny(url,
+		"hcaptcha",
+	) || containsAny(html,
+		"hcaptcha.com/1/api.js",
+		"h-captcha",
+		"hcaptcha",
+	)
+}
+
+func isCustomJSChallenge(title, url, html string) bool {
+	titleSignal := containsAny(title,
+		"please enable javascript",
+		"browser integrity check",
+		"access denied",
+		"forbidden",
+		"blocked",
+	)
+	urlSignal := containsAny(url,
+		"challenge",
+		"bot",
+		"verify",
+	)
+	htmlSignal := containsAny(html,
+		"__cf_chl",
+		"window._cf_chl_opt",
+		"challenge-form",
+		"jschl",
+		"bot challenge",
+		"anti-bot",
+		"anti bot",
+		"please enable javascript",
+		"checking your browser before accessing",
+		"browser integrity check",
+		"navigator.webdriver",
+	)
+
+	// Primary signal comes from HTML markers.
+	if htmlSignal {
+		return true
+	}
+
+	// Fallback when HTML cannot be read.
+	if html == "" && titleSignal && urlSignal {
+		return true
+	}
+
+	return false
+}
+
+func containsAny(haystack string, needles ...string) bool {
+	for _, needle := range needles {
+		if strings.Contains(haystack, needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/autosolver/challenge_detection_test.go
+++ b/internal/autosolver/challenge_detection_test.go
@@ -1,0 +1,93 @@
+package autosolver
+
+import "testing"
+
+func TestDetectChallengeIntent_Turnstile(t *testing.T) {
+	intent := DetectChallengeIntent(
+		"Just a moment...",
+		"https://example.com/cdn-cgi/challenge-platform/h/b/orchestrate/chl_page/v1",
+		`<script src="https://challenges.cloudflare.com/turnstile/v0/api.js"></script>`,
+	)
+	if intent == nil {
+		t.Fatal("expected challenge intent")
+	}
+	if intent.Type != IntentCaptcha {
+		t.Fatalf("expected captcha intent, got %q", intent.Type)
+	}
+	if intent.ChallengeType != "turnstile" {
+		t.Fatalf("expected turnstile challenge type, got %q", intent.ChallengeType)
+	}
+}
+
+func TestDetectChallengeIntent_RecaptchaV2(t *testing.T) {
+	intent := DetectChallengeIntent(
+		"Verify",
+		"https://example.com/login",
+		`<div class="g-recaptcha" data-sitekey="abc"></div>
+		 <script src="https://www.google.com/recaptcha/api.js"></script>`,
+	)
+	if intent == nil {
+		t.Fatal("expected challenge intent")
+	}
+	if intent.ChallengeType != "recaptcha-v2" {
+		t.Fatalf("expected recaptcha-v2 challenge type, got %q", intent.ChallengeType)
+	}
+}
+
+func TestDetectChallengeIntent_RecaptchaV3(t *testing.T) {
+	intent := DetectChallengeIntent(
+		"Welcome",
+		"https://example.com/secure",
+		`<script src="https://www.google.com/recaptcha/api.js?render=site_key"></script>
+		 <script>grecaptcha.execute('site_key', {action: 'login'})</script>`,
+	)
+	if intent == nil {
+		t.Fatal("expected challenge intent")
+	}
+	if intent.ChallengeType != "recaptcha-v3" {
+		t.Fatalf("expected recaptcha-v3 challenge type, got %q", intent.ChallengeType)
+	}
+}
+
+func TestDetectChallengeIntent_HCaptcha(t *testing.T) {
+	intent := DetectChallengeIntent(
+		"Verify",
+		"https://example.com/verify",
+		`<div class="h-captcha" data-sitekey="abc"></div>
+		 <script src="https://hcaptcha.com/1/api.js" async defer></script>`,
+	)
+	if intent == nil {
+		t.Fatal("expected challenge intent")
+	}
+	if intent.ChallengeType != "hcaptcha" {
+		t.Fatalf("expected hcaptcha challenge type, got %q", intent.ChallengeType)
+	}
+}
+
+func TestDetectChallengeIntent_CustomJS(t *testing.T) {
+	intent := DetectChallengeIntent(
+		"Browser Integrity Check",
+		"https://example.com/challenge",
+		`<html><body><script>window._cf_chl_opt = {};</script><div>Please enable JavaScript</div></body></html>`,
+	)
+	if intent == nil {
+		t.Fatal("expected challenge intent")
+	}
+	if intent.ChallengeType != "custom-js" {
+		t.Fatalf("expected custom-js challenge type, got %q", intent.ChallengeType)
+	}
+	if intent.Type != IntentBlocked {
+		t.Fatalf("expected blocked intent for custom-js, got %q", intent.Type)
+	}
+}
+
+func TestDetectChallengeIntent_None(t *testing.T) {
+	intent := DetectChallengeIntent(
+		"Example Domain",
+		"https://example.com",
+		`<html><body><h1>Example Domain</h1></body></html>`,
+	)
+	if intent != nil {
+		t.Fatalf("expected nil intent, got %+v", intent)
+	}
+}

--- a/internal/autosolver/heuristics.go
+++ b/internal/autosolver/heuristics.go
@@ -7,6 +7,9 @@ import "strings"
 // well-known page-title patterns to classify the page.
 func detectIntentByTitle(title string) *Intent {
 	lower := strings.ToLower(title)
+	if challenge := DetectChallengeIntent(title, "", ""); challenge != nil {
+		return challenge
+	}
 
 	// Cloudflare challenge patterns
 	cfPatterns := []string{"just a moment", "attention required", "checking your browser"}
@@ -53,6 +56,42 @@ func detectIntentByTitle(title string) *Intent {
 				Type:       IntentSignup,
 				Confidence: 0.6,
 				Details:    "signup page detected via title",
+			}
+		}
+	}
+
+	// Onboarding patterns
+	onboardingPatterns := []string{"getting started", "welcome", "onboarding", "complete your profile", "step 1"}
+	for _, p := range onboardingPatterns {
+		if strings.Contains(lower, p) {
+			return &Intent{
+				Type:       IntentOnboarding,
+				Confidence: 0.65,
+				Details:    "onboarding flow detected via title",
+			}
+		}
+	}
+
+	// Navigation/task-flow patterns
+	navigationPatterns := []string{"continue", "next step", "choose option", "select plan", "wizard"}
+	for _, p := range navigationPatterns {
+		if strings.Contains(lower, p) {
+			return &Intent{
+				Type:       IntentNavigation,
+				Confidence: 0.6,
+				Details:    "navigation flow detected via title",
+			}
+		}
+	}
+
+	// Generic form-filling patterns
+	formPatterns := []string{"application form", "contact form", "checkout", "survey", "questionnaire"}
+	for _, p := range formPatterns {
+		if strings.Contains(lower, p) {
+			return &Intent{
+				Type:       IntentForm,
+				Confidence: 0.6,
+				Details:    "form flow detected via title",
 			}
 		}
 	}

--- a/internal/autosolver/semantic/adapter.go
+++ b/internal/autosolver/semantic/adapter.go
@@ -29,6 +29,10 @@ func NewAdapter(m semantic.ElementMatcher) *Adapter {
 func (a *Adapter) DetectIntent(ctx context.Context, page autosolver.Page) (*autosolver.Intent, error) {
 	title := strings.ToLower(page.Title())
 	url := page.URL()
+	html, _ := page.HTML()
+	if challenge := autosolver.DetectChallengeIntent(title, url, html); challenge != nil {
+		return challenge, nil
+	}
 
 	// Cloudflare challenge indicators
 	cfIndicators := []string{"just a moment", "attention required", "checking your browser"}
@@ -86,6 +90,39 @@ func (a *Adapter) DetectIntent(ctx context.Context, page autosolver.Page) (*auto
 		}
 	}
 
+	onboardingPatterns := []string{"getting started", "welcome", "onboarding", "complete your profile", "step 1"}
+	for _, p := range onboardingPatterns {
+		if strings.Contains(title, p) {
+			return &autosolver.Intent{
+				Type:       autosolver.IntentOnboarding,
+				Confidence: 0.65,
+				Details:    "onboarding flow detected via semantic title analysis",
+			}, nil
+		}
+	}
+
+	navigationPatterns := []string{"continue", "next step", "choose option", "select plan", "wizard"}
+	for _, p := range navigationPatterns {
+		if strings.Contains(title, p) {
+			return &autosolver.Intent{
+				Type:       autosolver.IntentNavigation,
+				Confidence: 0.6,
+				Details:    "navigation flow detected via semantic title analysis",
+			}, nil
+		}
+	}
+
+	formPatterns := []string{"application form", "contact form", "checkout", "survey", "questionnaire"}
+	for _, p := range formPatterns {
+		if strings.Contains(title, p) {
+			return &autosolver.Intent{
+				Type:       autosolver.IntentForm,
+				Confidence: 0.6,
+				Details:    "form flow detected via semantic title analysis",
+			}, nil
+		}
+	}
+
 	return &autosolver.Intent{
 		Type:       autosolver.IntentNormal,
 		Confidence: 0.6,
@@ -127,8 +164,11 @@ func (a *Adapter) FindElement(ctx context.Context, page autosolver.Page, query s
 	}
 
 	best := result.Matches[0]
+	// Semantic refs are selector-compatible in this adapter, so keep both
+	// fields aligned for executors that prefer CSS selectors.
 	return &autosolver.ElementMatch{
 		Ref:        best.Ref,
+		Selector:   best.Ref,
 		Role:       best.Role,
 		Name:       best.Name,
 		Score:      best.Score,
@@ -153,6 +193,12 @@ func (a *Adapter) SuggestAction(ctx context.Context, page autosolver.Page, inten
 		return a.suggestLoginAction(ctx, page)
 	case autosolver.IntentSignup:
 		return a.suggestSignupAction(ctx, page)
+	case autosolver.IntentOnboarding:
+		return a.suggestOnboardingAction(ctx, page)
+	case autosolver.IntentNavigation:
+		return a.suggestNavigationAction(ctx, page)
+	case autosolver.IntentForm:
+		return a.suggestFormAction(ctx, page)
 	case autosolver.IntentBlocked:
 		return &autosolver.SuggestedAction{
 			Action: autosolver.ActionWait,
@@ -219,6 +265,54 @@ func (a *Adapter) suggestSignupAction(ctx context.Context, page autosolver.Page)
 	}, nil
 }
 
+func (a *Adapter) suggestOnboardingAction(ctx context.Context, page autosolver.Page) (*autosolver.SuggestedAction, error) {
+	match, err := a.FindElement(ctx, page, "next continue skip done button")
+	if err != nil || match == nil {
+		return &autosolver.SuggestedAction{
+			Action: autosolver.ActionWait,
+			Reason: "onboarding controls not found yet",
+		}, nil
+	}
+
+	return &autosolver.SuggestedAction{
+		Action:   autosolver.ActionClick,
+		Selector: match.Selector,
+		Reason:   "advancing onboarding flow",
+	}, nil
+}
+
+func (a *Adapter) suggestNavigationAction(ctx context.Context, page autosolver.Page) (*autosolver.SuggestedAction, error) {
+	match, err := a.FindElement(ctx, page, "primary navigation button next continue link")
+	if err != nil || match == nil {
+		return &autosolver.SuggestedAction{
+			Action: autosolver.ActionNone,
+			Reason: "navigation controls not found",
+		}, nil
+	}
+
+	return &autosolver.SuggestedAction{
+		Action:   autosolver.ActionClick,
+		Selector: match.Selector,
+		Reason:   "advancing navigation flow",
+	}, nil
+}
+
+func (a *Adapter) suggestFormAction(ctx context.Context, page autosolver.Page) (*autosolver.SuggestedAction, error) {
+	match, err := a.FindElement(ctx, page, "required input field form control")
+	if err != nil || match == nil {
+		return &autosolver.SuggestedAction{
+			Action: autosolver.ActionNone,
+			Reason: "form fields not found",
+		}, nil
+	}
+
+	return &autosolver.SuggestedAction{
+		Action:   autosolver.ActionClick,
+		Selector: match.Selector,
+		Reason:   "focusing a required form field",
+	}, nil
+}
+
 // detectViaSemanticMatch uses the semantic matcher to classify page
 // elements and infer the page intent.
 func (a *Adapter) detectViaSemanticMatch(ctx context.Context, page autosolver.Page) (*autosolver.Intent, error) {
@@ -242,6 +336,33 @@ func (a *Adapter) detectViaSemanticMatch(ctx context.Context, page autosolver.Pa
 		}, nil
 	}
 
+	match, err = a.FindElement(ctx, page, "next continue done button")
+	if err == nil && match != nil && match.Score > 0.6 {
+		return &autosolver.Intent{
+			Type:       autosolver.IntentOnboarding,
+			Confidence: match.Score,
+			Details:    "onboarding flow detected via semantic element matching",
+		}, nil
+	}
+
+	match, err = a.FindElement(ctx, page, "primary navigation button link")
+	if err == nil && match != nil && match.Score > 0.6 {
+		return &autosolver.Intent{
+			Type:       autosolver.IntentNavigation,
+			Confidence: match.Score,
+			Details:    "navigation flow detected via semantic element matching",
+		}, nil
+	}
+
+	match, err = a.FindElement(ctx, page, "required input field submit button")
+	if err == nil && match != nil && match.Score > 0.6 {
+		return &autosolver.Intent{
+			Type:       autosolver.IntentForm,
+			Confidence: match.Score,
+			Details:    "form flow detected via semantic element matching",
+		}, nil
+	}
+
 	return nil, nil
 }
 
@@ -254,14 +375,15 @@ func extractDescriptors(html string) []semantic.ElementDescriptor {
 	// Extract interactive elements by scanning for common patterns.
 	// A full implementation would use the a11y tree from the bridge.
 	patterns := []struct {
-		tag  string
-		role string
+		searchTag string
+		selTag    string
+		role      string
 	}{
-		{"<input", "textbox"},
-		{"<button", "button"},
-		{"<a ", "link"},
-		{"<select", "combobox"},
-		{"<textarea", "textbox"},
+		{"<input", "input", "textbox"},
+		{"<button", "button", "button"},
+		{"<a ", "a", "link"},
+		{"<select", "select", "combobox"},
+		{"<textarea", "textarea", "textbox"},
 	}
 
 	lower := strings.ToLower(html)
@@ -269,11 +391,11 @@ func extractDescriptors(html string) []semantic.ElementDescriptor {
 	for _, p := range patterns {
 		idx := 0
 		for {
-			pos := strings.Index(lower[idx:], p.tag)
+			pos := strings.Index(lower[idx:], p.searchTag)
 			if pos == -1 {
 				break
 			}
-			idx += pos + len(p.tag)
+			idx += pos + len(p.searchTag)
 
 			// Extract a rough name from surrounding text.
 			end := strings.Index(lower[idx:], ">")
@@ -281,6 +403,8 @@ func extractDescriptors(html string) []semantic.ElementDescriptor {
 				break
 			}
 			snippet := html[idx : idx+end]
+			selector := buildSelector(p.selTag, snippet)
+
 			name := extractAttr(snippet, "placeholder")
 			if name == "" {
 				name = extractAttr(snippet, "aria-label")
@@ -288,10 +412,13 @@ func extractDescriptors(html string) []semantic.ElementDescriptor {
 			if name == "" {
 				name = extractAttr(snippet, "name")
 			}
+			if name == "" {
+				name = selector
+			}
 
 			ref++
 			descs = append(descs, semantic.ElementDescriptor{
-				Ref:  fmt.Sprintf("e%d", ref),
+				Ref:  selector,
 				Role: p.role,
 				Name: name,
 			})
@@ -302,6 +429,36 @@ func extractDescriptors(html string) []semantic.ElementDescriptor {
 		}
 	}
 	return descs
+}
+
+func buildSelector(tag, snippet string) string {
+	id := extractAttr(snippet, "id")
+	if id != "" {
+		return fmt.Sprintf("#%s", id)
+	}
+
+	name := extractAttr(snippet, "name")
+	if name != "" {
+		return fmt.Sprintf(`%s[name="%s"]`, tag, escapeAttrValue(name))
+	}
+
+	placeholder := extractAttr(snippet, "placeholder")
+	if placeholder != "" {
+		return fmt.Sprintf(`%s[placeholder="%s"]`, tag, escapeAttrValue(placeholder))
+	}
+
+	aria := extractAttr(snippet, "aria-label")
+	if aria != "" {
+		return fmt.Sprintf(`%s[aria-label="%s"]`, tag, escapeAttrValue(aria))
+	}
+
+	return tag
+}
+
+func escapeAttrValue(v string) string {
+	v = strings.ReplaceAll(v, `\\`, `\\\\`)
+	v = strings.ReplaceAll(v, `"`, `\\"`)
+	return v
 }
 
 // extractAttr extracts an HTML attribute value from a tag snippet.

--- a/internal/autosolver/solvers/jschallenge.go
+++ b/internal/autosolver/solvers/jschallenge.go
@@ -1,0 +1,111 @@
+package solvers
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/pinchtab/pinchtab/internal/autosolver"
+)
+
+// JSChallenge is a built-in fallback solver for generic JavaScript-based
+// anti-bot blocks and interstitial challenge pages.
+type JSChallenge struct{}
+
+func (s *JSChallenge) Name() string  { return "jschallenge" }
+func (s *JSChallenge) Priority() int { return 40 }
+
+func (s *JSChallenge) CanHandle(_ context.Context, page autosolver.Page) (bool, error) {
+	html, err := page.HTML()
+	if err != nil {
+		return false, nil
+	}
+	intent := autosolver.DetectChallengeIntent(page.Title(), page.URL(), html)
+	if intent == nil {
+		return false, nil
+	}
+	return intent.ChallengeType == "custom-js" || intent.Type == autosolver.IntentBlocked, nil
+}
+
+func (s *JSChallenge) Solve(ctx context.Context, page autosolver.Page, executor autosolver.ActionExecutor) (*autosolver.Result, error) {
+	result := &autosolver.Result{SolverUsed: s.Name()}
+
+	// Step 1: wait briefly for JS anti-bot scripts to execute naturally.
+	if err := executor.WaitFor(ctx, "body", 2*time.Second); err != nil {
+		result.Error = fmt.Sprintf("wait for body: %v", err)
+		return result, err
+	}
+
+	// Step 2: click common continue/verify buttons if present.
+	for _, selector := range []string{
+		"button[type='submit']",
+		"button[name='verify']",
+		"button[id*='verify']",
+		"button[class*='verify']",
+		"input[type='submit']",
+		"#challenge-stage button",
+		"form button",
+	} {
+		// Non-fatal; continue probing other controls.
+		_ = clickIfExists(ctx, executor, selector)
+	}
+
+	// Step 3: poll for resolution by challenge intent re-check.
+	deadline := time.Now().Add(8 * time.Second)
+	for time.Now().Before(deadline) {
+		html, err := page.HTML()
+		if err == nil {
+			intent := autosolver.DetectChallengeIntent(page.Title(), page.URL(), html)
+			if intent == nil || intent.Type == autosolver.IntentNormal {
+				result.Solved = true
+				result.FinalTitle = page.Title()
+				result.FinalURL = page.URL()
+				return result, nil
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			result.Error = ctx.Err().Error()
+			return result, ctx.Err()
+		case <-time.After(400 * time.Millisecond):
+		}
+	}
+
+	// Final state snapshot.
+	result.FinalTitle = page.Title()
+	result.FinalURL = page.URL()
+	html, err := page.HTML()
+	if err != nil {
+		result.Error = fmt.Sprintf("get final html: %v", err)
+		return result, nil
+	}
+	intent := autosolver.DetectChallengeIntent(page.Title(), page.URL(), html)
+	if intent == nil || intent.Type == autosolver.IntentNormal {
+		result.Solved = true
+		return result, nil
+	}
+	result.Error = fmt.Sprintf("challenge still present (%s)", intent.ChallengeType)
+	return result, nil
+}
+
+func clickIfExists(ctx context.Context, executor autosolver.ActionExecutor, selector string) error {
+	var coords struct {
+		X float64 `json:"x"`
+		Y float64 `json:"y"`
+	}
+	expr := fmt.Sprintf(`(() => {
+		const el = document.querySelector(%q);
+		if (!el) return null;
+		const r = el.getBoundingClientRect();
+		if (!r || r.width <= 0 || r.height <= 0) return null;
+		return {x: r.x + r.width/2, y: r.y + r.height/2};
+	})()`, selector)
+	if err := executor.Evaluate(ctx, expr, &coords); err != nil {
+		return err
+	}
+	if coords.X == 0 && coords.Y == 0 {
+		return nil
+	}
+	return executor.Click(ctx, coords.X, coords.Y)
+}

--- a/internal/autosolver/solvers/jschallenge_test.go
+++ b/internal/autosolver/solvers/jschallenge_test.go
@@ -1,0 +1,160 @@
+package solvers
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/pinchtab/pinchtab/internal/autosolver"
+)
+
+type jsMockPage struct {
+	title   string
+	url     string
+	htmlSeq []string
+	idx     int
+}
+
+func (m *jsMockPage) URL() string   { return m.url }
+func (m *jsMockPage) Title() string { return m.title }
+func (m *jsMockPage) Screenshot() ([]byte, error) {
+	return nil, nil
+}
+func (m *jsMockPage) HTML() (string, error) {
+	if len(m.htmlSeq) == 0 {
+		return "", nil
+	}
+	if m.idx >= len(m.htmlSeq) {
+		return m.htmlSeq[len(m.htmlSeq)-1], nil
+	}
+	h := m.htmlSeq[m.idx]
+	m.idx++
+	return h, nil
+}
+
+type jsMockExecutor struct {
+	clicks      int
+	evals       int
+	waits       int
+	clickErr    error
+	evaluateErr error
+	waitErr     error
+}
+
+func (m *jsMockExecutor) Click(_ context.Context, _, _ float64) error {
+	m.clicks++
+	return m.clickErr
+}
+func (m *jsMockExecutor) Type(_ context.Context, _ string) error { return nil }
+func (m *jsMockExecutor) WaitFor(_ context.Context, _ string, _ time.Duration) error {
+	m.waits++
+	return m.waitErr
+}
+func (m *jsMockExecutor) Evaluate(_ context.Context, _ string, _ interface{}) error {
+	m.evals++
+	return m.evaluateErr
+}
+func (m *jsMockExecutor) Navigate(_ context.Context, _ string) error { return nil }
+
+func TestJSChallenge_CanHandle(t *testing.T) {
+	s := &JSChallenge{}
+	page := &jsMockPage{
+		title: "Browser Integrity Check",
+		url:   "https://example.com/challenge",
+		htmlSeq: []string{
+			`<script>window._cf_chl_opt = {}</script>`,
+		},
+	}
+	ok, err := s.CanHandle(context.Background(), page)
+	if err != nil {
+		t.Fatalf("CanHandle error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected CanHandle=true")
+	}
+}
+
+func TestJSChallenge_SolveResolves(t *testing.T) {
+	s := &JSChallenge{}
+	page := &jsMockPage{
+		title: "Browser Integrity Check",
+		url:   "https://example.com/challenge",
+		htmlSeq: []string{
+			`<script>window._cf_chl_opt = {}</script>`,
+			`<html><body>still loading</body></html>`,
+			`<html><body>ok</body></html>`,
+		},
+	}
+	executor := &jsMockExecutor{}
+
+	result, err := s.Solve(context.Background(), page, executor)
+	if err != nil {
+		t.Fatalf("Solve error: %v", err)
+	}
+	if !result.Solved {
+		t.Fatalf("expected solved result, got error=%q", result.Error)
+	}
+	if executor.waits == 0 {
+		t.Fatal("expected wait to be called")
+	}
+}
+
+func TestJSChallenge_SolveWaitError(t *testing.T) {
+	s := &JSChallenge{}
+	page := &jsMockPage{
+		title: "Browser Integrity Check",
+		url:   "https://example.com/challenge",
+		htmlSeq: []string{
+			`<script>window._cf_chl_opt = {}</script>`,
+		},
+	}
+	executor := &jsMockExecutor{waitErr: errors.New("wait fail")}
+
+	result, err := s.Solve(context.Background(), page, executor)
+	if err == nil {
+		t.Fatal("expected wait error")
+	}
+	if result == nil || result.Error == "" {
+		t.Fatal("expected result error message")
+	}
+}
+
+func TestJSChallenge_SolveContextCancel(t *testing.T) {
+	s := &JSChallenge{}
+	page := &jsMockPage{
+		title: "Browser Integrity Check",
+		url:   "https://example.com/challenge",
+		htmlSeq: []string{
+			`<script>window._cf_chl_opt = {}</script>`,
+			`<script>window._cf_chl_opt = {}</script>`,
+			`<script>window._cf_chl_opt = {}</script>`,
+		},
+	}
+	executor := &jsMockExecutor{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	result, err := s.Solve(ctx, page, executor)
+	if err == nil {
+		t.Fatal("expected context cancellation error")
+	}
+	if result == nil || result.Error == "" {
+		t.Fatal("expected result with context error")
+	}
+}
+
+func TestJSChallenge_UsesSharedDetection(t *testing.T) {
+	intent := autosolver.DetectChallengeIntent(
+		"Browser Integrity Check",
+		"https://example.com/challenge",
+		`<script>window._cf_chl_opt = {}</script>`,
+	)
+	if intent == nil {
+		t.Fatal("expected shared detection intent")
+	}
+	if intent.ChallengeType != "custom-js" {
+		t.Fatalf("expected custom-js challenge type, got %q", intent.ChallengeType)
+	}
+}

--- a/internal/autosolver/types.go
+++ b/internal/autosolver/types.go
@@ -132,7 +132,7 @@ func DefaultConfig() Config {
 		Enabled:        true,
 		MaxAttempts:    8,
 		SolverTimeout:  30 * time.Second,
-		Solvers:        []string{"cloudflare", "semantic", "capsolver", "twocaptcha"},
+		Solvers:        []string{"cloudflare", "semantic"},
 		LLMFallback:    false,
 		RetryBaseDelay: 500 * time.Millisecond,
 		RetryMaxDelay:  10 * time.Second,

--- a/internal/autosolver/types.go
+++ b/internal/autosolver/types.go
@@ -10,6 +10,7 @@ const (
 	IntentCaptcha    IntentType = "captcha"    // CAPTCHA challenge (Turnstile, reCAPTCHA, hCaptcha)
 	IntentLogin      IntentType = "login"      // Login form detected
 	IntentSignup     IntentType = "signup"     // Signup/registration form detected
+	IntentForm       IntentType = "form"       // Generic form-filling flow detected
 	IntentBlocked    IntentType = "blocked"    // Navigation blocked (interstitial, bot gate)
 	IntentOnboarding IntentType = "onboarding" // Multi-step onboarding flow
 	IntentNavigation IntentType = "navigation" // Multi-step navigation task
@@ -131,7 +132,7 @@ func DefaultConfig() Config {
 		Enabled:        true,
 		MaxAttempts:    8,
 		SolverTimeout:  30 * time.Second,
-		Solvers:        []string{"cloudflare", "semantic"},
+		Solvers:        []string{"cloudflare", "semantic", "capsolver", "twocaptcha"},
 		LLMFallback:    false,
 		RetryBaseDelay: 500 * time.Millisecond,
 		RetryMaxDelay:  10 * time.Second,

--- a/internal/config/config_file.go
+++ b/internal/config/config_file.go
@@ -50,6 +50,15 @@ func DefaultFileConfig() FileConfig {
 	dashboardSessionElevationWindowSec := 15 * 60
 	dashboardSessionPersistElevationAcrossRestart := false
 	dashboardSessionRequireElevation := false
+	autoSolverEnabled := false
+	autoSolverAutoTrigger := true
+	autoSolverTriggerOnNavigate := true
+	autoSolverTriggerOnAction := true
+	autoSolverMaxAttempts := 8
+	autoSolverSolverTimeoutSec := 30
+	autoSolverRetryBaseDelayMs := 500
+	autoSolverRetryMaxDelayMs := 10000
+	autoSolverLLMFallback := false
 	return FileConfig{
 		ConfigVersion: CurrentConfigVersion,
 		Server: ServerConfig{
@@ -145,6 +154,18 @@ func DefaultFileConfig() FileConfig {
 				PersistElevationAcrossRestart: &dashboardSessionPersistElevationAcrossRestart,
 				RequireElevation:              &dashboardSessionRequireElevation,
 			},
+		},
+		AutoSolver: AutoSolverFileConfig{
+			Enabled:           &autoSolverEnabled,
+			AutoTrigger:       &autoSolverAutoTrigger,
+			TriggerOnNavigate: &autoSolverTriggerOnNavigate,
+			TriggerOnAction:   &autoSolverTriggerOnAction,
+			MaxAttempts:       &autoSolverMaxAttempts,
+			SolverTimeoutSec:  &autoSolverSolverTimeoutSec,
+			RetryBaseDelayMs:  &autoSolverRetryBaseDelayMs,
+			RetryMaxDelayMs:   &autoSolverRetryMaxDelayMs,
+			Solvers:           []string{"cloudflare", "semantic", "capsolver", "twocaptcha"},
+			LLMFallback:       &autoSolverLLMFallback,
 		},
 	}
 }
@@ -312,12 +333,18 @@ type dashboardSessionConfigJSON struct {
 }
 
 type autoSolverFileConfigJSON struct {
-	Enabled     *bool                   `json:"enabled,omitempty"`
-	MaxAttempts *int                    `json:"maxAttempts,omitempty"`
-	Solvers     []string                `json:"solvers,omitempty"`
-	LLMProvider string                  `json:"llmProvider,omitempty"`
-	LLMFallback *bool                   `json:"llmFallback,omitempty"`
-	External    autoSolverExtConfigJSON `json:"external,omitempty"`
+	Enabled           *bool                   `json:"enabled,omitempty"`
+	AutoTrigger       *bool                   `json:"autoTrigger,omitempty"`
+	TriggerOnNavigate *bool                   `json:"triggerOnNavigate,omitempty"`
+	TriggerOnAction   *bool                   `json:"triggerOnAction,omitempty"`
+	MaxAttempts       *int                    `json:"maxAttempts,omitempty"`
+	SolverTimeoutSec  *int                    `json:"solverTimeoutSec,omitempty"`
+	RetryBaseDelayMs  *int                    `json:"retryBaseDelayMs,omitempty"`
+	RetryMaxDelayMs   *int                    `json:"retryMaxDelayMs,omitempty"`
+	Solvers           []string                `json:"solvers,omitempty"`
+	LLMProvider       string                  `json:"llmProvider,omitempty"`
+	LLMFallback       *bool                   `json:"llmFallback,omitempty"`
+	External          autoSolverExtConfigJSON `json:"external,omitempty"`
 }
 
 type autoSolverExtConfigJSON struct {
@@ -464,11 +491,17 @@ func (fc FileConfig) MarshalJSON() ([]byte, error) {
 			},
 		},
 		AutoSolver: autoSolverFileConfigJSON{
-			Enabled:     fc.AutoSolver.Enabled,
-			MaxAttempts: fc.AutoSolver.MaxAttempts,
-			Solvers:     copyStringSlice(fc.AutoSolver.Solvers),
-			LLMProvider: fc.AutoSolver.LLMProvider,
-			LLMFallback: fc.AutoSolver.LLMFallback,
+			Enabled:           fc.AutoSolver.Enabled,
+			AutoTrigger:       fc.AutoSolver.AutoTrigger,
+			TriggerOnNavigate: fc.AutoSolver.TriggerOnNavigate,
+			TriggerOnAction:   fc.AutoSolver.TriggerOnAction,
+			MaxAttempts:       fc.AutoSolver.MaxAttempts,
+			SolverTimeoutSec:  fc.AutoSolver.SolverTimeoutSec,
+			RetryBaseDelayMs:  fc.AutoSolver.RetryBaseDelayMs,
+			RetryMaxDelayMs:   fc.AutoSolver.RetryMaxDelayMs,
+			Solvers:           copyStringSlice(fc.AutoSolver.Solvers),
+			LLMProvider:       fc.AutoSolver.LLMProvider,
+			LLMFallback:       fc.AutoSolver.LLMFallback,
 			External: autoSolverExtConfigJSON{
 				CapsolverKey:  fc.AutoSolver.External.CapsolverKey,
 				TwoCaptchaKey: fc.AutoSolver.External.TwoCaptchaKey,
@@ -540,6 +573,15 @@ func FileConfigFromRuntime(cfg *RuntimeConfig) FileConfig {
 	dashboardSessionElevationWindowSec := int(cfg.Sessions.Dashboard.ElevationWindow / time.Second)
 	dashboardSessionPersistElevationAcrossRestart := cfg.Sessions.Dashboard.PersistElevationAcrossRestart
 	dashboardSessionRequireElevation := cfg.Sessions.Dashboard.RequireElevation
+	autoSolverEnabled := cfg.AutoSolver.Enabled
+	autoSolverAutoTrigger := cfg.AutoSolver.AutoTrigger
+	autoSolverTriggerOnNavigate := cfg.AutoSolver.TriggerOnNavigate
+	autoSolverTriggerOnAction := cfg.AutoSolver.TriggerOnAction
+	autoSolverMaxAttempts := cfg.AutoSolver.MaxAttempts
+	autoSolverSolverTimeoutSec := cfg.AutoSolver.SolverTimeoutSec
+	autoSolverRetryBaseDelayMs := cfg.AutoSolver.RetryBaseDelayMs
+	autoSolverRetryMaxDelayMs := cfg.AutoSolver.RetryMaxDelayMs
+	autoSolverLLMFallback := cfg.AutoSolver.LLMFallback
 
 	mode := "headless"
 	if !cfg.Headless {
@@ -656,6 +698,23 @@ func FileConfigFromRuntime(cfg *RuntimeConfig) FileConfig {
 				ElevationWindowSec:            &dashboardSessionElevationWindowSec,
 				PersistElevationAcrossRestart: &dashboardSessionPersistElevationAcrossRestart,
 				RequireElevation:              &dashboardSessionRequireElevation,
+			},
+		},
+		AutoSolver: AutoSolverFileConfig{
+			Enabled:           &autoSolverEnabled,
+			AutoTrigger:       &autoSolverAutoTrigger,
+			TriggerOnNavigate: &autoSolverTriggerOnNavigate,
+			TriggerOnAction:   &autoSolverTriggerOnAction,
+			MaxAttempts:       &autoSolverMaxAttempts,
+			SolverTimeoutSec:  &autoSolverSolverTimeoutSec,
+			RetryBaseDelayMs:  &autoSolverRetryBaseDelayMs,
+			RetryMaxDelayMs:   &autoSolverRetryMaxDelayMs,
+			Solvers:           copyStringSlice(cfg.AutoSolver.Solvers),
+			LLMProvider:       cfg.AutoSolver.LLMProvider,
+			LLMFallback:       &autoSolverLLMFallback,
+			External: AutoSolverExtConf{
+				CapsolverKey:  cfg.AutoSolver.CapsolverKey,
+				TwoCaptchaKey: cfg.AutoSolver.TwoCaptchaKey,
 			},
 		},
 	}

--- a/internal/config/config_file_test.go
+++ b/internal/config/config_file_test.go
@@ -95,6 +95,27 @@ func TestDefaultFileConfig(t *testing.T) {
 	if fc.Observability.Activity.StateDir != "" {
 		t.Errorf("DefaultFileConfig.Observability.Activity.StateDir = %q, want empty string", fc.Observability.Activity.StateDir)
 	}
+	if fc.AutoSolver.Enabled == nil || *fc.AutoSolver.Enabled {
+		t.Errorf("DefaultFileConfig.AutoSolver.Enabled = %v, want explicit false", formatBoolPtr(fc.AutoSolver.Enabled))
+	}
+	if fc.AutoSolver.AutoTrigger == nil || !*fc.AutoSolver.AutoTrigger {
+		t.Errorf("DefaultFileConfig.AutoSolver.AutoTrigger = %v, want explicit true", formatBoolPtr(fc.AutoSolver.AutoTrigger))
+	}
+	if fc.AutoSolver.TriggerOnNavigate == nil || !*fc.AutoSolver.TriggerOnNavigate {
+		t.Errorf("DefaultFileConfig.AutoSolver.TriggerOnNavigate = %v, want explicit true", formatBoolPtr(fc.AutoSolver.TriggerOnNavigate))
+	}
+	if fc.AutoSolver.TriggerOnAction == nil || !*fc.AutoSolver.TriggerOnAction {
+		t.Errorf("DefaultFileConfig.AutoSolver.TriggerOnAction = %v, want explicit true", formatBoolPtr(fc.AutoSolver.TriggerOnAction))
+	}
+	if fc.AutoSolver.SolverTimeoutSec == nil || *fc.AutoSolver.SolverTimeoutSec != 30 {
+		t.Errorf("DefaultFileConfig.AutoSolver.SolverTimeoutSec = %v, want 30", formatIntPtr(fc.AutoSolver.SolverTimeoutSec))
+	}
+	if fc.AutoSolver.RetryBaseDelayMs == nil || *fc.AutoSolver.RetryBaseDelayMs != 500 {
+		t.Errorf("DefaultFileConfig.AutoSolver.RetryBaseDelayMs = %v, want 500", formatIntPtr(fc.AutoSolver.RetryBaseDelayMs))
+	}
+	if fc.AutoSolver.RetryMaxDelayMs == nil || *fc.AutoSolver.RetryMaxDelayMs != 10000 {
+		t.Errorf("DefaultFileConfig.AutoSolver.RetryMaxDelayMs = %v, want 10000", formatIntPtr(fc.AutoSolver.RetryMaxDelayMs))
+	}
 	if fc.Observability.Activity.Events.Dashboard == nil || *fc.Observability.Activity.Events.Dashboard {
 		t.Errorf("DefaultFileConfig.Observability.Activity.Events.Dashboard = %v, want explicit false", formatBoolPtr(fc.Observability.Activity.Events.Dashboard))
 	}

--- a/internal/config/config_load.go
+++ b/internal/config/config_load.go
@@ -5,16 +5,8 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 )
-
-var supportedAutoSolverNames = map[string]struct{}{
-	"cloudflare": {},
-	"semantic":   {},
-}
-
-var defaultAutoSolverNames = []string{"cloudflare", "semantic"}
 
 // Load returns the RuntimeConfig with precedence: env vars > config file > defaults.
 func Load() *RuntimeConfig {
@@ -129,10 +121,16 @@ func Load() *RuntimeConfig {
 
 		// AutoSolver defaults (disabled by default)
 		AutoSolver: AutoSolverConfig{
-			Enabled:     false,
-			MaxAttempts: 8,
-			Solvers:     []string{"cloudflare", "semantic"},
-			LLMFallback: false,
+			Enabled:           false,
+			AutoTrigger:       true,
+			TriggerOnNavigate: true,
+			TriggerOnAction:   true,
+			MaxAttempts:       8,
+			SolverTimeoutSec:  30,
+			RetryBaseDelayMs:  500,
+			RetryMaxDelayMs:   10000,
+			Solvers:           []string{"cloudflare", "semantic", "capsolver", "twocaptcha"},
+			LLMFallback:       false,
 		},
 	}
 	finalizeProfileConfig(cfg)
@@ -500,8 +498,26 @@ func applyFileConfig(cfg *RuntimeConfig, fc *FileConfig) {
 	if fc.AutoSolver.Enabled != nil {
 		cfg.AutoSolver.Enabled = *fc.AutoSolver.Enabled
 	}
+	if fc.AutoSolver.AutoTrigger != nil {
+		cfg.AutoSolver.AutoTrigger = *fc.AutoSolver.AutoTrigger
+	}
+	if fc.AutoSolver.TriggerOnNavigate != nil {
+		cfg.AutoSolver.TriggerOnNavigate = *fc.AutoSolver.TriggerOnNavigate
+	}
+	if fc.AutoSolver.TriggerOnAction != nil {
+		cfg.AutoSolver.TriggerOnAction = *fc.AutoSolver.TriggerOnAction
+	}
 	if fc.AutoSolver.MaxAttempts != nil && *fc.AutoSolver.MaxAttempts > 0 {
 		cfg.AutoSolver.MaxAttempts = *fc.AutoSolver.MaxAttempts
+	}
+	if fc.AutoSolver.SolverTimeoutSec != nil && *fc.AutoSolver.SolverTimeoutSec > 0 {
+		cfg.AutoSolver.SolverTimeoutSec = *fc.AutoSolver.SolverTimeoutSec
+	}
+	if fc.AutoSolver.RetryBaseDelayMs != nil && *fc.AutoSolver.RetryBaseDelayMs >= 0 {
+		cfg.AutoSolver.RetryBaseDelayMs = *fc.AutoSolver.RetryBaseDelayMs
+	}
+	if fc.AutoSolver.RetryMaxDelayMs != nil && *fc.AutoSolver.RetryMaxDelayMs >= 0 {
+		cfg.AutoSolver.RetryMaxDelayMs = *fc.AutoSolver.RetryMaxDelayMs
 	}
 	if len(fc.AutoSolver.Solvers) > 0 {
 		cfg.AutoSolver.Solvers = append([]string(nil), fc.AutoSolver.Solvers...)
@@ -514,59 +530,6 @@ func applyFileConfig(cfg *RuntimeConfig, fc *FileConfig) {
 	}
 	cfg.AutoSolver.CapsolverKey = fc.AutoSolver.External.CapsolverKey
 	cfg.AutoSolver.TwoCaptchaKey = fc.AutoSolver.External.TwoCaptchaKey
-	sanitizeAutoSolverRuntimeConfig(cfg)
-}
-
-func sanitizeAutoSolverRuntimeConfig(cfg *RuntimeConfig) {
-	if cfg == nil {
-		return
-	}
-
-	sanitized := normalizeAutoSolverNames(cfg.AutoSolver.Solvers)
-	if len(sanitized) == 0 {
-		sanitized = append([]string(nil), defaultAutoSolverNames...)
-	}
-	cfg.AutoSolver.Solvers = sanitized
-
-	if strings.TrimSpace(cfg.AutoSolver.LLMProvider) != "" {
-		slog.Warn("autosolver llmProvider is not implemented; ignoring configured provider",
-			"provider", cfg.AutoSolver.LLMProvider)
-		cfg.AutoSolver.LLMProvider = ""
-	}
-
-	if cfg.AutoSolver.LLMFallback {
-		slog.Warn("autosolver llmFallback is not implemented; forcing disabled")
-		cfg.AutoSolver.LLMFallback = false
-	}
-}
-
-func normalizeAutoSolverNames(raw []string) []string {
-	if len(raw) == 0 {
-		return nil
-	}
-
-	out := make([]string, 0, len(raw))
-	seen := make(map[string]struct{}, len(raw))
-
-	for _, name := range raw {
-		normalized := strings.ToLower(strings.TrimSpace(name))
-		if normalized == "" {
-			continue
-		}
-
-		if _, ok := supportedAutoSolverNames[normalized]; !ok {
-			slog.Warn("autosolver solver is not implemented; ignoring configured solver", "solver", name)
-			continue
-		}
-
-		if _, ok := seen[normalized]; ok {
-			continue
-		}
-		seen[normalized] = struct{}{}
-		out = append(out, normalized)
-	}
-
-	return out
 }
 
 // ApplyFileConfigToRuntime merges file configuration into an existing runtime

--- a/internal/config/config_load_test.go
+++ b/internal/config/config_load_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
-	"reflect"
 	"testing"
 	"time"
 )
@@ -141,6 +140,24 @@ func TestLoadConfigDefaults(t *testing.T) {
 	}
 	if cfg.Sessions.Dashboard.RequireElevation {
 		t.Errorf("default Sessions.Dashboard.RequireElevation = %v, want false", cfg.Sessions.Dashboard.RequireElevation)
+	}
+	if cfg.AutoSolver.AutoTrigger != true {
+		t.Errorf("default AutoSolver.AutoTrigger = %v, want true", cfg.AutoSolver.AutoTrigger)
+	}
+	if cfg.AutoSolver.TriggerOnNavigate != true {
+		t.Errorf("default AutoSolver.TriggerOnNavigate = %v, want true", cfg.AutoSolver.TriggerOnNavigate)
+	}
+	if cfg.AutoSolver.TriggerOnAction != true {
+		t.Errorf("default AutoSolver.TriggerOnAction = %v, want true", cfg.AutoSolver.TriggerOnAction)
+	}
+	if cfg.AutoSolver.SolverTimeoutSec != 30 {
+		t.Errorf("default AutoSolver.SolverTimeoutSec = %d, want 30", cfg.AutoSolver.SolverTimeoutSec)
+	}
+	if cfg.AutoSolver.RetryBaseDelayMs != 500 {
+		t.Errorf("default AutoSolver.RetryBaseDelayMs = %d, want 500", cfg.AutoSolver.RetryBaseDelayMs)
+	}
+	if cfg.AutoSolver.RetryMaxDelayMs != 10000 {
+		t.Errorf("default AutoSolver.RetryMaxDelayMs = %d, want 10000", cfg.AutoSolver.RetryMaxDelayMs)
 	}
 }
 
@@ -288,7 +305,7 @@ func TestLoadConfigActivityStateDirIgnoresConfigOverride(t *testing.T) {
 	_ = os.Setenv("PINCHTAB_CONFIG", configPath)
 	defer func() { _ = os.Unsetenv("PINCHTAB_CONFIG") }()
 
-	payload := map[string]any{
+	cfgDoc, err := json.Marshal(map[string]any{
 		"server": map[string]any{
 			"stateDir": "/tmp/profile-state",
 		},
@@ -297,12 +314,12 @@ func TestLoadConfigActivityStateDirIgnoresConfigOverride(t *testing.T) {
 				"stateDir": sharedActivityDir,
 			},
 		},
-	}
-	raw, err := json.Marshal(payload)
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(configPath, raw, 0644); err != nil {
+
+	if err := os.WriteFile(configPath, cfgDoc, 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -668,44 +685,78 @@ func TestApplyFileConfigToRuntime_SanitizesChromeExtraFlags(t *testing.T) {
 	}
 }
 
-func TestApplyFileConfigToRuntime_SanitizesAutoSolverUnsupportedSettings(t *testing.T) {
+func TestApplyFileConfigToRuntime_AutoSolverSettings(t *testing.T) {
+	cfg := &RuntimeConfig{}
+	enabled := true
+	autoTrigger := true
+	triggerOnNavigate := true
+	triggerOnAction := false
+	maxAttempts := 5
+	solverTimeoutSec := 45
+	retryBaseDelayMs := 250
+	retryMaxDelayMs := 2500
 	llmFallback := true
-	cfg := &RuntimeConfig{}
+
 	fc := &FileConfig{
 		AutoSolver: AutoSolverFileConfig{
-			Solvers:     []string{" cloudflare ", "capsolver", "semantic", "twocaptcha", "semantic"},
-			LLMProvider: "openai",
-			LLMFallback: &llmFallback,
+			Enabled:           &enabled,
+			AutoTrigger:       &autoTrigger,
+			TriggerOnNavigate: &triggerOnNavigate,
+			TriggerOnAction:   &triggerOnAction,
+			MaxAttempts:       &maxAttempts,
+			SolverTimeoutSec:  &solverTimeoutSec,
+			RetryBaseDelayMs:  &retryBaseDelayMs,
+			RetryMaxDelayMs:   &retryMaxDelayMs,
+			Solvers:           []string{"jschallenge", "cloudflare"},
+			LLMProvider:       "openai",
+			LLMFallback:       &llmFallback,
+			External: AutoSolverExtConf{
+				CapsolverKey:  "cap-key",
+				TwoCaptchaKey: "two-key",
+			},
 		},
 	}
 
 	ApplyFileConfigToRuntime(cfg, fc)
 
-	if cfg.AutoSolver.LLMProvider != "" {
-		t.Fatalf("AutoSolver.LLMProvider = %q, want empty", cfg.AutoSolver.LLMProvider)
+	if !cfg.AutoSolver.Enabled {
+		t.Fatal("AutoSolver.Enabled = false, want true")
 	}
-	if cfg.AutoSolver.LLMFallback {
-		t.Fatal("AutoSolver.LLMFallback = true, want false")
+	if !cfg.AutoSolver.AutoTrigger {
+		t.Fatal("AutoSolver.AutoTrigger = false, want true")
 	}
-	wantSolvers := []string{"cloudflare", "semantic"}
-	if !reflect.DeepEqual(cfg.AutoSolver.Solvers, wantSolvers) {
-		t.Fatalf("AutoSolver.Solvers = %v, want %v", cfg.AutoSolver.Solvers, wantSolvers)
+	if !cfg.AutoSolver.TriggerOnNavigate {
+		t.Fatal("AutoSolver.TriggerOnNavigate = false, want true")
 	}
-}
-
-func TestApplyFileConfigToRuntime_AutoSolverFallsBackToDefaultSupportedSolvers(t *testing.T) {
-	cfg := &RuntimeConfig{}
-	fc := &FileConfig{
-		AutoSolver: AutoSolverFileConfig{
-			Solvers: []string{"capsolver", "twocaptcha"},
-		},
+	if cfg.AutoSolver.TriggerOnAction {
+		t.Fatal("AutoSolver.TriggerOnAction = true, want false")
 	}
-
-	ApplyFileConfigToRuntime(cfg, fc)
-
-	wantSolvers := []string{"cloudflare", "semantic"}
-	if !reflect.DeepEqual(cfg.AutoSolver.Solvers, wantSolvers) {
-		t.Fatalf("AutoSolver.Solvers = %v, want %v", cfg.AutoSolver.Solvers, wantSolvers)
+	if cfg.AutoSolver.MaxAttempts != 5 {
+		t.Fatalf("AutoSolver.MaxAttempts = %d, want 5", cfg.AutoSolver.MaxAttempts)
+	}
+	if cfg.AutoSolver.SolverTimeoutSec != 45 {
+		t.Fatalf("AutoSolver.SolverTimeoutSec = %d, want 45", cfg.AutoSolver.SolverTimeoutSec)
+	}
+	if cfg.AutoSolver.RetryBaseDelayMs != 250 {
+		t.Fatalf("AutoSolver.RetryBaseDelayMs = %d, want 250", cfg.AutoSolver.RetryBaseDelayMs)
+	}
+	if cfg.AutoSolver.RetryMaxDelayMs != 2500 {
+		t.Fatalf("AutoSolver.RetryMaxDelayMs = %d, want 2500", cfg.AutoSolver.RetryMaxDelayMs)
+	}
+	if len(cfg.AutoSolver.Solvers) != 2 || cfg.AutoSolver.Solvers[0] != "jschallenge" {
+		t.Fatalf("AutoSolver.Solvers = %v, want configured order", cfg.AutoSolver.Solvers)
+	}
+	if cfg.AutoSolver.LLMProvider != "openai" {
+		t.Fatalf("AutoSolver.LLMProvider = %q, want openai", cfg.AutoSolver.LLMProvider)
+	}
+	if !cfg.AutoSolver.LLMFallback {
+		t.Fatal("AutoSolver.LLMFallback = false, want true")
+	}
+	if cfg.AutoSolver.CapsolverKey != "cap-key" {
+		t.Fatalf("AutoSolver.CapsolverKey = %q, want cap-key", cfg.AutoSolver.CapsolverKey)
+	}
+	if cfg.AutoSolver.TwoCaptchaKey != "two-key" {
+		t.Fatalf("AutoSolver.TwoCaptchaKey = %q, want two-key", cfg.AutoSolver.TwoCaptchaKey)
 	}
 }
 

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -157,13 +157,19 @@ type SchedulerConfig struct {
 
 // AutoSolverConfig holds autosolver runtime settings.
 type AutoSolverConfig struct {
-	Enabled       bool     `json:"enabled,omitempty"`
-	MaxAttempts   int      `json:"maxAttempts,omitempty"`
-	Solvers       []string `json:"solvers,omitempty"`     // Ordered solver names
-	LLMProvider   string   `json:"llmProvider,omitempty"` // "openai", "anthropic", etc.
-	LLMFallback   bool     `json:"llmFallback,omitempty"` // Enable LLM as last resort
-	CapsolverKey  string   `json:"capsolverKey,omitempty"`
-	TwoCaptchaKey string   `json:"twoCaptchaKey,omitempty"`
+	Enabled           bool     `json:"enabled,omitempty"`
+	AutoTrigger       bool     `json:"autoTrigger,omitempty"`
+	TriggerOnNavigate bool     `json:"triggerOnNavigate,omitempty"`
+	TriggerOnAction   bool     `json:"triggerOnAction,omitempty"`
+	MaxAttempts       int      `json:"maxAttempts,omitempty"`
+	SolverTimeoutSec  int      `json:"solverTimeoutSec,omitempty"`
+	RetryBaseDelayMs  int      `json:"retryBaseDelayMs,omitempty"`
+	RetryMaxDelayMs   int      `json:"retryMaxDelayMs,omitempty"`
+	Solvers           []string `json:"solvers,omitempty"`     // Ordered solver names
+	LLMProvider       string   `json:"llmProvider,omitempty"` // "openai", "anthropic", etc.
+	LLMFallback       bool     `json:"llmFallback,omitempty"` // Enable LLM as last resort
+	CapsolverKey      string   `json:"capsolverKey,omitempty"`
+	TwoCaptchaKey     string   `json:"twoCaptchaKey,omitempty"`
 }
 
 type ObservabilityConfig struct {
@@ -353,12 +359,18 @@ type ActivityEventsFileConfig struct {
 
 // AutoSolverFileConfig is the persistent configuration for the autosolver system.
 type AutoSolverFileConfig struct {
-	Enabled     *bool             `json:"enabled,omitempty"`
-	MaxAttempts *int              `json:"maxAttempts,omitempty"`
-	Solvers     []string          `json:"solvers,omitempty"`
-	LLMProvider string            `json:"llmProvider,omitempty"`
-	LLMFallback *bool             `json:"llmFallback,omitempty"`
-	External    AutoSolverExtConf `json:"external,omitempty"`
+	Enabled           *bool             `json:"enabled,omitempty"`
+	AutoTrigger       *bool             `json:"autoTrigger,omitempty"`
+	TriggerOnNavigate *bool             `json:"triggerOnNavigate,omitempty"`
+	TriggerOnAction   *bool             `json:"triggerOnAction,omitempty"`
+	MaxAttempts       *int              `json:"maxAttempts,omitempty"`
+	SolverTimeoutSec  *int              `json:"solverTimeoutSec,omitempty"`
+	RetryBaseDelayMs  *int              `json:"retryBaseDelayMs,omitempty"`
+	RetryMaxDelayMs   *int              `json:"retryMaxDelayMs,omitempty"`
+	Solvers           []string          `json:"solvers,omitempty"`
+	LLMProvider       string            `json:"llmProvider,omitempty"`
+	LLMFallback       *bool             `json:"llmFallback,omitempty"`
+	External          AutoSolverExtConf `json:"external,omitempty"`
 }
 
 // AutoSolverExtConf holds external solver API keys.

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -194,6 +194,47 @@ func ValidateFileConfig(fc *FileConfig) []error {
 		})
 	}
 
+	if fc.AutoSolver.MaxAttempts != nil && *fc.AutoSolver.MaxAttempts < 1 {
+		errs = append(errs, ValidationError{
+			Field:   "autoSolver.maxAttempts",
+			Message: fmt.Sprintf("must be >= 1 (got %d)", *fc.AutoSolver.MaxAttempts),
+		})
+	}
+	if fc.AutoSolver.SolverTimeoutSec != nil && *fc.AutoSolver.SolverTimeoutSec <= 0 {
+		errs = append(errs, ValidationError{
+			Field:   "autoSolver.solverTimeoutSec",
+			Message: fmt.Sprintf("must be > 0 (got %d)", *fc.AutoSolver.SolverTimeoutSec),
+		})
+	}
+	if fc.AutoSolver.RetryBaseDelayMs != nil && *fc.AutoSolver.RetryBaseDelayMs < 0 {
+		errs = append(errs, ValidationError{
+			Field:   "autoSolver.retryBaseDelayMs",
+			Message: fmt.Sprintf("must be >= 0 (got %d)", *fc.AutoSolver.RetryBaseDelayMs),
+		})
+	}
+	if fc.AutoSolver.RetryMaxDelayMs != nil && *fc.AutoSolver.RetryMaxDelayMs < 0 {
+		errs = append(errs, ValidationError{
+			Field:   "autoSolver.retryMaxDelayMs",
+			Message: fmt.Sprintf("must be >= 0 (got %d)", *fc.AutoSolver.RetryMaxDelayMs),
+		})
+	}
+	if fc.AutoSolver.RetryBaseDelayMs != nil && fc.AutoSolver.RetryMaxDelayMs != nil &&
+		*fc.AutoSolver.RetryBaseDelayMs > *fc.AutoSolver.RetryMaxDelayMs {
+		errs = append(errs, ValidationError{
+			Field:   "autoSolver.retryBaseDelayMs/retryMaxDelayMs",
+			Message: fmt.Sprintf("retry base delay (%d) must be <= retry max delay (%d)", *fc.AutoSolver.RetryBaseDelayMs, *fc.AutoSolver.RetryMaxDelayMs),
+		})
+	}
+	for _, solverName := range fc.AutoSolver.Solvers {
+		if strings.TrimSpace(solverName) == "" {
+			errs = append(errs, ValidationError{
+				Field:   "autoSolver.solvers",
+				Message: "solver names must not be empty",
+			})
+			break
+		}
+	}
+
 	if fc.Observability.Activity.SessionIdleSec != nil && *fc.Observability.Activity.SessionIdleSec < 0 {
 		errs = append(errs, ValidationError{
 			Field:   "observability.activity.sessionIdleSec",
@@ -229,41 +270,6 @@ func ValidateFileConfig(fc *FileConfig) []error {
 		errs = append(errs, ValidationError{
 			Field:   "sessions.dashboard.idleTimeoutSec/maxLifetimeSec",
 			Message: fmt.Sprintf("idle timeout (%d) must be <= max lifetime (%d)", *fc.Sessions.Dashboard.IdleTimeoutSec, *fc.Sessions.Dashboard.MaxLifetimeSec),
-		})
-	}
-
-	// AutoSolver validation
-	for _, solver := range fc.AutoSolver.Solvers {
-		switch strings.ToLower(strings.TrimSpace(solver)) {
-		case "":
-			errs = append(errs, ValidationError{
-				Field:   "autoSolver.solvers",
-				Message: "solver name must not be empty",
-			})
-		case "cloudflare", "semantic":
-			// Supported.
-		case "capsolver", "twocaptcha":
-			errs = append(errs, ValidationError{
-				Field:   "autoSolver.solvers",
-				Message: fmt.Sprintf("solver %q is not implemented yet; remove it from autoSolver.solvers", solver),
-			})
-		default:
-			errs = append(errs, ValidationError{
-				Field:   "autoSolver.solvers",
-				Message: fmt.Sprintf("invalid solver %q (supported: cloudflare, semantic)", solver),
-			})
-		}
-	}
-	if fc.AutoSolver.LLMFallback != nil && *fc.AutoSolver.LLMFallback {
-		errs = append(errs, ValidationError{
-			Field:   "autoSolver.llmFallback",
-			Message: "LLM fallback is not implemented yet and cannot be enabled",
-		})
-	}
-	if strings.TrimSpace(fc.AutoSolver.LLMProvider) != "" {
-		errs = append(errs, ValidationError{
-			Field:   "autoSolver.llmProvider",
-			Message: "LLM provider integration is not implemented yet; leave autoSolver.llmProvider unset",
 		})
 	}
 

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -514,103 +514,6 @@ func TestValidEnumValues(t *testing.T) {
 	}
 }
 
-func TestValidateFileConfig_AutoSolverUnsupportedSolver(t *testing.T) {
-	fc := &FileConfig{
-		AutoSolver: AutoSolverFileConfig{
-			Solvers: []string{"cloudflare", "capsolver"},
-		},
-	}
-
-	errs := ValidateFileConfig(fc)
-	if len(errs) == 0 {
-		t.Fatal("expected autosolver validation error, got none")
-	}
-	found := false
-	for _, err := range errs {
-		if strings.Contains(err.Error(), "autoSolver.solvers") &&
-			strings.Contains(err.Error(), "not implemented") {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Fatalf("expected not implemented solver error, got %v", errs)
-	}
-}
-
-func TestValidateFileConfig_AutoSolverInvalidSolverName(t *testing.T) {
-	fc := &FileConfig{
-		AutoSolver: AutoSolverFileConfig{
-			Solvers: []string{"cloudflare", "madeupsolver"},
-		},
-	}
-
-	errs := ValidateFileConfig(fc)
-	if len(errs) == 0 {
-		t.Fatal("expected autosolver validation error, got none")
-	}
-	found := false
-	for _, err := range errs {
-		if strings.Contains(err.Error(), "autoSolver.solvers") &&
-			strings.Contains(err.Error(), "invalid solver") {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Fatalf("expected invalid solver name error, got %v", errs)
-	}
-}
-
-func TestValidateFileConfig_AutoSolverLLMFallbackRejected(t *testing.T) {
-	enabled := true
-	fc := &FileConfig{
-		AutoSolver: AutoSolverFileConfig{
-			LLMFallback: &enabled,
-		},
-	}
-
-	errs := ValidateFileConfig(fc)
-	if len(errs) == 0 {
-		t.Fatal("expected autosolver llmFallback validation error, got none")
-	}
-	found := false
-	for _, err := range errs {
-		if strings.Contains(err.Error(), "autoSolver.llmFallback") &&
-			strings.Contains(err.Error(), "not implemented") {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Fatalf("expected llm fallback not implemented error, got %v", errs)
-	}
-}
-
-func TestValidateFileConfig_AutoSolverLLMProviderRejected(t *testing.T) {
-	fc := &FileConfig{
-		AutoSolver: AutoSolverFileConfig{
-			LLMProvider: "openai",
-		},
-	}
-
-	errs := ValidateFileConfig(fc)
-	if len(errs) == 0 {
-		t.Fatal("expected autosolver llmProvider validation error, got none")
-	}
-	found := false
-	for _, err := range errs {
-		if strings.Contains(err.Error(), "autoSolver.llmProvider") &&
-			strings.Contains(err.Error(), "not implemented") {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Fatalf("expected llm provider not implemented error, got %v", errs)
-	}
-}
-
 // --- IDPI validation tests ---
 
 // TestValidateIDPIConfig_Disabled verifies that a disabled IDPI config produces
@@ -844,6 +747,44 @@ func TestValidateFileConfig_TransferLimits(t *testing.T) {
 				t.Fatalf("expected error containing %q, got %v", tt.wantErr, errs[0])
 			}
 		})
+	}
+}
+
+func TestValidateFileConfig_AutoSolverValidation(t *testing.T) {
+	maxAttempts := 0
+	solverTimeout := 0
+	retryBase := 2000
+	retryMax := 1000
+
+	fc := &FileConfig{
+		AutoSolver: AutoSolverFileConfig{
+			MaxAttempts:      &maxAttempts,
+			SolverTimeoutSec: &solverTimeout,
+			RetryBaseDelayMs: &retryBase,
+			RetryMaxDelayMs:  &retryMax,
+			Solvers:          []string{"cloudflare", ""},
+		},
+	}
+
+	errs := ValidateFileConfig(fc)
+	if len(errs) == 0 {
+		t.Fatal("expected autosolver validation errors, got none")
+	}
+
+	joined := ""
+	for _, err := range errs {
+		joined += err.Error() + "\n"
+	}
+
+	for _, want := range []string{
+		"autoSolver.maxAttempts",
+		"autoSolver.solverTimeoutSec",
+		"autoSolver.retryBaseDelayMs/retryMaxDelayMs",
+		"autoSolver.solvers",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("expected error containing %q, got:\n%s", want, joined)
+		}
 	}
 }
 

--- a/internal/handlers/actions.go
+++ b/internal/handlers/actions.go
@@ -179,7 +179,7 @@ func (h *Handlers) HandleAction(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if err := h.enforceTabNotPausedForHandoff(resolvedTabID); err != nil {
-			httpx.ErrorCode(w, 409, "tab_paused_handoff", err.Error(), false, nil)
+			httpx.ErrorCode(w, 409, "tab_paused_handoff", err.Error(), false, h.handoffErrorDetails(resolvedTabID))
 			return
 		}
 	}
@@ -413,6 +413,9 @@ func (h *Handlers) HandleAction(w http.ResponseWriter, r *http.Request) {
 
 	if engineName == "" {
 		engineName = "chrome"
+	}
+	if engineName != "lite" {
+		h.maybeAutoSolve(tCtx, resolvedTabID, autoSolverTriggerAction)
 	}
 	w.Header().Set("X-Engine", engineName)
 	h.recordEngine(r, engineName)
@@ -824,11 +827,16 @@ func (h *Handlers) handleActionsBatch(w http.ResponseWriter, r *http.Request, re
 		}
 	}
 
+	successful := countSuccessful(results)
+	if !allLite && successful > 0 {
+		h.maybeAutoSolve(ctx, resolvedTabID, autoSolverTriggerAction)
+	}
+
 	httpx.JSON(w, 200, map[string]any{
 		"results":    results,
 		"total":      len(req.Actions),
-		"successful": countSuccessful(results),
-		"failed":     len(req.Actions) - countSuccessful(results),
+		"successful": successful,
+		"failed":     len(req.Actions) - successful,
 	})
 }
 
@@ -1113,12 +1121,17 @@ func (h *Handlers) HandleMacro(w http.ResponseWriter, r *http.Request) {
 		results = append(results, actionResult{Index: i, Success: true, Result: res})
 	}
 
+	successful := countSuccessful(results)
+	if !allLiteMacro && successful > 0 {
+		h.maybeAutoSolve(ctx, resolvedTabID, autoSolverTriggerAction)
+	}
+
 	httpx.JSON(w, 200, map[string]any{
 		"kind":       "macro",
 		"results":    results,
 		"total":      len(req.Steps),
-		"successful": countSuccessful(results),
-		"failed":     len(req.Steps) - countSuccessful(results),
+		"successful": successful,
+		"failed":     len(req.Steps) - successful,
 	})
 }
 

--- a/internal/handlers/autosolver.go
+++ b/internal/handlers/autosolver.go
@@ -17,24 +17,40 @@ import (
 const (
 	autoSolverTriggerNavigate = "navigate"
 	autoSolverTriggerAction   = "action"
+
+	// autoTriggerMaxAttempts caps retries on nav/action auto-triggers so a
+	// missed challenge doesn't block the request path. Explicit POST /solve
+	// still uses the fully configured MaxAttempts.
+	autoTriggerMaxAttempts = 2
+
+	// autoTriggerRunBudget caps the total time an auto-trigger run can take
+	// end-to-end (detection + retries). Safety valve for slow pages or solvers.
+	autoTriggerRunBudget = 45 * time.Second
 )
 
-func (h *Handlers) maybeAutoSolve(ctx context.Context, tabID, trigger string) {
+// maybeAutoSolve kicks off the autosolver pipeline for tabID in the background.
+// It never blocks the caller: the HTTP request that triggered this returns
+// immediately while the solver runs with its own bounded context. If the
+// solver detects a challenge and fails, the tab is flipped to paused_handoff
+// so subsequent action requests see the 409 handoff error.
+func (h *Handlers) maybeAutoSolve(_ context.Context, tabID, trigger string) {
 	if tabID == "" || h.autoSolverRunner == nil || !h.shouldAutoSolve(trigger) {
 		return
 	}
-	if ctx == nil {
-		ctx = context.Background()
-	}
 
-	if err := h.autoSolverRunner(ctx, tabID); err != nil &&
-		!errors.Is(err, context.Canceled) &&
-		!errors.Is(err, context.DeadlineExceeded) {
-		slog.Warn("autosolver auto-trigger failed",
-			"trigger", trigger,
-			"tab_id", tabID,
-			"error", err)
-	}
+	go func() {
+		runCtx, cancel := context.WithTimeout(context.Background(), autoTriggerRunBudget)
+		defer cancel()
+
+		if err := h.autoSolverRunner(runCtx, tabID); err != nil &&
+			!errors.Is(err, context.Canceled) &&
+			!errors.Is(err, context.DeadlineExceeded) {
+			slog.Warn("autosolver auto-trigger failed",
+				"trigger", trigger,
+				"tab_id", tabID,
+				"error", err)
+		}
+	}()
 }
 
 func (h *Handlers) shouldAutoSolve(trigger string) bool {
@@ -67,17 +83,23 @@ func (h *Handlers) runAutoSolver(ctx context.Context, tabID string) error {
 		return err
 	}
 
-	html, err := page.HTML()
+	// Detection is the cheap path that runs on every nav/action — keep it
+	// short so normal pages return almost immediately.
+	detectCtx, detectCancel := context.WithTimeout(ctx, 5*time.Second)
+	html, err := fetchHTMLWithTimeout(detectCtx, page)
+	detectCancel()
 	if err != nil {
 		return err
 	}
 
-	// Auto-trigger focuses on challenge resolution and should be a no-op on normal pages.
 	if coreautosolver.DetectChallengeIntent(page.Title(), page.URL(), html) == nil {
 		return nil
 	}
 
 	cfg := h.normalizedAutoSolverConfig()
+	if cfg.MaxAttempts > autoTriggerMaxAttempts {
+		cfg.MaxAttempts = autoTriggerMaxAttempts
+	}
 	as := h.buildAutoSolver(cfg, true)
 
 	solveCtx, cancel := context.WithTimeout(ctx, estimateAutoSolverRunTimeout(cfg))
@@ -99,10 +121,59 @@ func (h *Handlers) runAutoSolver(ctx context.Context, tabID string) error {
 				"tab_id", tabID,
 				"attempts", result.Attempts,
 				"error", result.Error)
+			h.autoHandoffAfterFailure(tabID, deriveChallengeType(result, page))
 		}
 	}
 
 	return nil
+}
+
+// fetchHTMLWithTimeout runs page.HTML() but aborts if ctx fires first. Since
+// Page.HTML has no context argument, we run it in a goroutine and select on
+// ctx — a stuck CDP call will leak the goroutine until the call itself
+// unblocks, but the caller returns promptly.
+func fetchHTMLWithTimeout(ctx context.Context, page coreautosolver.Page) (string, error) {
+	type result struct {
+		html string
+		err  error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		html, err := page.HTML()
+		ch <- result{html: html, err: err}
+	}()
+	select {
+	case <-ctx.Done():
+		return "", ctx.Err()
+	case r := <-ch:
+		return r.html, r.err
+	}
+}
+
+// autoHandoffAfterFailure flips the tab into paused_handoff so action routes
+// block and the dashboard/agent can escalate to a human. No-op if the tab is
+// already paused or the bridge does not support handoff state.
+func (h *Handlers) autoHandoffAfterFailure(tabID, challengeType string) {
+	if tabID == "" {
+		return
+	}
+	ctrl, ok := h.handoffController()
+	if !ok {
+		return
+	}
+	if state, exists := ctrl.TabHandoffState(tabID); exists && state.Status == "paused_handoff" {
+		return
+	}
+	reason := "autosolver_unsolved"
+	if trimmed := strings.TrimSpace(challengeType); trimmed != "" {
+		reason = "autosolver_unsolved:" + trimmed
+	}
+	if _, err := h.pauseTabForHandoff(tabID, reason, "autosolver", 0); err != nil {
+		slog.Warn("autosolver: auto-handoff failed",
+			"tab_id", tabID,
+			"reason", reason,
+			"error", err)
+	}
 }
 
 func (h *Handlers) normalizedAutoSolverConfig() coreautosolver.Config {

--- a/internal/handlers/autosolver.go
+++ b/internal/handlers/autosolver.go
@@ -1,0 +1,232 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"time"
+
+	coreautosolver "github.com/pinchtab/pinchtab/internal/autosolver"
+	"github.com/pinchtab/pinchtab/internal/autosolver/adapters"
+	"github.com/pinchtab/pinchtab/internal/autosolver/external"
+	autosolversemantic "github.com/pinchtab/pinchtab/internal/autosolver/semantic"
+	autosolvers "github.com/pinchtab/pinchtab/internal/autosolver/solvers"
+)
+
+const (
+	autoSolverTriggerNavigate = "navigate"
+	autoSolverTriggerAction   = "action"
+)
+
+func (h *Handlers) maybeAutoSolve(ctx context.Context, tabID, trigger string) {
+	if tabID == "" || h.autoSolverRunner == nil || !h.shouldAutoSolve(trigger) {
+		return
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	if err := h.autoSolverRunner(ctx, tabID); err != nil &&
+		!errors.Is(err, context.Canceled) &&
+		!errors.Is(err, context.DeadlineExceeded) {
+		slog.Warn("autosolver auto-trigger failed",
+			"trigger", trigger,
+			"tab_id", tabID,
+			"error", err)
+	}
+}
+
+func (h *Handlers) shouldAutoSolve(trigger string) bool {
+	if h == nil || h.Config == nil {
+		return false
+	}
+
+	cfg := h.Config.AutoSolver
+	if !cfg.Enabled || !cfg.AutoTrigger {
+		return false
+	}
+
+	switch trigger {
+	case autoSolverTriggerNavigate:
+		return cfg.TriggerOnNavigate
+	case autoSolverTriggerAction:
+		return cfg.TriggerOnAction
+	default:
+		return false
+	}
+}
+
+func (h *Handlers) runAutoSolver(ctx context.Context, tabID string) error {
+	if h == nil || h.Config == nil || h.Bridge == nil {
+		return nil
+	}
+
+	page, executor, err := adapters.NewFromBridge(h.Bridge, tabID)
+	if err != nil {
+		return err
+	}
+
+	html, err := page.HTML()
+	if err != nil {
+		return err
+	}
+
+	// Auto-trigger focuses on challenge resolution and should be a no-op on normal pages.
+	if coreautosolver.DetectChallengeIntent(page.Title(), page.URL(), html) == nil {
+		return nil
+	}
+
+	cfg := h.normalizedAutoSolverConfig()
+	as := h.buildAutoSolver(cfg, true)
+
+	solveCtx, cancel := context.WithTimeout(ctx, estimateAutoSolverRunTimeout(cfg))
+	defer cancel()
+
+	result, err := as.Solve(solveCtx, page, executor)
+	if err != nil {
+		return err
+	}
+
+	if result != nil {
+		if result.Solved && result.Attempts > 0 {
+			slog.Info("autosolver auto-trigger solved challenge",
+				"tab_id", tabID,
+				"solver", result.SolverUsed,
+				"attempts", result.Attempts)
+		} else if !result.Solved && result.Attempts > 0 {
+			slog.Warn("autosolver auto-trigger did not solve challenge",
+				"tab_id", tabID,
+				"attempts", result.Attempts,
+				"error", result.Error)
+		}
+	}
+
+	return nil
+}
+
+func (h *Handlers) normalizedAutoSolverConfig() coreautosolver.Config {
+	cfg := coreautosolver.DefaultConfig()
+	if h == nil || h.Config == nil {
+		return cfg
+	}
+
+	cfg.Enabled = h.Config.AutoSolver.Enabled
+	if h.Config.AutoSolver.MaxAttempts > 0 {
+		cfg.MaxAttempts = h.Config.AutoSolver.MaxAttempts
+	}
+	if h.Config.AutoSolver.SolverTimeoutSec > 0 {
+		cfg.SolverTimeout = time.Duration(h.Config.AutoSolver.SolverTimeoutSec) * time.Second
+	}
+	if h.Config.AutoSolver.RetryBaseDelayMs >= 0 {
+		cfg.RetryBaseDelay = time.Duration(h.Config.AutoSolver.RetryBaseDelayMs) * time.Millisecond
+	}
+	if h.Config.AutoSolver.RetryMaxDelayMs >= 0 {
+		cfg.RetryMaxDelay = time.Duration(h.Config.AutoSolver.RetryMaxDelayMs) * time.Millisecond
+	}
+	if len(h.Config.AutoSolver.Solvers) > 0 {
+		configured := make([]string, 0, len(h.Config.AutoSolver.Solvers))
+		for _, name := range h.Config.AutoSolver.Solvers {
+			trimmed := strings.TrimSpace(name)
+			if trimmed != "" {
+				configured = append(configured, trimmed)
+			}
+		}
+		if len(configured) > 0 {
+			cfg.Solvers = configured
+		}
+	}
+	cfg.LLMFallback = h.Config.AutoSolver.LLMFallback
+
+	return cfg
+}
+
+func (h *Handlers) buildAutoSolver(cfg coreautosolver.Config, includeSemantic bool) *coreautosolver.AutoSolver {
+	var semanticEngine coreautosolver.SemanticEngine
+	if includeSemantic {
+		semanticEngine = autosolversemantic.NewAdapter(h.Matcher)
+	}
+
+	as := coreautosolver.New(cfg, semanticEngine, nil)
+	as.Registry().MustRegister(&autosolvers.Cloudflare{})
+	as.Registry().MustRegister(&autosolvers.JSChallenge{})
+
+	if h != nil && h.Config != nil {
+		if key := strings.TrimSpace(h.Config.AutoSolver.CapsolverKey); key != "" {
+			as.Registry().MustRegister(external.NewCapsolver(external.CapsolverConfig{APIKey: key}))
+		}
+		if key := strings.TrimSpace(h.Config.AutoSolver.TwoCaptchaKey); key != "" {
+			as.Registry().MustRegister(external.NewTwoCaptcha(external.TwoCaptchaConfig{APIKey: key}))
+		}
+	}
+
+	return as
+}
+
+func (h *Handlers) availableAutoSolverNames() []string {
+	cfg := h.normalizedAutoSolverConfig()
+	available := map[string]bool{
+		"cloudflare":  true,
+		"semantic":    true,
+		"jschallenge": true,
+	}
+	if h != nil && h.Config != nil {
+		if strings.TrimSpace(h.Config.AutoSolver.CapsolverKey) != "" {
+			available["capsolver"] = true
+		}
+		if strings.TrimSpace(h.Config.AutoSolver.TwoCaptchaKey) != "" {
+			available["twocaptcha"] = true
+		}
+	}
+
+	names := make([]string, 0, len(available))
+	seen := make(map[string]struct{}, len(available))
+	for _, configured := range cfg.Solvers {
+		if !available[configured] {
+			continue
+		}
+		if _, ok := seen[configured]; ok {
+			continue
+		}
+		names = append(names, configured)
+		seen[configured] = struct{}{}
+	}
+
+	for _, fallback := range []string{"cloudflare", "semantic", "jschallenge", "capsolver", "twocaptcha"} {
+		if !available[fallback] {
+			continue
+		}
+		if _, ok := seen[fallback]; ok {
+			continue
+		}
+		names = append(names, fallback)
+		seen[fallback] = struct{}{}
+	}
+
+	return names
+}
+
+func (h *Handlers) isAvailableAutoSolver(name string) bool {
+	for _, n := range h.availableAutoSolverNames() {
+		if n == name {
+			return true
+		}
+	}
+	return false
+}
+
+func estimateAutoSolverRunTimeout(cfg coreautosolver.Config) time.Duration {
+	attempts := cfg.MaxAttempts
+	if attempts < 1 {
+		attempts = 1
+	}
+
+	timeout := time.Duration(attempts) * cfg.SolverTimeout
+	if attempts > 1 {
+		timeout += time.Duration(attempts-1) * cfg.RetryMaxDelay
+	}
+	if timeout <= 0 {
+		timeout = 30 * time.Second
+	}
+	return timeout + 2*time.Second
+}

--- a/internal/handlers/autosolver_test.go
+++ b/internal/handlers/autosolver_test.go
@@ -2,7 +2,9 @@ package handlers
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/pinchtab/pinchtab/internal/config"
 )
@@ -86,28 +88,44 @@ func TestMaybeAutoSolve_InvokesRunnerWhenEnabled(t *testing.T) {
 		}},
 	}
 
-	calls := 0
+	var calls atomic.Int64
+	done := make(chan struct{}, 8)
 	h.autoSolverRunner = func(_ context.Context, tabID string) error {
-		calls++
+		calls.Add(1)
 		if tabID != "tab1" {
-			t.Fatalf("runner tabID = %q, want tab1", tabID)
+			t.Errorf("runner tabID = %q, want tab1", tabID)
 		}
+		done <- struct{}{}
 		return nil
 	}
 
-	h.maybeAutoSolve(context.Background(), "tab1", autoSolverTriggerNavigate)
-	if calls != 1 {
-		t.Fatalf("autoSolverRunner calls = %d, want 1", calls)
+	waitFor := func(expected int64) bool {
+		deadline := time.Now().Add(2 * time.Second)
+		for time.Now().Before(deadline) {
+			if calls.Load() == expected {
+				return true
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+		return false
 	}
 
+	h.maybeAutoSolve(context.Background(), "tab1", autoSolverTriggerNavigate)
+	if !waitFor(1) {
+		t.Fatalf("autoSolverRunner calls = %d, want 1", calls.Load())
+	}
+	<-done
+
 	h.maybeAutoSolve(context.Background(), "", autoSolverTriggerNavigate)
-	if calls != 1 {
-		t.Fatalf("autoSolverRunner calls with empty tab id = %d, want unchanged", calls)
+	time.Sleep(20 * time.Millisecond) // ensure no goroutine was spawned
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("autoSolverRunner calls with empty tab id = %d, want unchanged", got)
 	}
 
 	h.Config.AutoSolver.TriggerOnNavigate = false
 	h.maybeAutoSolve(context.Background(), "tab1", autoSolverTriggerNavigate)
-	if calls != 1 {
-		t.Fatalf("autoSolverRunner calls with navigate trigger disabled = %d, want unchanged", calls)
+	time.Sleep(20 * time.Millisecond)
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("autoSolverRunner calls with navigate trigger disabled = %d, want unchanged", got)
 	}
 }

--- a/internal/handlers/autosolver_test.go
+++ b/internal/handlers/autosolver_test.go
@@ -1,0 +1,113 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pinchtab/pinchtab/internal/config"
+)
+
+func TestShouldAutoSolve(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     *config.RuntimeConfig
+		trigger string
+		want    bool
+	}{
+		{
+			name:    "nil config",
+			cfg:     nil,
+			trigger: autoSolverTriggerNavigate,
+			want:    false,
+		},
+		{
+			name: "disabled autosolver",
+			cfg: &config.RuntimeConfig{AutoSolver: config.AutoSolverConfig{
+				Enabled:           false,
+				AutoTrigger:       true,
+				TriggerOnNavigate: true,
+				TriggerOnAction:   true,
+			}},
+			trigger: autoSolverTriggerNavigate,
+			want:    false,
+		},
+		{
+			name: "auto trigger disabled",
+			cfg: &config.RuntimeConfig{AutoSolver: config.AutoSolverConfig{
+				Enabled:           true,
+				AutoTrigger:       false,
+				TriggerOnNavigate: true,
+				TriggerOnAction:   true,
+			}},
+			trigger: autoSolverTriggerNavigate,
+			want:    false,
+		},
+		{
+			name: "navigate trigger enabled",
+			cfg: &config.RuntimeConfig{AutoSolver: config.AutoSolverConfig{
+				Enabled:           true,
+				AutoTrigger:       true,
+				TriggerOnNavigate: true,
+				TriggerOnAction:   false,
+			}},
+			trigger: autoSolverTriggerNavigate,
+			want:    true,
+		},
+		{
+			name: "action trigger disabled",
+			cfg: &config.RuntimeConfig{AutoSolver: config.AutoSolverConfig{
+				Enabled:           true,
+				AutoTrigger:       true,
+				TriggerOnNavigate: true,
+				TriggerOnAction:   false,
+			}},
+			trigger: autoSolverTriggerAction,
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &Handlers{Config: tt.cfg}
+			if got := h.shouldAutoSolve(tt.trigger); got != tt.want {
+				t.Fatalf("shouldAutoSolve(%q) = %v, want %v", tt.trigger, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMaybeAutoSolve_InvokesRunnerWhenEnabled(t *testing.T) {
+	h := &Handlers{
+		Config: &config.RuntimeConfig{AutoSolver: config.AutoSolverConfig{
+			Enabled:           true,
+			AutoTrigger:       true,
+			TriggerOnNavigate: true,
+			TriggerOnAction:   true,
+		}},
+	}
+
+	calls := 0
+	h.autoSolverRunner = func(_ context.Context, tabID string) error {
+		calls++
+		if tabID != "tab1" {
+			t.Fatalf("runner tabID = %q, want tab1", tabID)
+		}
+		return nil
+	}
+
+	h.maybeAutoSolve(context.Background(), "tab1", autoSolverTriggerNavigate)
+	if calls != 1 {
+		t.Fatalf("autoSolverRunner calls = %d, want 1", calls)
+	}
+
+	h.maybeAutoSolve(context.Background(), "", autoSolverTriggerNavigate)
+	if calls != 1 {
+		t.Fatalf("autoSolverRunner calls with empty tab id = %d, want unchanged", calls)
+	}
+
+	h.Config.AutoSolver.TriggerOnNavigate = false
+	h.maybeAutoSolve(context.Background(), "tab1", autoSolverTriggerNavigate)
+	if calls != 1 {
+		t.Fatalf("autoSolverRunner calls with navigate trigger disabled = %d, want unchanged", calls)
+	}
+}

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -37,8 +37,9 @@ type Handlers struct {
 	clipboard    clipboardStore
 
 	// Optional dependency injection (for unit testing)
-	evalJS      func(ctx context.Context, expression string, out *string) error
-	evalRuntime func(ctx context.Context, expression string, out any, opts ...chromedp.EvaluateOption) error
+	evalJS           func(ctx context.Context, expression string, out *string) error
+	autoSolverRunner func(ctx context.Context, tabID string) error
+	evalRuntime      func(ctx context.Context, expression string, out any, opts ...chromedp.EvaluateOption) error
 }
 
 func New(b bridge.BridgeAPI, cfg *config.RuntimeConfig, p bridge.ProfileService, d *dashboard.Dashboard, o bridge.OrchestratorService) *Handlers {
@@ -97,6 +98,7 @@ func New(b bridge.BridgeAPI, cfg *config.RuntimeConfig, p bridge.ProfileService,
 	h.evalJS = func(ctx context.Context, expression string, out *string) error {
 		return chromedp.Run(ctx, chromedp.Evaluate(expression, out))
 	}
+	h.autoSolverRunner = h.runAutoSolver
 	h.evalRuntime = func(ctx context.Context, expression string, out any, opts ...chromedp.EvaluateOption) error {
 		return chromedp.Run(ctx, chromedp.Evaluate(expression, out, opts...))
 	}
@@ -209,6 +211,7 @@ func (h *Handlers) RegisterRoutes(mux *http.ServeMux, doShutdown func()) {
 	mux.HandleFunc("GET /cookies", h.HandleGetCookies)
 	mux.HandleFunc("POST /cookies", h.HandleSetCookies)
 	mux.HandleFunc("GET /solvers", h.HandleListSolvers)
+	mux.HandleFunc("GET /config/autosolver", h.HandleAutoSolverConfig)
 	mux.HandleFunc("POST /solve", h.HandleSolve)
 	mux.HandleFunc("POST /solve/{name}", h.HandleSolve)
 	mux.HandleFunc("POST /tabs/{id}/solve", h.HandleTabSolve)

--- a/internal/handlers/handoff.go
+++ b/internal/handlers/handoff.go
@@ -26,6 +26,63 @@ func (h *Handlers) handoffController() (tabHandoffController, bool) {
 	return ctrl, ok
 }
 
+// handoffHintMessage is included in error responses and dashboard events when
+// the agent must yield control to a human operator.
+const handoffHintMessage = "return control to the user and ask them to manually solve the challenge in the browser window, then call POST /tabs/{id}/resume to continue"
+
+// handoffErrorDetails builds the details payload attached to 409 responses
+// when an action hits a tab that is paused for handoff. Always includes the
+// agent hint; when known, also includes the current reason and pausedAt.
+func (h *Handlers) handoffErrorDetails(tabID string) map[string]any {
+	details := map[string]any{"hint": handoffHintMessage}
+	if ctrl, ok := h.handoffController(); ok {
+		if state, exists := ctrl.TabHandoffState(tabID); exists {
+			if state.Reason != "" {
+				details["reason"] = state.Reason
+			}
+			if !state.PausedAt.IsZero() {
+				details["pausedAt"] = state.PausedAt.Format(time.RFC3339)
+			}
+		}
+	}
+	return details
+}
+
+// pauseTabForHandoff marks a tab as paused for human handoff and broadcasts
+// a dashboard event. source identifies what triggered the handoff
+// (e.g. "autosolver", "manual"). Returns the applied reason.
+func (h *Handlers) pauseTabForHandoff(tabID, reason, source string, timeout time.Duration) (string, error) {
+	ctrl, ok := h.handoffController()
+	if !ok {
+		return "", fmt.Errorf("bridge does not support handoff state")
+	}
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		reason = "manual_handoff"
+	}
+	if err := ctrl.SetTabHandoff(tabID, reason, timeout); err != nil {
+		return reason, err
+	}
+	if h.Dashboard != nil {
+		payload := map[string]any{
+			"tabId":       tabID,
+			"status":      "paused_handoff",
+			"reason":      reason,
+			"source":      source,
+			"hint":        handoffHintMessage,
+			"requestedAt": time.Now().UTC().Format(time.RFC3339),
+		}
+		if timeout > 0 {
+			payload["timeoutMs"] = int(timeout / time.Millisecond)
+		}
+		h.Dashboard.BroadcastSystemEvent(dashboard.SystemEvent{
+			Type:     "tab.handoff",
+			Instance: payload,
+		})
+	}
+	return reason, nil
+}
+
 func (h *Handlers) HandleTabHandoff(w http.ResponseWriter, r *http.Request) {
 	tabID := strings.TrimSpace(r.PathValue("id"))
 	if tabID == "" {
@@ -56,45 +113,29 @@ func (h *Handlers) HandleTabHandoff(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctrl, ok := h.handoffController()
-	if !ok {
+	if _, ok := h.handoffController(); !ok {
 		httpx.ErrorCode(w, 501, "handoff_not_supported", "bridge does not support handoff state", false, nil)
 		return
 	}
-
-	reason := strings.TrimSpace(req.Reason)
-	if reason == "" {
-		reason = "manual_handoff"
-	}
-	timeout := time.Duration(req.TimeoutMs) * time.Millisecond
 	if req.TimeoutMs < 0 {
 		httpx.Error(w, 400, fmt.Errorf("timeoutMs must be >= 0"))
 		return
 	}
-	if err := ctrl.SetTabHandoff(resolvedTabID, reason, timeout); err != nil {
+	timeout := time.Duration(req.TimeoutMs) * time.Millisecond
+	reason, err := h.pauseTabForHandoff(resolvedTabID, req.Reason, "manual", timeout)
+	if err != nil {
 		httpx.ErrorCode(w, 500, "handoff_failed", err.Error(), false, nil)
 		return
 	}
 
 	h.recordActivity(r, activity.Update{Action: "handoff", TabID: resolvedTabID})
-	if h.Dashboard != nil {
-		h.Dashboard.BroadcastSystemEvent(dashboard.SystemEvent{
-			Type: "tab.handoff",
-			Instance: map[string]any{
-				"tabId":       resolvedTabID,
-				"status":      "paused_handoff",
-				"reason":      reason,
-				"timeoutMs":   req.TimeoutMs,
-				"requestedAt": time.Now().UTC().Format(time.RFC3339),
-			},
-		})
-	}
 
 	resp := map[string]any{
 		"tabId":     resolvedTabID,
 		"status":    "paused_handoff",
 		"reason":    reason,
 		"timeoutMs": req.TimeoutMs,
+		"hint":      handoffHintMessage,
 	}
 	if timeout > 0 {
 		resp["expiresAt"] = time.Now().UTC().Add(timeout).Format(time.RFC3339)

--- a/internal/handlers/middleware.go
+++ b/internal/handlers/middleware.go
@@ -447,7 +447,7 @@ func sessionConsoleGrantAllows(method, path string) bool {
 func sessionSolveGrantAllows(method, path string) bool {
 	switch method {
 	case http.MethodGet:
-		return path == "/solvers"
+		return path == "/solvers" || path == "/config/autosolver"
 	case http.MethodPost:
 		switch {
 		case path == "/solve" || strings.HasPrefix(path, "/solve/"):

--- a/internal/handlers/navigation.go
+++ b/internal/handlers/navigation.go
@@ -244,6 +244,8 @@ func (h *Handlers) HandleNavigate(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
+		h.maybeAutoSolve(tCtx, newTabID, autoSolverTriggerNavigate)
+
 		var navURL string
 		_ = chromedp.Run(tCtx, chromedp.Location(&navURL))
 		title, _ := bridge.WaitForTitle(tCtx, titleWait)
@@ -299,6 +301,8 @@ func (h *Handlers) HandleNavigate(w http.ResponseWriter, r *http.Request) {
 		httpx.ErrorCode(w, 400, "bad_wait_for", err.Error(), false, nil)
 		return
 	}
+
+	h.maybeAutoSolve(tCtx, resolvedTabID, autoSolverTriggerNavigate)
 
 	var navURL string
 	_ = chromedp.Run(tCtx, chromedp.Location(&navURL))

--- a/internal/handlers/solver.go
+++ b/internal/handlers/solver.go
@@ -156,14 +156,26 @@ func (h *Handlers) HandleSolve(w http.ResponseWriter, r *http.Request) {
 		title = page.Title()
 	}
 
-	httpx.JSON(w, 200, map[string]any{
+	challengeType := deriveChallengeType(result, page)
+	resp := map[string]any{
 		"tabId":         resolvedTabID,
 		"solver":        solverName,
 		"solved":        result.Solved,
-		"challengeType": deriveChallengeType(result, page),
+		"challengeType": challengeType,
 		"attempts":      result.Attempts,
 		"title":         title,
-	})
+	}
+
+	// If a challenge was detected but the solver couldn't resolve it, flip the
+	// tab into paused_handoff so subsequent actions block and the caller can
+	// escalate to a human.
+	if !result.Solved && result.Attempts > 0 && challengeType != "" {
+		h.autoHandoffAfterFailure(resolvedTabID, challengeType)
+		resp["handoff"] = "paused_handoff"
+		resp["hint"] = handoffHintMessage
+	}
+
+	httpx.JSON(w, 200, resp)
 }
 
 // HandleTabSolve handles POST /tabs/{id}/solve and /tabs/{id}/solve/{name}.

--- a/internal/handlers/solver.go
+++ b/internal/handlers/solver.go
@@ -8,15 +8,12 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/pinchtab/pinchtab/internal/activity"
+	coreautosolver "github.com/pinchtab/pinchtab/internal/autosolver"
+	"github.com/pinchtab/pinchtab/internal/autosolver/adapters"
 	"github.com/pinchtab/pinchtab/internal/httpx"
-	"github.com/pinchtab/pinchtab/internal/solver"
-
-	// Register built-in solvers via init().
-	_ "github.com/pinchtab/pinchtab/internal/bridge"
 )
 
 // HandleSolve attempts to solve a browser challenge on the current page.
@@ -33,7 +30,7 @@ import (
 // @Param maxAttempts int     body  Max solve attempts (optional, default: 3)
 // @Param timeout     float64 body  Timeout in ms (optional, default: 30000)
 //
-// @Response 200 application/json Returns {tabId, solver, solved, challengeType, attempts, title, needsHumanHandoff, handoffReason}
+// @Response 200 application/json Returns {tabId, solver, solved, challengeType, attempts, title}
 // @Response 400 application/json Invalid request body or unknown solver
 // @Response 423 application/json Tab is locked by another owner
 // @Response 500 application/json Chrome/CDP error
@@ -69,9 +66,9 @@ func (h *Handlers) HandleSolve(w http.ResponseWriter, r *http.Request) {
 
 	// Validate solver name early.
 	if req.Solver != "" {
-		if _, ok := solver.Get(req.Solver); !ok {
+		if !h.isAvailableAutoSolver(req.Solver) {
 			httpx.ErrorCode(w, 400, "unknown_solver",
-				fmt.Sprintf("unknown solver %q (available: %v)", req.Solver, solver.Names()),
+				fmt.Sprintf("unknown solver %q (available: %v)", req.Solver, h.availableAutoSolverNames()),
 				false, nil)
 			return
 		}
@@ -99,23 +96,49 @@ func (h *Handlers) HandleSolve(w http.ResponseWriter, r *http.Request) {
 	}
 	h.recordActivity(r, activity.Update{Action: action, TabID: resolvedTabID})
 
+	page, executor, err := adapters.NewFromBridge(h.Bridge, resolvedTabID)
+	if err != nil {
+		httpx.Error(w, 500, fmt.Errorf("resolve solve tab: %w", err))
+		return
+	}
+
+	cfg := h.normalizedAutoSolverConfig()
+	cfg.Enabled = true
+	if req.MaxAttempts > 0 {
+		cfg.MaxAttempts = req.MaxAttempts
+	}
+	if req.Solver != "" {
+		cfg.Solvers = []string{req.Solver}
+	}
+
+	// Explicit named solvers should run directly without semantic-first flow,
+	// except when the caller explicitly requested the semantic solver.
+	includeSemantic := req.Solver == "" || req.Solver == "semantic"
+	as := h.buildAutoSolver(cfg, includeSemantic)
+
 	timeout := 30 * time.Second
 	if req.Timeout > 0 {
 		timeout = time.Duration(req.Timeout) * time.Millisecond
+	} else {
+		estimated := estimateAutoSolverRunTimeout(cfg)
+		if estimated > timeout {
+			timeout = estimated
+		}
 	}
 
 	tCtx, tCancel := context.WithTimeout(ctx, timeout)
 	defer tCancel()
 	go httpx.CancelOnClientDone(r.Context(), tCancel)
 
-	result, err := solver.Solve(tCtx, req.Solver, solver.Options{
-		MaxAttempts: req.MaxAttempts,
-	})
+	result, err := as.Solve(tCtx, page, executor)
 	if err != nil {
 		httpx.Error(w, 500, fmt.Errorf("solve: %w", err))
 		return
 	}
-	needsHumanHandoff, handoffReason := deriveHumanHandoff(result)
+	if result == nil {
+		httpx.Error(w, 500, fmt.Errorf("solve: empty result"))
+		return
+	}
 
 	// Re-check domain policy after solve — the page may have redirected
 	// to a different domain once the challenge was resolved.
@@ -123,48 +146,24 @@ func (h *Handlers) HandleSolve(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	solverName := result.SolverUsed
+	if solverName == "" && req.Solver != "" {
+		solverName = req.Solver
+	}
+
+	title := result.FinalTitle
+	if title == "" {
+		title = page.Title()
+	}
+
 	httpx.JSON(w, 200, map[string]any{
-		"tabId":             resolvedTabID,
-		"solver":            result.Solver,
-		"solved":            result.Solved,
-		"challengeType":     result.ChallengeType,
-		"attempts":          result.Attempts,
-		"title":             result.Title,
-		"needsHumanHandoff": needsHumanHandoff,
-		"handoffReason":     handoffReason,
+		"tabId":         resolvedTabID,
+		"solver":        solverName,
+		"solved":        result.Solved,
+		"challengeType": deriveChallengeType(result, page),
+		"attempts":      result.Attempts,
+		"title":         title,
 	})
-}
-
-func deriveHumanHandoff(result *solver.Result) (bool, string) {
-	if result == nil || result.Solved {
-		return false, ""
-	}
-
-	challengeType := strings.ToLower(strings.TrimSpace(result.ChallengeType))
-	title := strings.ToLower(strings.TrimSpace(result.Title))
-
-	if strings.Contains(challengeType, "login") ||
-		strings.Contains(challengeType, "auth") ||
-		strings.Contains(challengeType, "credential") ||
-		strings.Contains(challengeType, "password") ||
-		strings.Contains(title, "sign in") ||
-		strings.Contains(title, "log in") ||
-		strings.Contains(title, "password") {
-		return true, "credentials_required"
-	}
-
-	if strings.Contains(challengeType, "captcha") ||
-		strings.Contains(challengeType, "turnstile") ||
-		strings.Contains(challengeType, "recaptcha") ||
-		strings.Contains(challengeType, "hcaptcha") ||
-		strings.Contains(challengeType, "challenge") ||
-		strings.Contains(title, "verify you are human") ||
-		strings.Contains(title, "attention required") ||
-		strings.Contains(title, "just a moment") {
-		return true, "challenge_requires_manual_intervention"
-	}
-
-	return false, ""
 }
 
 // HandleTabSolve handles POST /tabs/{id}/solve and /tabs/{id}/solve/{name}.
@@ -207,6 +206,74 @@ func (h *Handlers) HandleTabSolve(w http.ResponseWriter, r *http.Request) {
 // @Response 200 application/json Returns {solvers: ["cloudflare", ...]}
 func (h *Handlers) HandleListSolvers(w http.ResponseWriter, r *http.Request) {
 	httpx.JSON(w, 200, map[string]any{
-		"solvers": solver.Names(),
+		"solvers": h.availableAutoSolverNames(),
 	})
+}
+
+// HandleAutoSolverConfig returns effective autosolver runtime settings.
+//
+// @Endpoint GET /config/autosolver
+// @Description Return effective autosolver configuration and available solver names
+// @Response 200 application/json Returns autosolver runtime config
+func (h *Handlers) HandleAutoSolverConfig(w http.ResponseWriter, r *http.Request) {
+	cfg := h.normalizedAutoSolverConfig()
+
+	autoTrigger := true
+	triggerOnNavigate := true
+	triggerOnAction := true
+	llmProvider := ""
+
+	if h != nil && h.Config != nil {
+		autoTrigger = h.Config.AutoSolver.AutoTrigger
+		triggerOnNavigate = h.Config.AutoSolver.TriggerOnNavigate
+		triggerOnAction = h.Config.AutoSolver.TriggerOnAction
+		llmProvider = h.Config.AutoSolver.LLMProvider
+	}
+
+	httpx.JSON(w, 200, map[string]any{
+		"enabled":           cfg.Enabled,
+		"autoTrigger":       autoTrigger,
+		"triggerOnNavigate": triggerOnNavigate,
+		"triggerOnAction":   triggerOnAction,
+		"maxAttempts":       cfg.MaxAttempts,
+		"solverTimeoutSec":  int(cfg.SolverTimeout / time.Second),
+		"retryBaseDelayMs":  int(cfg.RetryBaseDelay / time.Millisecond),
+		"retryMaxDelayMs":   int(cfg.RetryMaxDelay / time.Millisecond),
+		"solvers":           h.availableAutoSolverNames(),
+		"llmProvider":       llmProvider,
+		"llmFallback":       cfg.LLMFallback,
+	})
+}
+
+func deriveChallengeType(result *coreautosolver.Result, page coreautosolver.Page) string {
+	if result == nil || page == nil {
+		return ""
+	}
+
+	finalTitle := result.FinalTitle
+	if finalTitle == "" {
+		finalTitle = page.Title()
+	}
+	finalURL := result.FinalURL
+	if finalURL == "" {
+		finalURL = page.URL()
+	}
+
+	html, err := page.HTML()
+	if err == nil {
+		if detected := coreautosolver.DetectChallengeIntent(finalTitle, finalURL, html); detected != nil {
+			if detected.ChallengeType != "" {
+				return detected.ChallengeType
+			}
+			if detected.Type != "" && detected.Type != coreautosolver.IntentNormal {
+				return string(detected.Type)
+			}
+		}
+	}
+
+	if result.Intent != "" && result.Intent != coreautosolver.IntentNormal {
+		return string(result.Intent)
+	}
+
+	return ""
 }

--- a/internal/handlers/solver_test.go
+++ b/internal/handlers/solver_test.go
@@ -2,30 +2,14 @@ package handlers
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	coreautosolver "github.com/pinchtab/pinchtab/internal/autosolver"
 	"github.com/pinchtab/pinchtab/internal/config"
-	"github.com/pinchtab/pinchtab/internal/solver"
 )
-
-type testStaticSolver struct {
-	name   string
-	result *solver.Result
-	err    error
-}
-
-func (s *testStaticSolver) Name() string { return s.name }
-func (s *testStaticSolver) CanHandle(context.Context) (bool, error) {
-	return true, nil
-}
-func (s *testStaticSolver) Solve(context.Context, solver.Options) (*solver.Result, error) {
-	return s.result, s.err
-}
 
 func TestHandleListSolvers(t *testing.T) {
 	h := New(&mockBridge{}, &config.RuntimeConfig{}, nil, nil, nil)
@@ -47,16 +31,68 @@ func TestHandleListSolvers(t *testing.T) {
 		t.Fatal("expected 'solvers' key in response")
 	}
 
-	// cloudflare solver is registered via bridge init
-	found := false
+	foundCloudflare := false
+	foundSemantic := false
 	for _, s := range solvers {
 		if s == "cloudflare" {
-			found = true
-			break
+			foundCloudflare = true
+		}
+		if s == "semantic" {
+			foundSemantic = true
 		}
 	}
-	if !found {
+	if !foundCloudflare {
 		t.Errorf("expected cloudflare in solvers list, got %v", solvers)
+	}
+	if !foundSemantic {
+		t.Errorf("expected semantic in solvers list, got %v", solvers)
+	}
+}
+
+func TestHandleAutoSolverConfig(t *testing.T) {
+	h := New(&mockBridge{}, &config.RuntimeConfig{
+		AutoSolver: config.AutoSolverConfig{
+			Enabled:           true,
+			AutoTrigger:       true,
+			TriggerOnNavigate: false,
+			TriggerOnAction:   true,
+			MaxAttempts:       5,
+			SolverTimeoutSec:  42,
+			RetryBaseDelayMs:  200,
+			RetryMaxDelayMs:   1200,
+			Solvers:           []string{"cloudflare", "semantic", "jschallenge"},
+			LLMProvider:       "openai",
+			LLMFallback:       true,
+		},
+	}, nil, nil, nil)
+
+	req := httptest.NewRequest("GET", "/config/autosolver", nil)
+	w := httptest.NewRecorder()
+	h.HandleAutoSolverConfig(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if got, ok := resp["enabled"].(bool); !ok || !got {
+		t.Fatalf("enabled = %v, want true", resp["enabled"])
+	}
+	if got, ok := resp["triggerOnNavigate"].(bool); !ok || got {
+		t.Fatalf("triggerOnNavigate = %v, want false", resp["triggerOnNavigate"])
+	}
+	if got, ok := resp["solverTimeoutSec"].(float64); !ok || int(got) != 42 {
+		t.Fatalf("solverTimeoutSec = %v, want 42", resp["solverTimeoutSec"])
+	}
+	if got, ok := resp["llmProvider"].(string); !ok || got != "openai" {
+		t.Fatalf("llmProvider = %v, want openai", resp["llmProvider"])
+	}
+	if got, ok := resp["solvers"].([]any); !ok || len(got) == 0 {
+		t.Fatalf("solvers = %v, want non-empty array", resp["solvers"])
 	}
 }
 
@@ -185,9 +221,10 @@ func TestHandleSolve_PathUnknownSolver(t *testing.T) {
 	}
 }
 
-// Verify solver.Names includes cloudflare (registered by bridge init).
+// Verify the HTTP-exposed solver list includes cloudflare.
 func TestCloudflareSolverRegistered(t *testing.T) {
-	names := solver.Names()
+	h := New(&mockBridge{}, &config.RuntimeConfig{}, nil, nil, nil)
+	names := h.availableAutoSolverNames()
 	found := false
 	for _, n := range names {
 		if n == "cloudflare" {
@@ -200,119 +237,9 @@ func TestCloudflareSolverRegistered(t *testing.T) {
 	}
 }
 
-func TestDeriveHumanHandoff(t *testing.T) {
-	tests := []struct {
-		name       string
-		result     *solver.Result
-		wantNeeded bool
-		wantReason string
-	}{
-		{
-			name:       "solved result does not require handoff",
-			result:     &solver.Result{Solved: true, ChallengeType: "turnstile"},
-			wantNeeded: false,
-			wantReason: "",
-		},
-		{
-			name:       "captcha challenge requires handoff",
-			result:     &solver.Result{Solved: false, ChallengeType: "cloudflare-turnstile"},
-			wantNeeded: true,
-			wantReason: "challenge_requires_manual_intervention",
-		},
-		{
-			name:       "credential gate requires handoff",
-			result:     &solver.Result{Solved: false, ChallengeType: "login"},
-			wantNeeded: true,
-			wantReason: "credentials_required",
-		},
-		{
-			name:       "title heuristics detect credentials requirement",
-			result:     &solver.Result{Solved: false, Title: "Sign In - Example"},
-			wantNeeded: true,
-			wantReason: "credentials_required",
-		},
+func TestDeriveChallengeType_NilPage(t *testing.T) {
+	result := &coreautosolver.Result{Intent: coreautosolver.IntentCaptcha}
+	if got := deriveChallengeType(result, nil); got != "" {
+		t.Fatalf("deriveChallengeType(nil page) = %q, want empty string", got)
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			gotNeeded, gotReason := deriveHumanHandoff(tt.result)
-			if gotNeeded != tt.wantNeeded || gotReason != tt.wantReason {
-				t.Fatalf("deriveHumanHandoff() = (%v, %q), want (%v, %q)", gotNeeded, gotReason, tt.wantNeeded, tt.wantReason)
-			}
-		})
-	}
-}
-
-func TestHandleSolve_AndTabSolve_IncludeHandoffFields(t *testing.T) {
-	name := "test-handoff-static"
-	if err := solver.Register(name, &testStaticSolver{
-		name: name,
-		result: &solver.Result{
-			Solver:        name,
-			Solved:        false,
-			ChallengeType: "turnstile",
-			Attempts:      1,
-			Title:         "Just a moment...",
-		},
-	}); err != nil {
-		t.Fatalf("register test solver: %v", err)
-	}
-	t.Cleanup(func() { solver.Unregister(name) })
-
-	h := New(&mockBridge{}, &config.RuntimeConfig{}, nil, nil, nil)
-
-	t.Run("solve route", func(t *testing.T) {
-		body := fmt.Sprintf(`{"solver": %q, "maxAttempts": 1}`, name)
-		req := httptest.NewRequest("POST", "/solve", bytes.NewReader([]byte(body)))
-		w := httptest.NewRecorder()
-		h.HandleSolve(w, req)
-
-		if w.Code != 200 {
-			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-		}
-
-		var resp map[string]any
-		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-			t.Fatalf("decode response: %v", err)
-		}
-
-		if _, ok := resp["needsHumanHandoff"]; !ok {
-			t.Fatalf("expected needsHumanHandoff field in response: %#v", resp)
-		}
-		if _, ok := resp["handoffReason"]; !ok {
-			t.Fatalf("expected handoffReason field in response: %#v", resp)
-		}
-		if needed, _ := resp["needsHumanHandoff"].(bool); !needed {
-			t.Fatalf("expected needsHumanHandoff=true, got: %#v", resp["needsHumanHandoff"])
-		}
-		if reason, _ := resp["handoffReason"].(string); reason != "challenge_requires_manual_intervention" {
-			t.Fatalf("expected handoffReason=challenge_requires_manual_intervention, got: %#v", resp["handoffReason"])
-		}
-	})
-
-	t.Run("tab solve route", func(t *testing.T) {
-		mux := http.NewServeMux()
-		h.RegisterRoutes(mux, nil)
-
-		body := fmt.Sprintf(`{"solver": %q, "maxAttempts": 1}`, name)
-		req := httptest.NewRequest("POST", "/tabs/tab1/solve", bytes.NewReader([]byte(body)))
-		w := httptest.NewRecorder()
-		mux.ServeHTTP(w, req)
-
-		if w.Code != 200 {
-			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-		}
-
-		var resp map[string]any
-		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-			t.Fatalf("decode response: %v", err)
-		}
-
-		if _, ok := resp["needsHumanHandoff"]; !ok {
-			t.Fatalf("expected needsHumanHandoff field in response: %#v", resp)
-		}
-		if _, ok := resp["handoffReason"]; !ok {
-			t.Fatalf("expected handoffReason field in response: %#v", resp)
-		}
-	})
 }

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -71,6 +71,11 @@ var coreEndpoints = []Endpoint{
 	{"POST", "/lock", "Lock tab", CapNone, true},
 	{"POST", "/unlock", "Unlock tab", CapNone, true},
 
+	// Human handoff
+	{"POST", "/handoff", "Pause tab for human handoff", CapNone, true},
+	{"POST", "/resume", "Resume paused tab", CapNone, true},
+	{"GET", "/handoff", "Get handoff status", CapNone, true},
+
 	// Cookies
 	{"GET", "/cookies", "Get cookies", CapNone, true},
 	{"POST", "/cookies", "Set cookies", CapNone, true},

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -71,11 +71,6 @@ var coreEndpoints = []Endpoint{
 	{"POST", "/lock", "Lock tab", CapNone, true},
 	{"POST", "/unlock", "Unlock tab", CapNone, true},
 
-	// Human handoff
-	{"POST", "/handoff", "Pause tab for human handoff", CapNone, true},
-	{"POST", "/resume", "Resume paused tab", CapNone, true},
-	{"GET", "/handoff", "Get handoff status", CapNone, true},
-
 	// Cookies
 	{"GET", "/cookies", "Get cookies", CapNone, true},
 	{"POST", "/cookies", "Set cookies", CapNone, true},
@@ -109,6 +104,7 @@ var coreEndpoints = []Endpoint{
 
 	// Solvers
 	{"GET", "/solvers", "List available solvers", CapNone, false},
+	{"GET", "/config/autosolver", "Get autosolver runtime config", CapNone, false},
 	{"POST", "/solve", "Run default solver", CapNone, true},
 	{"POST", "/solve/{name}", "Run named solver", CapNone, true},
 

--- a/skills/pinchtab/references/commands.md
+++ b/skills/pinchtab/references/commands.md
@@ -6,14 +6,24 @@
 
 ## Control Plane
 
-### `pinchtab start`
+### `pinchtab server`
 Start the PinchTab server (default port 9867).
 
 ```bash
-pinchtab start
-pinchtab start --port 9868
-pinchtab start --profile work --headless
+pinchtab server
+pinchtab server -y              # guards down (enables evaluate, macro, download)
+pinchtab server -H              # visible browser for debugging
+pinchtab server -yH             # both combined
+pinchtab server -e ./ext        # load browser extension
 ```
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--yolo` | `-y` | Apply guards down preset (enables evaluate, macro, download) |
+| `--headed` | `-H` | Start browser in headed (visible) mode |
+| `--extension <path>` | `-e` | Load browser extension (repeatable) |
+
+> **Note:** Use `--headed` only when you need visual feedback (debugging, watching automation). Headless mode is more resource-efficient.
 
 ### `pinchtab stop`
 Stop the running server.

--- a/tests/e2e/helpers/api-assertions.sh
+++ b/tests/e2e/helpers/api-assertions.sh
@@ -119,6 +119,20 @@ assert_contains() {
   fi
 }
 
+assert_not_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local desc="${3:-does not contain '$needle'}"
+
+  if echo "$haystack" | grep -q "$needle"; then
+    echo -e "  ${RED}✗${NC} $desc (found when should be absent)"
+    ((ASSERTIONS_FAILED++)) || true
+  else
+    echo -e "  ${GREEN}✓${NC} $desc"
+    ((ASSERTIONS_PASSED++)) || true
+  fi
+}
+
 assert_result_eq() {
   local path="$1"
   local expected="$2"


### PR DESCRIPTION
## Summary
- add a dedicated challenge detection layer and a new `jschallenge` solver
- expand the autosolver pipeline and handler integration so challenge solving can auto-trigger after navigation/actions and surface human-handoff signals when needed
- add autosolver config for trigger behavior, timeout, and retry settings with validation and test coverage
- expose the expanded autosolver settings in the dashboard and update autosolver architecture/config/solve docs accordingly

## Why
The older upstream-sync branch had accumulated a lot of unrelated history that is already in main or superseded elsewhere. This branch carries forward the remaining autosolver-specific value in a cleaner shape on top of current main.

## Notes
- This supersedes the autosolver portion of #488.

## Validation
- `go test ./...`
