### PR TITLE
chore(autosolver): move semantic credentials into config flow

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -278,18 +278,32 @@ Current nested file-config shape:
 `autoSolver.external` is config-file-only. Capsolver and 2Captcha credentials
 are stored there.
 
-### Semantic Flow Environment Variables
+### Semantic Flow Credentials
 
-The semantic-first autosolver flow can consume optional environment variables
-for login/signup/form-filling steps:
+The semantic-first autosolver flow injects credential values into recognised
+login/signup/form fields. Configure them under `autoSolver.credentials` in
+the config file:
 
-- `PINCHTAB_AUTOSOLVER_LOGIN_USER` or `PINCHTAB_AUTOSOLVER_LOGIN_EMAIL`: login username/email value
-- `PINCHTAB_AUTOSOLVER_LOGIN_PASS` or `PINCHTAB_AUTOSOLVER_LOGIN_PASSWORD`: login password value
-- `PINCHTAB_AUTOSOLVER_SIGNUP_NAME`: signup full-name value
-- `PINCHTAB_AUTOSOLVER_SIGNUP_EMAIL`: signup email value
-- `PINCHTAB_AUTOSOLVER_SIGNUP_PASSWORD`: signup password value
-- `PINCHTAB_AUTOSOLVER_FORM_FIELD1`: generic form field value (step 1)
-- `PINCHTAB_AUTOSOLVER_FORM_FIELD2` or `PINCHTAB_AUTOSOLVER_FORM_EMAIL`: generic form field/email value (step 2)
+```json
+{
+  "autoSolver": {
+    "credentials": {
+      "login":  { "user": "you@example.com", "password": "..." },
+      "signup": { "name": "Jane Doe", "email": "you@example.com", "password": "..." },
+      "form":   { "field1": "...", "field2": "...", "email": "you@example.com" }
+    }
+  }
+}
+```
+
+Notes:
+
+- Edit credentials by writing the config file directly. The dashboard config API
+  redacts them on read (GET returns blanks) and preserves on-disk values when a
+  PUT comes in with empty fields, so secrets never round-trip through the UI.
+- The form solver step 2 falls back to `form.email` when `form.field2` is empty.
+- Steps without a configured value fall through to a click-only flow (e.g. a
+  login attempt with no password becomes a "click submit" attempt).
 
 The dashboard Settings page exposes the non-secret AutoSolver settings and
 shows the active config file path. Provider keys remain managed directly in the

--- a/internal/autosolver/autosolver.go
+++ b/internal/autosolver/autosolver.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"os"
 	"sort"
 	"time"
 )
