### PR TITLE
fix: tighten config and state file permissions

### DIFF
--- a/internal/config/fileio.go
+++ b/internal/config/fileio.go
@@ -5,7 +5,28 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 )
+
+// tightenConfigPerms best-effort enforces 0700 on the config directory and
+// 0600 on the config file. It is invoked from both the save path (to handle
+// pre-existing loose perms left by older versions) and the load path (to
+// proactively recover regardless of whether the user mutates anything).
+// Failures are intentionally swallowed: chmod can fail on read-only FS,
+// foreign-owned files, or filesystems that don't honor unix perms, none of
+// which should block reading config.
+func tightenConfigPerms(path string) {
+	if runtime.GOOS == "windows" {
+		return
+	}
+	if fi, err := os.Stat(path); err == nil && fi.Mode().Perm() != 0600 {
+		_ = os.Chmod(path, 0600)
+	}
+	dir := filepath.Dir(path)
+	if fi, err := os.Stat(dir); err == nil && fi.Mode().Perm() != 0700 {
+		_ = os.Chmod(dir, 0700)
+	}
+}
 
 // LoadFileConfig loads a FileConfig from the default or specified path.
 // Returns the config and the path it was loaded from.
@@ -19,6 +40,8 @@ func LoadFileConfig() (*FileConfig, string, error) {
 		}
 		return nil, configPath, fmt.Errorf("failed to read config file: %w", err)
 	}
+
+	tightenConfigPerms(configPath)
 
 	if isLegacyConfig(data) {
 		fc, err := loadLegacyFileConfig(data)

--- a/internal/config/fileio.go
+++ b/internal/config/fileio.go
@@ -38,8 +38,12 @@ func LoadFileConfig() (*FileConfig, string, error) {
 
 // SaveFileConfig saves a FileConfig to the specified path.
 func SaveFileConfig(fc *FileConfig, path string) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0700); err != nil {
 		return fmt.Errorf("failed to create config directory: %w", err)
+	}
+	if err := os.Chmod(dir, 0700); err != nil {
+		return fmt.Errorf("failed to set config directory permissions: %w", err)
 	}
 
 	data, err := json.MarshalIndent(fc, "", "  ")
@@ -48,8 +52,11 @@ func SaveFileConfig(fc *FileConfig, path string) error {
 	}
 	data = append(data, '\n')
 
-	if err := os.WriteFile(path, data, 0644); err != nil {
+	if err := os.WriteFile(path, data, 0600); err != nil {
 		return fmt.Errorf("failed to write config file: %w", err)
+	}
+	if err := os.Chmod(path, 0600); err != nil {
+		return fmt.Errorf("failed to set config file permissions: %w", err)
 	}
 
 	return nil

--- a/internal/config/fileio_test.go
+++ b/internal/config/fileio_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -110,5 +111,91 @@ func TestLoadFileConfig_PromotesLegacyIDPIAllowedDomains(t *testing.T) {
 	}
 	if got := loaded.Security.AllowedDomains; len(got) != 2 || got[0] != "fixtures" || got[1] != "*.example.com" {
 		t.Fatalf("security.allowedDomains = %v, want promoted legacy values", got)
+	}
+}
+
+func TestSaveFileConfigSetsOwnerOnlyPermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix-only file mode semantics")
+	}
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "sub", "config.json")
+
+	fc := DefaultFileConfig()
+	if err := SaveFileConfig(&fc, configPath); err != nil {
+		t.Fatalf("SaveFileConfig() error = %v", err)
+	}
+
+	if fi, err := os.Stat(configPath); err != nil {
+		t.Fatalf("stat config: %v", err)
+	} else if got := fi.Mode().Perm(); got != 0600 {
+		t.Errorf("config.json mode = %o, want 0600", got)
+	}
+	if fi, err := os.Stat(filepath.Dir(configPath)); err != nil {
+		t.Fatalf("stat dir: %v", err)
+	} else if got := fi.Mode().Perm(); got != 0700 {
+		t.Errorf("config dir mode = %o, want 0700", got)
+	}
+}
+
+func TestSaveFileConfigTightensExistingLoosePermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix-only file mode semantics")
+	}
+	tmpDir := t.TempDir()
+	dir := filepath.Join(tmpDir, "loose")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	configPath := filepath.Join(dir, "config.json")
+	if err := os.WriteFile(configPath, []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	fc := DefaultFileConfig()
+	if err := SaveFileConfig(&fc, configPath); err != nil {
+		t.Fatalf("SaveFileConfig() error = %v", err)
+	}
+
+	if fi, err := os.Stat(configPath); err != nil {
+		t.Fatal(err)
+	} else if got := fi.Mode().Perm(); got != 0600 {
+		t.Errorf("config.json mode = %o, want 0600 after tightening", got)
+	}
+	if fi, err := os.Stat(dir); err != nil {
+		t.Fatal(err)
+	} else if got := fi.Mode().Perm(); got != 0700 {
+		t.Errorf("config dir mode = %o, want 0700 after tightening", got)
+	}
+}
+
+func TestLoadFileConfigTightensExistingLoosePermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix-only file mode semantics")
+	}
+	tmpDir := t.TempDir()
+	dir := filepath.Join(tmpDir, "loose")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	configPath := filepath.Join(dir, "config.json")
+	if err := os.WriteFile(configPath, []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("PINCHTAB_CONFIG", configPath)
+	if _, _, err := LoadFileConfig(); err != nil {
+		t.Fatalf("LoadFileConfig() error = %v", err)
+	}
+
+	if fi, err := os.Stat(configPath); err != nil {
+		t.Fatal(err)
+	} else if got := fi.Mode().Perm(); got != 0600 {
+		t.Errorf("config.json mode after load = %o, want 0600", got)
+	}
+	if fi, err := os.Stat(dir); err != nil {
+		t.Fatal(err)
+	} else if got := fi.Mode().Perm(); got != 0700 {
+		t.Errorf("config dir mode after load = %o, want 0700", got)
 	}
 }

