### PR TITLE
test: move slow e2e checks to smoke and trim fixed waits

### DIFF
--- a/tests/e2e/helpers/api-actions.sh
+++ b/tests/e2e/helpers/api-actions.sh
@@ -36,21 +36,21 @@ action_click_humanized() {
   assert_ok "humanized click ref=$ref"
 }
 
-# Humanized type by ref (character-by-character key events).
+# Humanized type by ref (character-by-character key events with shorter E2E delay).
 # Usage: action_type_humanized "$ref" "hello"
 action_type_humanized() {
   local ref="$1"
   local text="$2"
-  pt_post /action -d "{\"kind\":\"type\",\"ref\":\"$ref\",\"text\":\"$text\",\"humanize\":true}" > /dev/null
+  pt_post /action -d "{\"kind\":\"type\",\"ref\":\"$ref\",\"text\":\"$text\",\"humanize\":true,\"fast\":true}" > /dev/null
   assert_ok "humanized type '$text' into ref=$ref"
 }
 
-# Humanized type by CSS selector.
+# Humanized type by CSS selector (character-by-character key events with shorter E2E delay).
 # Usage: action_type_humanized_selector "#email" "hello"
 action_type_humanized_selector() {
   local selector="$1"
   local text="$2"
-  pt_post /action -d "{\"kind\":\"type\",\"selector\":\"$selector\",\"text\":\"$text\",\"humanize\":true}" > /dev/null
+  pt_post /action -d "{\"kind\":\"type\",\"selector\":\"$selector\",\"text\":\"$text\",\"humanize\":true,\"fast\":true}" > /dev/null
   assert_ok "humanized type '$text' into $selector"
 }
 

--- a/tests/e2e/scenarios/api/actions-extended.sh
+++ b/tests/e2e/scenarios/api/actions-extended.sh
@@ -188,7 +188,7 @@ end_test
 # ─────────────────────────────────────────────────────────────────
 start_test "fill: textarea by ref"
 