@@ -412,9 +411,11 @@ func (as *AutoSolver) trySemantic(ctx context.Context, page Page, executor Actio
 }
 
 type semanticFlowStep struct {
-	Query   string
-	Action  ActionType
-	EnvKeys []string
+	Query  string
+	Action ActionType
+	// Value is the credential the step injects into the matched element when
+	// Action == ActionType_. Empty means the step is just a click/wait.
+	Value string
 }
 
 func (as *AutoSolver) planSemanticAction(intent *Intent, step int, suggested *SuggestedAction) *SuggestedAction {
@@ -425,14 +426,14 @@ func (as *AutoSolver) planSemanticAction(intent *Intent, step int, suggested *Su
 	}
 
 	intentType := intentTypeOf(intent)
-	flowStep := semanticFlowStepForIntent(intentType, step)
+	flowStep := semanticFlowStepForIntent(intentType, step, as.config.Credentials)
 
 	if planned.Action == ActionNone || isHighLevelIntent(intentType) {
 		planned.Action = flowStep.Action
 	}
 
 	if planned.Text == "" && planned.Action == ActionType_ {
-		planned.Text = firstNonEmptyEnv(flowStep.EnvKeys...)
+		planned.Text = flowStep.Value
 	}
 
 	if planned.Reason == "" {
@@ -448,7 +449,7 @@ func (as *AutoSolver) prepareSemanticAction(ctx context.Context, page Page, inte
 	}
 
 	resolved := *action
-	flowStep := semanticFlowStepForIntent(intentTypeOf(intent), step)
+	flowStep := semanticFlowStepForIntent(intentTypeOf(intent), step, as.config.Credentials)
 
 	shouldResolveTarget := isHighLevelIntent(intentTypeOf(intent)) || actionNeedsTarget(&resolved)
 	if shouldResolveTarget {
@@ -472,7 +473,7 @@ func (as *AutoSolver) prepareSemanticAction(ctx context.Context, page Page, inte
 	}
 
 	if resolved.Action == ActionType_ && resolved.Text == "" {
-		resolved.Text = firstNonEmptyEnv(flowStep.EnvKeys...)
+		resolved.Text = flowStep.Value
 		if resolved.Text == "" {
 			resolved.Action = ActionClick
 		}
@@ -490,7 +491,7 @@ func (as *AutoSolver) selfHealSemanticAction(ctx context.Context, page Page, int
 		return nil, fmt.Errorf("nil action")
 	}
 
-	flowStep := semanticFlowStepForIntent(intentTypeOf(intent), step)
+	flowStep := semanticFlowStepForIntent(intentTypeOf(intent), step, as.config.Credentials)
 	match, err := as.semantic.FindElement(ctx, page, flowStep.Query)
 	if err != nil {
 		return nil, fmt.Errorf("semantic self-heal find query %q: %w", flowStep.Query, err)
@@ -511,7 +512,7 @@ func (as *AutoSolver) selfHealSemanticAction(ctx context.Context, page Page, int
 	}
 
 	if healed.Action == ActionType_ && healed.Text == "" {
-		healed.Text = firstNonEmptyEnv(flowStep.EnvKeys...)
+		healed.Text = flowStep.Value
 		if healed.Text == "" {
 			healed.Action = ActionClick
 		}
@@ -557,7 +558,7 @@ func semanticStepBudget(intentType IntentType) int {
 	}
 }
 
-func semanticFlowStepForIntent(intentType IntentType, step int) semanticFlowStep {
+func semanticFlowStepForIntent(intentType IntentType, step int, creds Credentials) semanticFlowStep {
 	steps := []semanticFlowStep{{Query: "primary continue submit button", Action: ActionClick}}
 
 	switch intentType {
@@ -573,21 +574,21 @@ func semanticFlowStepForIntent(intentType IntentType, step int) semanticFlowStep
 		}
 	case IntentLogin:
 		steps = []semanticFlowStep{
-			{Query: "username email input field", Action: ActionType_, EnvKeys: []string{"PINCHTAB_AUTOSOLVER_LOGIN_USER", "PINCHTAB_AUTOSOLVER_LOGIN_EMAIL"}},
-			{Query: "password input field", Action: ActionType_, EnvKeys: []string{"PINCHTAB_AUTOSOLVER_LOGIN_PASS", "PINCHTAB_AUTOSOLVER_LOGIN_PASSWORD"}},
+			{Query: "username email input field", Action: ActionType_, Value: creds.Login.User},
+			{Query: "password input field", Action: ActionType_, Value: creds.Login.Password},
 			{Query: "login submit sign in button", Action: ActionClick},
 		}
 	case IntentSignup:
 		steps = []semanticFlowStep{
-			{Query: "name full name input field", Action: ActionType_, EnvKeys: []string{"PINCHTAB_AUTOSOLVER_SIGNUP_NAME"}},
-			{Query: "email input field", Action: ActionType_, EnvKeys: []string{"PINCHTAB_AUTOSOLVER_SIGNUP_EMAIL"}},
-			{Query: "password create password input field", Action: ActionType_, EnvKeys: []string{"PINCHTAB_AUTOSOLVER_SIGNUP_PASSWORD"}},
+			{Query: "name full name input field", Action: ActionType_, Value: creds.Signup.Name},
+			{Query: "email input field", Action: ActionType_, Value: creds.Signup.Email},
+			{Query: "password create password input field", Action: ActionType_, Value: creds.Signup.Password},
 			{Query: "sign up register create account submit button", Action: ActionClick},
 		}
 	case IntentForm:
 		steps = []semanticFlowStep{
-			{Query: "first required input field", Action: ActionType_, EnvKeys: []string{"PINCHTAB_AUTOSOLVER_FORM_FIELD1"}},
-			{Query: "second required input field", Action: ActionType_, EnvKeys: []string{"PINCHTAB_AUTOSOLVER_FORM_FIELD2", "PINCHTAB_AUTOSOLVER_FORM_EMAIL"}},
+			{Query: "first required input field", Action: ActionType_, Value: creds.Form.Field1},
+			{Query: "second required input field", Action: ActionType_, Value: firstNonEmpty(creds.Form.Field2, creds.Form.Email)},
 			{Query: "primary submit button", Action: ActionClick},
 		}
 	case IntentOnboarding:
@@ -614,9 +615,9 @@ func semanticFlowStepForIntent(intentType IntentType, step int) semanticFlowStep
 	return steps[step]
 }
 
-func firstNonEmptyEnv(keys ...string) string {
-	for _, key := range keys {
-		if v := os.Getenv(key); v != "" {
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
 			return v
 		}
 	}

--- a/internal/autosolver/autosolver_test.go
+++ b/internal/autosolver/autosolver_test.go
@@ -294,11 +294,14 @@ func TestSolve_SemanticFirst_FailureFallsBackToRuleSolvers(t *testing.T) {
 }
 
 func TestSolve_SemanticHighLevel_LoginFlow(t *testing.T) {
-	t.Setenv("PINCHTAB_AUTOSOLVER_LOGIN_USER", "user@example.com")
-	t.Setenv("PINCHTAB_AUTOSOLVER_LOGIN_PASSWORD", "secret")
-
 	cfg := DefaultConfig()
 	cfg.MaxAttempts = 1
+	cfg.Credentials = Credentials{
+		Login: LoginCredentials{
+			User:     "user@example.com",
+			Password: "secret",
+		},
+	}
 
 	semantic := &mockSemantic{
 		detectSeq: []*Intent{

--- a/internal/autosolver/types.go
+++ b/internal/autosolver/types.go
@@ -115,6 +115,33 @@ type LLMResponse struct {
 	Confidence float64    `json:"confidence"`
 }
 
+// Credentials supplies values the semantic solver injects into recognised
+// login/signup/form fields. They live in pinchtab config (write-only,
+// redacted on dashboard read) and are passed through Config rather than
+// pulled from process env vars.
+type Credentials struct {
+	Login  LoginCredentials  `json:"login"`
+	Signup SignupCredentials `json:"signup"`
+	Form   FormCredentials   `json:"form"`
+}
+
+type LoginCredentials struct {
+	User     string `json:"user"`
+	Password string `json:"password"`
+}
+
+type SignupCredentials struct {
+	Name     string `json:"name"`
+	Email    string `json:"email"`
+	Password string `json:"password"`
+}
+
+type FormCredentials struct {
+	Field1 string `json:"field1"`
+	Field2 string `json:"field2"`
+	Email  string `json:"email"`
+}
+
 // Config holds autosolver runtime configuration.
 type Config struct {
 	Enabled        bool          `json:"enabled"`
@@ -124,6 +151,7 @@ type Config struct {
 	LLMFallback    bool          `json:"llmFallback"`    // Enable LLM as last resort
 	RetryBaseDelay time.Duration `json:"retryBaseDelay"` // Base delay for exponential backoff
 	RetryMaxDelay  time.Duration `json:"retryMaxDelay"`  // Cap for exponential backoff
+	Credentials    Credentials   `json:"-"`              // Never serialised: redacted secrets
 }
 
 // DefaultConfig returns a Config with sensible defaults.

--- a/internal/config/config_file.go
+++ b/internal/config/config_file.go
@@ -333,23 +333,47 @@ type dashboardSessionConfigJSON struct {
 }
 
 type autoSolverFileConfigJSON struct {
-	Enabled           *bool                   `json:"enabled,omitempty"`
-	AutoTrigger       *bool                   `json:"autoTrigger,omitempty"`
-	TriggerOnNavigate *bool                   `json:"triggerOnNavigate,omitempty"`
-	TriggerOnAction   *bool                   `json:"triggerOnAction,omitempty"`
-	MaxAttempts       *int                    `json:"maxAttempts,omitempty"`
-	SolverTimeoutSec  *int                    `json:"solverTimeoutSec,omitempty"`
-	RetryBaseDelayMs  *int                    `json:"retryBaseDelayMs,omitempty"`
-	RetryMaxDelayMs   *int                    `json:"retryMaxDelayMs,omitempty"`
-	Solvers           []string                `json:"solvers,omitempty"`
-	LLMProvider       string                  `json:"llmProvider,omitempty"`
-	LLMFallback       *bool                   `json:"llmFallback,omitempty"`
-	External          autoSolverExtConfigJSON `json:"external,omitempty"`
+	Enabled           *bool                           `json:"enabled,omitempty"`
+	AutoTrigger       *bool                           `json:"autoTrigger,omitempty"`
+	TriggerOnNavigate *bool                           `json:"triggerOnNavigate,omitempty"`
+	TriggerOnAction   *bool                           `json:"triggerOnAction,omitempty"`
+	MaxAttempts       *int                            `json:"maxAttempts,omitempty"`
+	SolverTimeoutSec  *int                            `json:"solverTimeoutSec,omitempty"`
+	RetryBaseDelayMs  *int                            `json:"retryBaseDelayMs,omitempty"`
+	RetryMaxDelayMs   *int                            `json:"retryMaxDelayMs,omitempty"`
+	Solvers           []string                        `json:"solvers,omitempty"`
+	LLMProvider       string                          `json:"llmProvider,omitempty"`
+	LLMFallback       *bool                           `json:"llmFallback,omitempty"`
+	External          autoSolverExtConfigJSON         `json:"external,omitempty"`
+	Credentials       autoSolverCredentialsConfigJSON `json:"credentials,omitempty"`
 }
 
 type autoSolverExtConfigJSON struct {
 	CapsolverKey  string `json:"capsolverKey,omitempty"`
 	TwoCaptchaKey string `json:"twoCaptchaKey,omitempty"`
+}
+
+type autoSolverCredentialsConfigJSON struct {
+	Login  autoSolverLoginConfigJSON  `json:"login,omitempty"`
+	Signup autoSolverSignupConfigJSON `json:"signup,omitempty"`
+	Form   autoSolverFormConfigJSON   `json:"form,omitempty"`
+}
+
+type autoSolverLoginConfigJSON struct {
+	User     string `json:"user,omitempty"`
+	Password string `json:"password,omitempty"`
+}
+
+type autoSolverSignupConfigJSON struct {
+	Name     string `json:"name,omitempty"`
+	Email    string `json:"email,omitempty"`
+	Password string `json:"password,omitempty"`
+}
+
+type autoSolverFormConfigJSON struct {
+	Field1 string `json:"field1,omitempty"`
+	Field2 string `json:"field2,omitempty"`
+	Email  string `json:"email,omitempty"`
 }
 
 func copyStringSlice(items []string) []string {
@@ -505,6 +529,22 @@ func (fc FileConfig) MarshalJSON() ([]byte, error) {
 			External: autoSolverExtConfigJSON{
 				CapsolverKey:  fc.AutoSolver.External.CapsolverKey,
 				TwoCaptchaKey: fc.AutoSolver.External.TwoCaptchaKey,
+			},
+			Credentials: autoSolverCredentialsConfigJSON{
+				Login: autoSolverLoginConfigJSON{
+					User:     fc.AutoSolver.Credentials.Login.User,
+					Password: fc.AutoSolver.Credentials.Login.Password,
+				},
+				Signup: autoSolverSignupConfigJSON{
+					Name:     fc.AutoSolver.Credentials.Signup.Name,
+					Email:    fc.AutoSolver.Credentials.Signup.Email,
+					Password: fc.AutoSolver.Credentials.Signup.Password,
+				},
+				Form: autoSolverFormConfigJSON{
+					Field1: fc.AutoSolver.Credentials.Form.Field1,
+					Field2: fc.AutoSolver.Credentials.Form.Field2,
+					Email:  fc.AutoSolver.Credentials.Form.Email,
+				},
 			},
 		},
 	})
@@ -715,6 +755,22 @@ func FileConfigFromRuntime(cfg *RuntimeConfig) FileConfig {
 			External: AutoSolverExtConf{
 				CapsolverKey:  cfg.AutoSolver.CapsolverKey,
 				TwoCaptchaKey: cfg.AutoSolver.TwoCaptchaKey,
+			},
+			Credentials: AutoSolverCredentialsConf{
+				Login: AutoSolverLoginConf{
+					User:     cfg.AutoSolver.Credentials.Login.User,
+					Password: cfg.AutoSolver.Credentials.Login.Password,
+				},
+				Signup: AutoSolverSignupConf{
+					Name:     cfg.AutoSolver.Credentials.Signup.Name,
+					Email:    cfg.AutoSolver.Credentials.Signup.Email,
+					Password: cfg.AutoSolver.Credentials.Signup.Password,
+				},
+				Form: AutoSolverFormConf{
+					Field1: cfg.AutoSolver.Credentials.Form.Field1,
+					Field2: cfg.AutoSolver.Credentials.Form.Field2,
+					Email:  cfg.AutoSolver.Credentials.Form.Email,
+				},
 			},
 		},
 	}

--- a/internal/config/config_load.go
+++ b/internal/config/config_load.go
@@ -530,6 +530,22 @@ func applyFileConfig(cfg *RuntimeConfig, fc *FileConfig) {
 	}
 	cfg.AutoSolver.CapsolverKey = fc.AutoSolver.External.CapsolverKey
 	cfg.AutoSolver.TwoCaptchaKey = fc.AutoSolver.External.TwoCaptchaKey
+	cfg.AutoSolver.Credentials = AutoSolverCredentials{
+		Login: AutoSolverLoginCreds{
+			User:     fc.AutoSolver.Credentials.Login.User,
+			Password: fc.AutoSolver.Credentials.Login.Password,
+		},
+		Signup: AutoSolverSignupCreds{
+			Name:     fc.AutoSolver.Credentials.Signup.Name,
+			Email:    fc.AutoSolver.Credentials.Signup.Email,
+			Password: fc.AutoSolver.Credentials.Signup.Password,
+		},
+		Form: AutoSolverFormCreds{
+			Field1: fc.AutoSolver.Credentials.Form.Field1,
+			Field2: fc.AutoSolver.Credentials.Form.Field2,
+			Email:  fc.AutoSolver.Credentials.Form.Email,
+		},
+	}
 }
 
 // ApplyFileConfigToRuntime merges file configuration into an existing runtime

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -170,6 +170,33 @@ type AutoSolverConfig struct {
 	LLMFallback       bool     `json:"llmFallback,omitempty"` // Enable LLM as last resort
 	CapsolverKey      string   `json:"capsolverKey,omitempty"`
 	TwoCaptchaKey     string   `json:"twoCaptchaKey,omitempty"`
+	Credentials       AutoSolverCredentials
+}
+
+// AutoSolverCredentials carries values the semantic solver injects into
+// matched login/signup/form fields. Persisted to the config file but
+// redacted when read back through the dashboard config API.
+type AutoSolverCredentials struct {
+	Login  AutoSolverLoginCreds
+	Signup AutoSolverSignupCreds
+	Form   AutoSolverFormCreds
+}
+
+type AutoSolverLoginCreds struct {
+	User     string
+	Password string
+}
+
+type AutoSolverSignupCreds struct {
+	Name     string
+	Email    string
+	Password string
+}
+
+type AutoSolverFormCreds struct {
+	Field1 string
+	Field2 string
+	Email  string
 }
 
 type ObservabilityConfig struct {
@@ -359,22 +386,49 @@ type ActivityEventsFileConfig struct {
 
 // AutoSolverFileConfig is the persistent configuration for the autosolver system.
 type AutoSolverFileConfig struct {
-	Enabled           *bool             `json:"enabled,omitempty"`
-	AutoTrigger       *bool             `json:"autoTrigger,omitempty"`
-	TriggerOnNavigate *bool             `json:"triggerOnNavigate,omitempty"`
-	TriggerOnAction   *bool             `json:"triggerOnAction,omitempty"`
-	MaxAttempts       *int              `json:"maxAttempts,omitempty"`
-	SolverTimeoutSec  *int              `json:"solverTimeoutSec,omitempty"`
-	RetryBaseDelayMs  *int              `json:"retryBaseDelayMs,omitempty"`
-	RetryMaxDelayMs   *int              `json:"retryMaxDelayMs,omitempty"`
-	Solvers           []string          `json:"solvers,omitempty"`
-	LLMProvider       string            `json:"llmProvider,omitempty"`
-	LLMFallback       *bool             `json:"llmFallback,omitempty"`
-	External          AutoSolverExtConf `json:"external,omitempty"`
+	Enabled           *bool                     `json:"enabled,omitempty"`
+	AutoTrigger       *bool                     `json:"autoTrigger,omitempty"`
+	TriggerOnNavigate *bool                     `json:"triggerOnNavigate,omitempty"`
+	TriggerOnAction   *bool                     `json:"triggerOnAction,omitempty"`
+	MaxAttempts       *int                      `json:"maxAttempts,omitempty"`
+	SolverTimeoutSec  *int                      `json:"solverTimeoutSec,omitempty"`
+	RetryBaseDelayMs  *int                      `json:"retryBaseDelayMs,omitempty"`
+	RetryMaxDelayMs   *int                      `json:"retryMaxDelayMs,omitempty"`
+	Solvers           []string                  `json:"solvers,omitempty"`
+	LLMProvider       string                    `json:"llmProvider,omitempty"`
+	LLMFallback       *bool                     `json:"llmFallback,omitempty"`
+	External          AutoSolverExtConf         `json:"external,omitempty"`
+	Credentials       AutoSolverCredentialsConf `json:"credentials,omitempty"`
 }
 
 // AutoSolverExtConf holds external solver API keys.
 type AutoSolverExtConf struct {
 	CapsolverKey  string `json:"capsolverKey,omitempty"`
 	TwoCaptchaKey string `json:"twoCaptchaKey,omitempty"`
+}
+
+// AutoSolverCredentialsConf is the persisted form of the credentials block.
+// All fields are write-only from the dashboard's perspective: GET /api/config
+// returns them blanked, PUT preserves the on-disk values when blank.
+type AutoSolverCredentialsConf struct {
+	Login  AutoSolverLoginConf  `json:"login,omitempty"`
+	Signup AutoSolverSignupConf `json:"signup,omitempty"`
+	Form   AutoSolverFormConf   `json:"form,omitempty"`
+}
+
+type AutoSolverLoginConf struct {
+	User     string `json:"user,omitempty"`
+	Password string `json:"password,omitempty"`
+}
+
+type AutoSolverSignupConf struct {
+	Name     string `json:"name,omitempty"`
+	Email    string `json:"email,omitempty"`
+	Password string `json:"password,omitempty"`
+}
+
+type AutoSolverFormConf struct {
+	Field1 string `json:"field1,omitempty"`
+	Field2 string `json:"field2,omitempty"`
+	Email  string `json:"email,omitempty"`
 }

--- a/internal/dashboard/config_api.go
+++ b/internal/dashboard/config_api.go
@@ -273,6 +273,7 @@ func redactToken(cfg config.FileConfig) config.FileConfig {
 	cfg.Security.StateEncryptionKey = nil
 	cfg.AutoSolver.External.CapsolverKey = ""
 	cfg.AutoSolver.External.TwoCaptchaKey = ""
+	cfg.AutoSolver.Credentials = config.AutoSolverCredentialsConf{}
 	return cfg
 }
 
@@ -284,6 +285,31 @@ func preserveWriteOnlyConfigFields(dst, src *config.FileConfig) {
 	dst.Security.StateEncryptionKey = src.Security.StateEncryptionKey
 	dst.AutoSolver.External.CapsolverKey = src.AutoSolver.External.CapsolverKey
 	dst.AutoSolver.External.TwoCaptchaKey = src.AutoSolver.External.TwoCaptchaKey
+	// Credentials are write-only: when the dashboard PUTs config without a
+	// credential field (because GET redacted them), keep the value already
+	// on disk. Per-field so a deliberate set-to-blank still wins.
+	preserveCredString(&dst.AutoSolver.Credentials.Login.User, src.AutoSolver.Credentials.Login.User)
+	preserveCredString(&dst.AutoSolver.Credentials.Login.Password, src.AutoSolver.Credentials.Login.Password)
+	preserveCredString(&dst.AutoSolver.Credentials.Signup.Name, src.AutoSolver.Credentials.Signup.Name)
+	preserveCredString(&dst.AutoSolver.Credentials.Signup.Email, src.AutoSolver.Credentials.Signup.Email)
+	preserveCredString(&dst.AutoSolver.Credentials.Signup.Password, src.AutoSolver.Credentials.Signup.Password)
+	preserveCredString(&dst.AutoSolver.Credentials.Form.Field1, src.AutoSolver.Credentials.Form.Field1)
+	preserveCredString(&dst.AutoSolver.Credentials.Form.Field2, src.AutoSolver.Credentials.Form.Field2)
+	preserveCredString(&dst.AutoSolver.Credentials.Form.Email, src.AutoSolver.Credentials.Form.Email)
+}
+
+// preserveCredString keeps the existing src value when dst is empty (i.e. the
+// PUT didn't include this field because GET redacted it). A deliberate
+// blank from PUT is indistinguishable from "not provided" in JSON without
+// pointer types — given these are credentials, the safer default is to
+// preserve. Callers can clear by writing the JSON file directly.
+func preserveCredString(dst *string, src string) {
+	if dst == nil {
+		return
+	}
+	if *dst == "" {
+		*dst = src
+	}
 }
 
 func (c *ConfigAPI) restartReasonsFor(next config.FileConfig) []string {

--- a/internal/handlers/autosolver.go
+++ b/internal/handlers/autosolver.go
@@ -208,6 +208,23 @@ func (h *Handlers) normalizedAutoSolverConfig() coreautosolver.Config {
 		}
 	}
 	cfg.LLMFallback = h.Config.AutoSolver.LLMFallback
+	creds := h.Config.AutoSolver.Credentials
+	cfg.Credentials = coreautosolver.Credentials{
+		Login: coreautosolver.LoginCredentials{
+			User:     creds.Login.User,
+			Password: creds.Login.Password,
+		},
+		Signup: coreautosolver.SignupCredentials{
+			Name:     creds.Signup.Name,
+			Email:    creds.Signup.Email,
+			Password: creds.Signup.Password,
+		},
+		Form: coreautosolver.FormCredentials{
+			Field1: creds.Form.Field1,
+			Field2: creds.Form.Field2,
+			Email:  creds.Form.Email,
+		},
+	}
 
 	return cfg
 }


### PR DESCRIPTION
## Summary
- move semantic autosolver credentials into the regular config model instead of relying on an awkward env-only path
- update config load/types/file handling so the semantic autosolver settings are represented explicitly and persist correctly
- preserve dashboard config API secret-handling behavior while exposing the new autosolver config surface where appropriate
- refresh autosolver/config docs to explain the new configuration path

## Why
The autosolver feature set has grown enough that semantic-flow credentials and related settings should live in the same config path as the rest of autosolver instead of feeling like a separate hidden channel. This follow-up makes that configuration more explicit and maintainable.

## Validation
- `go test ./...`