--- a/internal/config/workflow/mutate.go
+++ b/internal/config/workflow/mutate.go
@@ -87,7 +87,7 @@ func UpdateValue(path, value string) (*config.RuntimeConfig, bool, error) {
 }
 
 func InitDefaultConfig(path string) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return fmt.Errorf("create config directory: %w", err)
 	}
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -340,8 +340,11 @@ func (o *Orchestrator) LaunchWithOptions(name, port string, headless bool, opts 
 		return nil, fmt.Errorf("create profile dir: %w", err)
 	}
 	instanceStateDir := filepath.Join(profilePath, ".pinchtab-state")
-	if err := os.MkdirAll(instanceStateDir, 0755); err != nil {
+	if err := os.MkdirAll(instanceStateDir, 0700); err != nil {
 		return nil, fmt.Errorf("create state dir: %w", err)
+	}
+	if err := os.Chmod(instanceStateDir, 0700); err != nil {
+		return nil, fmt.Errorf("set state dir permissions: %w", err)
 	}
 
 	requestedPolicy := cloneSecurityPolicy(opts.SecurityPolicy)
@@ -460,7 +463,10 @@ func (o *Orchestrator) writeChildConfig(port string, cdpPort int, profilePath, i
 	if err != nil {
 		return "", err
 	}
-	if err := os.WriteFile(configPath, data, 0644); err != nil {
+	if err := os.WriteFile(configPath, data, 0600); err != nil {
+		return "", err
+	}
+	if err := os.Chmod(configPath, 0600); err != nil {
 		return "", err
 	}
 	return configPath, nil


### PR DESCRIPTION
## Summary
- tighten config directories to owner-only permissions (`0700`)
- tighten config files and child config files to owner-only permissions (`0600`)
- tighten per-instance state directory permissions to owner-only
- recover old loose config permissions on load via best-effort chmod
- add tests covering secure create/write behavior and tightening of legacy loose permissions

## Why
PinchTab config and child config material can contain auth tokens, local runtime settings, and instance state configuration. Previous defaults were too loose for that kind of data. This changes the defaults to owner-only and also repairs older loose permissions when config is loaded.

## Notes
- load-time permission recovery is best-effort and intentionally non-fatal
- Windows skips the unix-style mode assertions in tests
- this is a small hardening fix; no product behavior change beyond safer filesystem defaults

## Validation
- tests for secure config file/directory creation
- tests for tightening existing loose permissions on save
- tests for tightening existing loose permissions on load