-navigate_fixture "text-fields.html"
+navigate_fixture "text-fields.html" 0
 fresh_snapshot
 
 require_ref "textbox" "Notes" NOTES_REF && {
@@ -205,7 +205,7 @@ end_test
 # ─────────────────────────────────────────────────────────────────
 start_test "type: textarea by ref"
 
-navigate_fixture "text-fields.html"
+navigate_fixture "text-fields.html" 0
 fresh_snapshot
 
 require_ref "textbox" "Notes" NOTES_REF && {
@@ -221,7 +221,7 @@ end_test
 # ─────────────────────────────────────────────────────────────────
 start_test "iframe: snapshot refs support fill and click inside iframe"
 
-navigate_fixture "iframe.html"
+navigate_fixture "iframe.html" 0
 fresh_snapshot
 
 assert_json_exists "$RESULT" '.nodes[] | select(.name == "payment-frame")' "snapshot includes iframe owner"
@@ -244,7 +244,7 @@ end_test
 # ─────────────────────────────────────────────────────────────────
 start_test "iframe: frame-scoped selectors support focus hover select check scroll and click"
 
-navigate_fixture "iframe.html"
+navigate_fixture "iframe.html" 0
 fresh_snapshot
 
 pt_get "/snapshot?filter=interactive&selector=%23card-number"
@@ -320,7 +320,7 @@ end_test
 # ─────────────────────────────────────────────────────────────────
 start_test "iframe: nested frames require explicit frame hops"
 
-navigate_fixture "nested-iframe.html"
+navigate_fixture "nested-iframe.html" 0
 fresh_snapshot
 
 pt_get "/snapshot?filter=interactive&selector=%23nested-code"
@@ -358,7 +358,7 @@ end_test
 # ─────────────────────────────────────────────────────────────────
 start_test "iframe: srcdoc frame-scoped selectors work"
 
-navigate_fixture "srcdoc-iframe.html"
+navigate_fixture "srcdoc-iframe.html" 0
 fresh_snapshot
 
 pt_post /frame -d '{"target":"#srcdoc-payment-frame"}'
@@ -392,14 +392,14 @@ end_test
 # ─────────────────────────────────────────────────────────────────
 start_test "iframe: stale refs after rerender require a fresh snapshot"
 
-navigate_fixture "iframe-rerender.html"
+navigate_fixture "iframe-rerender.html" 0
 fresh_snapshot
 
 require_ref "textbox" "Legacy field" LEGACY_REF && {
   pt_post /evaluate -d '{"expression":"window.replaceTestFrame()"}'
   assert_ok "trigger iframe rerender"
 
-  sleep 1
+  assert_eval_poll '(() => { const frame = document.getElementById("live-frame"); const doc = frame && frame.contentDocument; return !!(doc && doc.getElementById("fresh-field")); })()' "true" "fresh iframe loaded after rerender" 10 0.05
 
   pt_post /action -d "{\"kind\":\"fill\",\"ref\":\"${LEGACY_REF}\",\"text\":\"stale\"}"
   assert_not_ok "stale iframe ref rejected after rerender"
@@ -426,7 +426,7 @@ end_test
 # ─────────────────────────────────────────────────────────────────
 start_test "iframe: cross-origin selector scope is not claimed as supported"
 
-navigate_fixture "cross-origin-iframe.html"
+navigate_fixture "cross-origin-iframe.html" 0
 fresh_snapshot
 
 pt_post /frame -d '{"target":"#cross-origin-frame"}'

--- a/tests/e2e/scenarios/api/tabs-autoclose-smoke.sh
+++ b/tests/e2e/scenarios/api/tabs-autoclose-smoke.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# tabs-autoclose-extended.sh — verifies the auto-close-after-use lifecycle policy.
+# tabs-autoclose-smoke.sh — verifies the auto-close-after-use lifecycle policy.
 #
 # Requires the server to be started with tests/e2e/config/pinchtab-autoclose.json
 # (lifecycle=close_idle, closeDelaySec=1). The default e2e config uses the

--- a/tests/e2e/scenarios/cli/tabs-extended.sh
+++ b/tests/e2e/scenarios/cli/tabs-extended.sh
@@ -8,8 +8,13 @@ source "${GROUP_DIR}/../../helpers/cli.sh"
 start_test "pinchtab back (no history)"
 
 pt_ok back
-# Terse mode outputs just the URL (or "OK" if no URL)
-assert_output_contains "http" "back returns URL or OK"
+# Terse mode outputs the current URL (or "OK" if no URL).
+if [[ "$PT_OUT" == *"://"* ]] || [[ "$PT_OUT" == *"OK"* ]]; then
+  pass_assert "back returns URL or OK"
+else
+  fail_assert "back returns URL or OK"
+  echo -e "  ${RED}  output was: $PT_OUT${NC}"
+fi
 
 end_test
 
@@ -88,48 +93,13 @@ pt_fail tab close "nonexistent_tab_id_12345"
 
 end_test
 
-MAX_TABS=10
-
-# ─────────────────────────────────────────────────────────────────
-start_test "tab eviction: open tabs up to limit"
-
-TAB_IDS=()
-for i in $(seq 1 $MAX_TABS); do
-  pt_ok nav --new-tab "${FIXTURES_URL}/index.html?t=$i"
-  TAB_IDS+=($(echo "$PT_OUT" | tr -d '[:space:]'))
-done
-
-pt_ok tab --json
-TAB_COUNT=$(echo "$PT_OUT" | jq '.tabs | length')
-if [ "$TAB_COUNT" -ge "$MAX_TABS" ]; then
-  echo -e "  ${GREEN}✓${NC} $TAB_COUNT tabs open (>= $MAX_TABS)"
-  ((ASSERTIONS_PASSED++)) || true
-else
-  echo -e "  ${RED}✗${NC} expected >= $MAX_TABS tabs, got $TAB_COUNT"
-  ((ASSERTIONS_FAILED++)) || true
-fi
-
-end_test
-
-# ─────────────────────────────────────────────────────────────────
-start_test "tab eviction: new tab evicts oldest"
-
-FIRST_TAB="${TAB_IDS[0]}"
-sleep 0.1
-pt_ok nav --new-tab "${FIXTURES_URL}/index.html?t=overflow"
-
-pt_ok tab
-assert_output_not_contains "$FIRST_TAB" "oldest tab evicted (LRU)"
-
-end_test
-
 # ─────────────────────────────────────────────────────────────────
 # Human Handoff CLI Tests
 # ─────────────────────────────────────────────────────────────────
 
 start_test "tab handoff: pause and check status"
 
-pt_ok nav "${FIXTURES_URL}/buttons.html"
+pt_ok nav --new-tab "${FIXTURES_URL}/buttons.html"
 HANDOFF_TAB=$(echo "$PT_OUT" | tr -d '[:space:]')
 
 pt_ok tab handoff "$HANDOFF_TAB" --reason "cli_test"
@@ -154,7 +124,7 @@ end_test
 # ─────────────────────────────────────────────────────────────────
 start_test "tab handoff: --json flag returns raw JSON"
 
-pt_ok nav "${FIXTURES_URL}/buttons.html"
+pt_ok nav --new-tab "${FIXTURES_URL}/buttons.html"
 JSON_TAB=$(echo "$PT_OUT" | tr -d '[:space:]')
 
 pt_ok tab handoff "$JSON_TAB" --reason "json_test" --json
@@ -172,7 +142,7 @@ end_test
 # ─────────────────────────────────────────────────────────────────
 start_test "tab handoff: actions blocked while paused"
 
-pt_ok nav "${FIXTURES_URL}/buttons.html"
+pt_ok nav --new-tab "${FIXTURES_URL}/buttons.html"
 BLOCK_TAB=$(echo "$PT_OUT" | tr -d '[:space:]')
 
 pt_ok tab handoff "$BLOCK_TAB" --reason "block_test"

--- a/tests/e2e/scenarios/cli/tabs-smoke.sh
+++ b/tests/e2e/scenarios/cli/tabs-smoke.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# tabs-smoke.sh — slower CLI tab lifecycle smoke scenarios.
+
+GROUP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${GROUP_DIR}/../../helpers/cli.sh"
+
+MAX_TABS=10
+
+# ─────────────────────────────────────────────────────────────────
+start_test "tab eviction: open tabs up to limit"
+
+if ! wait_for_instance_ready "$E2E_SERVER" 30; then
+  fail_assert "instance ready before tab eviction"
+  TAB_IDS=()
+  end_test
+  return 0 2>/dev/null || exit 0
+fi
+
+TAB_IDS=()
+for i in $(seq 1 $MAX_TABS); do
+  pt_ok nav --new-tab "${FIXTURES_URL}/index.html?t=$i"
+  if [ "$PT_CODE" -eq 0 ]; then
+    TAB_IDS+=($(echo "$PT_OUT" | tr -d '[:space:]'))
+  fi
+done
+
+pt_ok tab --json
+TAB_COUNT=$(echo "$PT_OUT" | jq '.tabs | length')
+if [ "$TAB_COUNT" -ge "$MAX_TABS" ]; then
+  echo -e "  ${GREEN}✓${NC} $TAB_COUNT tabs open (>= $MAX_TABS)"
+  ((ASSERTIONS_PASSED++)) || true
+else
+  echo -e "  ${RED}✗${NC} expected >= $MAX_TABS tabs, got $TAB_COUNT"
+  ((ASSERTIONS_FAILED++)) || true
+fi
+
+end_test
+
+# ─────────────────────────────────────────────────────────────────
+start_test "tab eviction: new tab evicts oldest"
+
+if [ "${#TAB_IDS[@]}" -eq 0 ]; then
+  skip_assert "no tabs opened, skipping eviction assertion"
+  end_test
+  return 0 2>/dev/null || exit 0
+fi
+
+FIRST_TAB="${TAB_IDS[0]}"
+sleep 0.1
+pt_ok nav --new-tab "${FIXTURES_URL}/index.html?t=overflow"
+
+pt_ok tab
+assert_output_not_contains "$FIRST_TAB" "oldest tab evicted (LRU)"
+
+end_test

--- a/tests/e2e/scenarios/manifest.json
+++ b/tests/e2e/scenarios/manifest.json
@@ -17,10 +17,10 @@
       "ready": ["E2E_SERVER", "E2E_SECURE_SERVER"],
       "tags": ["tabs", "secure", "handoff"]
     },
-    "api/tabs-autoclose-extended.sh": {
+    "api/tabs-autoclose-smoke.sh": {
       "services": ["pinchtab", "pinchtab-autoclose", "fixtures"],
       "ready": ["E2E_SERVER", "E2E_AUTOCLOSE_SERVER"],
-      "tags": ["tabs", "autoclose", "lifecycle"]
+      "tags": ["tabs", "autoclose", "lifecycle", "smoke"]
     },
     "cli/actions-basic.sh": {
       "tags": ["actions", "pr"]
@@ -30,6 +30,9 @@
     },
     "cli/system-smoke.sh": {
       "tags": ["system", "lifecycle", "instance", "smoke"]
+    },
+    "cli/tabs-smoke.sh": {
+      "tags": ["tabs", "eviction", "smoke"]
     },
     "infra/auth-extended.sh": {
       "services": ["pinchtab", "pinchtab-full", "fixtures"],

--- a/tests/tools/runner/internal/e2e/e2e_test.go
+++ b/tests/tools/runner/internal/e2e/e2e_test.go
@@ -53,9 +53,9 @@ func TestDryRunExtendedPlan(t *testing.T) {
 	out := stdout.String()
 	for _, want := range []string{
 		"suite:  extended",
-		"docker compose -f tests/e2e/docker-compose-multi.yml up -d pinchtab pinchtab-secure pinchtab-autoclose pinchtab-medium pinchtab-full pinchtab-lite pinchtab-bridge fixtures",
+		"docker compose -f tests/e2e/docker-compose-multi.yml up -d pinchtab pinchtab-secure pinchtab-medium pinchtab-full pinchtab-lite pinchtab-bridge fixtures",
 		"run --rm --no-deps",
-		"E2E_READY_TARGETS=E2E_SERVER E2E_SECURE_SERVER E2E_AUTOCLOSE_SERVER",
+		"E2E_READY_TARGETS=E2E_SERVER E2E_SECURE_SERVER",
 		"E2E_SUMMARY_TITLE=PinchTab E2E API Extended Suite",
 		"runner-api /bin/bash /e2e/run.sh scenario=actions-basic.sh",
 		"scenario=actions-extended.sh",
@@ -504,11 +504,13 @@ func TestDryRunSmokePlan(t *testing.T) {
 	out := stdout.String()
 	for _, want := range []string{
 		"suite:  smoke",
-		`Skipping api-smoke: filter "" has no matching scenarios`,
 		`Skipping plugin-smoke: filter "" has no matching scenarios`,
-		"docker compose -f tests/e2e/docker-compose-multi.yml up -d pinchtab pinchtab-secure pinchtab-medium pinchtab-full fixtures",
+		"docker compose -f tests/e2e/docker-compose-multi.yml up -d pinchtab pinchtab-secure pinchtab-autoclose pinchtab-medium pinchtab-full fixtures",
+		"E2E_SUMMARY_TITLE=PinchTab E2E API Smoke Suite",
+		"runner-api /bin/bash /e2e/run.sh scenario=tabs-autoclose-smoke.sh",
 		"E2E_SUMMARY_TITLE=PinchTab E2E CLI Smoke Suite",
-		"runner-cli /bin/bash /e2e/run.sh scenario=system-smoke.sh",
+		"runner-cli /bin/bash /e2e/run.sh scenario=system-smoke.sh scenario=tabs-smoke.sh",
+		"docker compose -f tests/e2e/docker-compose-multi.yml restart pinchtab",
 		"E2E_SUMMARY_TITLE=PinchTab E2E Infra Smoke Suite",
 		"runner-api /bin/bash /e2e/run.sh scenario=autosolver-smoke.sh scenario=dashboard-smoke.sh scenario=orchestrator-smoke.sh scenario=security-smoke.sh",
 		"== E2E Docker Smoke tests (host) ==",

--- a/tests/tools/runner/internal/e2e/runner.go
+++ b/tests/tools/runner/internal/e2e/runner.go
@@ -295,9 +295,14 @@ func (r *Runner) runSmoke() int {
 			return code
 		}
 
-		for _, plan := range plans {
+		for i, plan := range plans {
 			if code := r.runSinglePlanWithCompose(plan, stack); code != 0 {
 				failed = true
+			}
+			if plan.def.Name == "cli-smoke" && i < len(plans)-1 {
+				if code := r.restartSharedStack(stack, []string{"pinchtab"}); code != 0 {
+					failed = true
+				}
 			}
 			_, _ = fmt.Fprintln(r.stdout, "")
 		}


### PR DESCRIPTION
## Summary
- move slow timing-sensitive E2E checks out of the extended lane and into smoke
- split CLI tab eviction coverage into a dedicated smoke scenario
- move API auto-close lifecycle coverage from extended to smoke
- trim a few fixed waits in action helpers and extended scenarios
- update manifest metadata and runner tests to match the new suite placement

## Why
Some lifecycle and eviction checks are legitimate coverage, but they are a poor fit for the regular extended path because they depend on timers and slower state transitions. This keeps the coverage while making the normal E2E path tighter and less draggy.

## Notes
- tab eviction and auto-close behavior remain covered, just in the smoke lane where they belong
- runner/manifest expectations were updated alongside the scenario moves
- this branch is intentionally test-infra only; no product behavior changes

## Validation
- scenario files updated for the new suite split
- manifest updated for smoke tagging/services
- runner tests adjusted to reflect the suite planning changes
