### PR TITLE
feat: add cold-start test infrastructure and agent-friendly startup ergonomics

### DIFF
--- a/cmd/pinchtab/cmd_cli_register.go
+++ b/cmd/pinchtab/cmd_cli_register.go
@@ -1,9 +1,13 @@
 package main
 
 import (
+	"io"
+	"net"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/pinchtab/pinchtab/internal/bridge"
 	"github.com/spf13/cobra"
@@ -478,10 +482,16 @@ func defaultTabFlagFromState(cmd *cobra.Command) {
 	if flag == nil || flag.Changed || flag.Value.String() != "" {
 		return
 	}
-	if tabID := readTabStateFile(); tabID != "" {
-		_ = cmd.Flags().Set("tab", tabID)
-		flag.Changed = false
+	tabID := readTabStateFile()
+	if tabID == "" {
+		return
 	}
+	if !probeTabExists(tabID) {
+		_ = os.Remove(tabStateFile())
+		return
+	}
+	_ = cmd.Flags().Set("tab", tabID)
+	flag.Changed = false
 }
 
 func useLocalTabStateFile() bool {
@@ -528,6 +538,53 @@ func ClearTabStateFileIfCurrent(tabID string) {
 		return
 	}
 	_ = os.Remove(tabStateFile())
+}
+
+// probeTabExists checks whether a cached tab ID still exists on the server.
+// Returns true if the tab is valid, the server is unreachable (it may auto-start
+// later), or the check is inconclusive. Returns false only on a definitive 404.
+func probeTabExists(tabID string) bool {
+	base := resolveBaseURL("http://127.0.0.1:9867")
+	token := resolveToken()
+
+	// Fast path: if the port isn't listening, skip the HTTP probe entirely.
+	// This avoids a 2s timeout on every CLI command when the server is down.
+	if !portIsListening(base) {
+		return true
+	}
+
+	client := &http.Client{Timeout: 2 * time.Second}
+	req, err := http.NewRequest("GET", base+"/tabs/"+tabID+"/title", nil)
+	if err != nil {
+		return true
+	}
+	req.Header.Set("X-PinchTab-Source", "client")
+	if token != "" {
+		if strings.HasPrefix(token, "ses_") {
+			req.Header.Set("Authorization", "Session "+token)
+		} else {
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return true
+	}
+	defer func() { _ = resp.Body.Close() }()
+	_, _ = io.Copy(io.Discard, resp.Body)
+	return resp.StatusCode != http.StatusNotFound
+}
+
+// portIsListening does a fast TCP dial to check if anything is listening.
+func portIsListening(baseURL string) bool {
+	host := strings.TrimPrefix(baseURL, "http://")
+	host = strings.TrimPrefix(host, "https://")
+	conn, err := net.DialTimeout("tcp", host, 200*time.Millisecond)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
 }
 
 func addJSONFlag(cmds ...*cobra.Command) {

--- a/cmd/pinchtab/cmd_cli_runtime.go
+++ b/cmd/pinchtab/cmd_cli_runtime.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/pinchtab/pinchtab/internal/activity"
+	"github.com/pinchtab/pinchtab/internal/cli/output"
 	"github.com/pinchtab/pinchtab/internal/config"
 	"github.com/spf13/cobra"
 )
@@ -59,20 +60,41 @@ func newCLIHTTPClient(agentID string) *http.Client {
 }
 
 func resolveCLIBase(cfg *config.RuntimeConfig) string {
-	if serverURL != "" {
-		return strings.TrimRight(serverURL, "/")
+	defaultBase := resolveDefaultCLIBase(cfg)
+	resolved := resolveBaseURL(defaultBase)
+	if resolved == defaultBase {
+		if serverURL != "" {
+			output.Hint("--server " + resolved + " is the default and can be omitted")
+		} else if os.Getenv("PINCHTAB_SERVER") != "" {
+			output.Hint("PINCHTAB_SERVER=" + resolved + " is the default and can be omitted")
+		}
 	}
-	if envURL := os.Getenv("PINCHTAB_SERVER"); envURL != "" {
-		return strings.TrimRight(envURL, "/")
-	}
-	// Default to the main server port so requests go through the
-	// orchestrator. This ensures activity is recorded in the shared
-	// store and visible in the dashboard.
-	return resolveDefaultCLIBase(cfg)
+	return resolved
 }
 
 func resolveDefaultCLIBase(cfg *config.RuntimeConfig) string {
 	return fmt.Sprintf("http://127.0.0.1:%s", cfg.Port)
+}
+
+// resolveBaseURL returns the server base URL from flag/env/default.
+// Shared by both the full CLI runtime path and the lightweight tab probe.
+func resolveBaseURL(defaultBase string) string {
+	if serverURL != "" {
+		return strings.TrimRight(serverURL, "/")
+	}
+	if u := os.Getenv("PINCHTAB_SERVER"); u != "" {
+		return strings.TrimRight(u, "/")
+	}
+	return defaultBase
+}
+
+// resolveToken returns the auth token from env vars (session takes precedence).
+// Shared by both the full CLI runtime path and the lightweight tab probe.
+func resolveToken() string {
+	if s := os.Getenv("PINCHTAB_SESSION"); s != "" {
+		return s
+	}
+	return os.Getenv("PINCHTAB_TOKEN")
 }
 
 func canAutoStartServerForCLI(cfg *config.RuntimeConfig, baseURL string) bool {
@@ -83,14 +105,10 @@ func canAutoStartServerForCLI(cfg *config.RuntimeConfig, baseURL string) bool {
 }
 
 func resolveCLIToken(cfg *config.RuntimeConfig) string {
-	if sessionToken := os.Getenv("PINCHTAB_SESSION"); sessionToken != "" {
-		return sessionToken
+	if t := resolveToken(); t != "" {
+		return t
 	}
-	token := cfg.Token
-	if envToken := os.Getenv("PINCHTAB_TOKEN"); envToken != "" {
-		token = envToken
-	}
-	return token
+	return cfg.Token
 }
 
 func resolveCLIAgentID() string {

--- a/cmd/pinchtab/cmd_server.go
+++ b/cmd/pinchtab/cmd_server.go
@@ -33,6 +33,8 @@ var serverCmd = &cobra.Command{
 		if exts, _ := cmd.Flags().GetStringArray("extension"); len(exts) > 0 {
 			cfg.ExtensionPaths = append(cfg.ExtensionPaths, exts...)
 		}
+		verbose, _ := cmd.Flags().GetBool("verbose")
+		cfg.VerboseStartup = verbose
 		server.RunDashboard(cfg, version)
 	},
 }
@@ -42,5 +44,6 @@ func init() {
 	serverCmd.Flags().StringArrayP("extension", "e", nil, "Load browser extension (repeatable)")
 	serverCmd.Flags().BoolP("headed", "H", false, "Start default instance in headed mode")
 	serverCmd.Flags().BoolP("yolo", "y", false, "Apply guards down preset (enables evaluate, macro, download)")
+	serverCmd.Flags().BoolP("verbose", "v", false, "Show full startup banner and logs")
 	rootCmd.AddCommand(serverCmd)
 }

--- a/cmd/pinchtab/cmd_session.go
+++ b/cmd/pinchtab/cmd_session.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 
 	"github.com/pinchtab/pinchtab/internal/cli/apiclient"
+	"github.com/pinchtab/pinchtab/internal/cli/output"
 	"github.com/spf13/cobra"
 )
 
@@ -18,6 +20,12 @@ func init() {
 		Use:   "info",
 		Short: "Show current agent session details",
 		Run: func(cmd *cobra.Command, args []string) {
+			sessionToken := os.Getenv("PINCHTAB_SESSION")
+			if sessionToken == "" {
+				fmt.Fprintln(os.Stderr, "Error: no session set")
+				output.Hint("create one: export PINCHTAB_SESSION=$(pinchtab session create --agent-id <id> --print-token)")
+				os.Exit(1)
+			}
 			runCLI(func(rt cliRuntime) {
 				apiclient.DoGet(rt.client, rt.base, rt.token, "/sessions/me", nil)
 			})
@@ -40,6 +48,7 @@ func init() {
 		Run: func(cmd *cobra.Command, args []string) {
 			agentID, _ := cmd.Flags().GetString("agent-id")
 			label, _ := cmd.Flags().GetString("label")
+			jsonOutput, _ := cmd.Flags().GetBool("json")
 			if agentID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --agent-id is required")
 				os.Exit(1)
@@ -49,12 +58,39 @@ func init() {
 				body["label"] = label
 			}
 			runCLI(func(rt cliRuntime) {
-				apiclient.DoPost(rt.client, rt.base, rt.token, "/sessions", body)
+				if jsonOutput {
+					apiclient.DoPost(rt.client, rt.base, rt.token, "/sessions", body)
+					return
+				}
+				statusCode, rawBody, _ := apiclient.DoPostQuietWithStatus(rt.client, rt.base, rt.token, "/sessions", body)
+				if statusCode == 404 {
+					fmt.Fprintln(os.Stderr, "Error: agent sessions are not enabled on this server")
+					output.Hint("enable with: sessions.agent.enabled = true in config.json, then restart the server")
+					os.Exit(1)
+				}
+				if statusCode >= 400 {
+					apiclient.ExitWithAPIError(statusCode, rawBody)
+				}
+				var result struct {
+					Token  string `json:"sessionToken"`
+					Status string `json:"status"`
+				}
+				if err := json.Unmarshal(rawBody, &result); err != nil {
+					fmt.Fprintf(os.Stderr, "Error: failed to parse session response\n")
+					os.Exit(1)
+				}
+				if result.Status != "active" {
+					fmt.Fprintf(os.Stderr, "Error: session is %s\n", result.Status)
+					output.Hint("create a new session: pinchtab session create --agent-id <id>")
+					os.Exit(1)
+				}
+				fmt.Println(result.Token)
 			})
 		},
 	}
 	createCmd.Flags().String("agent-id", "", "Agent ID to associate with the session (required)")
 	createCmd.Flags().String("label", "", "Optional human-readable label")
+	addJSONFlag(createCmd)
 
 	revokeCmd := &cobra.Command{
 		Use:   "revoke <session-id>",

--- a/internal/bridge/cdpops/pointer.go
+++ b/internal/bridge/cdpops/pointer.go
@@ -240,7 +240,10 @@ func ClickByNodeID(ctx context.Context, nodeID int64) error {
 
 	return chromedp.Run(ctx,
 		chromedp.ActionFunc(func(ctx context.Context) error {
-			return chromedp.FromContext(ctx).Target.Execute(ctx, "DOM.focus", map[string]any{"backendNodeId": nodeID}, nil)
+			return chromedp.FromContext(ctx).Target.Execute(ctx, "Input.dispatchMouseEvent", map[string]any{
+				"type": "mouseMoved",
+				"x":    x, "y": y,
+			}, nil)
 		}),
 		chromedp.ActionFunc(func(ctx context.Context) error {
 			return chromedp.FromContext(ctx).Target.Execute(ctx, "Input.dispatchMouseEvent", map[string]any{
@@ -258,7 +261,50 @@ func ClickByNodeID(ctx context.Context, nodeID int64) error {
 				"x":          x, "y": y,
 			}, nil)
 		}),
+		// CDP mouse events don't trigger default browser navigation on <a>
+		// elements. For links, fire a JS-level .click() so the browser
+		// follows the href.
+		chromedp.ActionFunc(func(ctx context.Context) error {
+			return jsClickIfLink(ctx, nodeID)
+		}),
 	)
+}
+
+// jsClickIfLink fires element.click() via JS if the node is an <a> with an
+// href. CDP Input.dispatchMouseEvent doesn't trigger the browser's default
+// link-navigation behavior, so this ensures anchor clicks actually navigate.
+func jsClickIfLink(ctx context.Context, nodeID int64) error {
+	// Resolve backend node to a remote object so we can call functions on it.
+	var resolved json.RawMessage
+	if err := chromedp.FromContext(ctx).Target.Execute(ctx, "DOM.resolveNode", map[string]any{
+		"backendNodeId": nodeID,
+	}, &resolved); err != nil {
+		return nil
+	}
+	var obj struct {
+		Object struct {
+			ObjectID string `json:"objectId"`
+		} `json:"object"`
+	}
+	if json.Unmarshal(resolved, &obj) != nil || obj.Object.ObjectID == "" {
+		return nil
+	}
+
+	const js = `function() {
+		var el = this;
+		while (el && el.nodeType === 1) {
+			if (el.tagName === 'A' && el.hasAttribute('href')) {
+				el.click();
+				return;
+			}
+			el = el.parentElement;
+		}
+	}`
+	return chromedp.FromContext(ctx).Target.Execute(ctx,
+		"Runtime.callFunctionOn", map[string]any{
+			"functionDeclaration": js,
+			"objectId":            obj.Object.ObjectID,
+		}, nil)
 }
 
 func DoubleClickByCoordinate(ctx context.Context, x, y float64) error {

--- a/internal/bridge/runtime/init.go
+++ b/internal/bridge/runtime/init.go
@@ -56,23 +56,24 @@ func InitChrome(cfg *config.RuntimeConfig, bundle *stealth.Bundle, hooks Hooks) 
 
 func findChromeBinary() string {
 	var candidates []string
-	if goruntime.GOARCH == "arm64" || goruntime.GOARCH == "arm" {
-		candidates = []string{
-			"/usr/bin/chromium-browser",
-			"/usr/bin/chromium",
-			"/usr/bin/google-chrome",
-			"/usr/bin/google-chrome-stable",
-		}
-	} else {
+	switch goruntime.GOOS {
+	case "darwin":
 		candidates = []string{
 			"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
 			"/Applications/Chromium.app/Contents/MacOS/Chromium",
+			"/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary",
+		}
+	case "windows":
+		candidates = []string{
+			"C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe",
+			"C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
+		}
+	default:
+		candidates = []string{
 			"/usr/bin/google-chrome",
 			"/usr/bin/google-chrome-stable",
 			"/usr/bin/chromium",
 			"/usr/bin/chromium-browser",
-			"C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe",
-			"C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
 		}
 	}
 

--- a/internal/cli/actions/actions_navigate.go
+++ b/internal/cli/actions/actions_navigate.go
@@ -3,6 +3,8 @@ package actions
 import (
 	"fmt"
 	"net/http"
+	"os"
+	"strings"
 
 	"github.com/pinchtab/pinchtab/internal/cli/apiclient"
 	"github.com/pinchtab/pinchtab/internal/cli/output"
@@ -118,6 +120,10 @@ func Navigate(client *http.Client, base, token string, url string, cmd *cobra.Co
 		fmt.Println(resultTabID)
 	}
 
+	if !isIdentifiedCaller() {
+		output.Hint("no session set — this tab is shared. Create one with: export PINCHTAB_SESSION=$(pinchtab session create --agent-id <id> --print-token)")
+	}
+
 	// If --snap or --snap-diff flag is set, fetch and output snapshot
 	snap, _ := cmd.Flags().GetBool("snap")
 	snapDiff, _ := cmd.Flags().GetBool("snap-diff")
@@ -178,6 +184,11 @@ func postNavigate(client *http.Client, base, token string, req navigateRequest, 
 		return apiclient.PrintAndDecode(respBody)
 	}
 	return result
+}
+
+func isIdentifiedCaller() bool {
+	return strings.TrimSpace(os.Getenv("PINCHTAB_SESSION")) != "" ||
+		strings.TrimSpace(os.Getenv("PINCHTAB_AGENT_ID")) != ""
 }
 
 func tabIDFromNavigateResult(result map[string]any) string {

--- a/internal/cli/apiclient/client.go
+++ b/internal/cli/apiclient/client.go
@@ -85,6 +85,17 @@ func DoPostQuiet(client *http.Client, base, token, path string, body map[string]
 	return DoPostQuietWithHeaders(client, base, token, path, body, nil)
 }
 
+// DoPostRaw sends a POST and returns the raw response body without printing.
+// Exits on HTTP errors.
+func DoPostRaw(client *http.Client, base, token, path string, body map[string]any) []byte {
+	statusCode, respBody, _ := doPostQuietWithStatus(client, base, token, path, body, nil)
+	if statusCode >= 400 {
+		handleAPIError(statusCode, respBody)
+		os.Exit(1)
+	}
+	return respBody
+}
+
 func DoPostQuietWithStatus(client *http.Client, base, token, path string, body map[string]any) (int, []byte, map[string]any) {
 	return doPostQuietWithStatus(client, base, token, path, body, nil)
 }

--- a/internal/config/config_load.go
+++ b/internal/config/config_load.go
@@ -1,7 +1,9 @@
 package config
 
 import (
+	"bytes"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -141,7 +143,14 @@ func Load() *RuntimeConfig {
 	finalizeProfileConfig(cfg)
 
 	// Load config file (supports both legacy flat and new nested format)
-	configPath := envOr("PINCHTAB_CONFIG", filepath.Join(userConfigDir(), "config.json"))
+	defaultConfigPath := filepath.Join(userConfigDir(), "config.json")
+	configPath := envOr("PINCHTAB_CONFIG", defaultConfigPath)
+
+	if configPath != defaultConfigPath {
+		if _, statErr := os.Stat(defaultConfigPath); statErr == nil {
+			fmt.Fprintf(os.Stderr, "HINT: default config exists at %s — you can edit it directly instead of using PINCHTAB_CONFIG\n", defaultConfigPath)
+		}
+	}
 
 	data, err := os.ReadFile(configPath)
 	if err != nil {
@@ -168,6 +177,12 @@ func Load() *RuntimeConfig {
 		if err := json.Unmarshal(data, fc); err != nil {
 			slog.Warn("failed to parse config", "path", configPath, "error", err)
 			return cfg
+		}
+		// Warn about unrecognized fields (non-fatal, config still loads).
+		dec := json.NewDecoder(bytes.NewReader(data))
+		dec.DisallowUnknownFields()
+		if ufErr := dec.Decode(&FileConfig{}); ufErr != nil {
+			slog.Warn("config has unrecognized fields that will be ignored", "path", configPath, "error", ufErr)
 		}
 	}
 
@@ -373,7 +388,14 @@ func applyFileConfig(cfg *RuntimeConfig, fc *FileConfig) {
 		cfg.ExtensionPaths = append([]string(nil), fc.Browser.ExtensionPaths...)
 	}
 
-	// Instance defaults
+	// Instance defaults — resolve headless bool into mode string.
+	if fc.InstanceDefaults.Headless != nil && fc.InstanceDefaults.Mode == "" {
+		if *fc.InstanceDefaults.Headless {
+			fc.InstanceDefaults.Mode = "headless"
+		} else {
+			fc.InstanceDefaults.Mode = "headed"
+		}
+	}
 	if fc.InstanceDefaults.Mode != "" {
 		cfg.Headless = modeToHeadless(fc.InstanceDefaults.Mode, cfg.Headless)
 		cfg.HeadlessSet = true

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -16,6 +16,7 @@ type RuntimeConfig struct {
 	StateDir          string
 	TrustProxyHeaders bool  // Only trust X-Forwarded-*/Forwarded headers when behind a trusted reverse proxy
 	CookieSecure      *bool // Nil = auto-detect based on request scheme/host for backward compatibility
+	VerboseStartup    bool  // Show full banner and slog output on server start
 
 	// Security settings
 	AllowEvaluate         bool
@@ -285,6 +286,7 @@ type BrowserConfig struct {
 
 type InstanceDefaultsConfig struct {
 	Mode              string             `json:"mode,omitempty"`
+	Headless          *bool              `json:"headless,omitempty"`
 	NoRestore         *bool              `json:"noRestore,omitempty"`
 	Timezone          string             `json:"timezone,omitempty"`
 	BlockImages       *bool              `json:"blockImages,omitempty"`

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -83,6 +83,12 @@ func ValidateFileConfig(fc *FileConfig) []error {
 	}
 
 	// Instance defaults validation
+	if fc.InstanceDefaults.Headless != nil && fc.InstanceDefaults.Mode != "" {
+		errs = append(errs, ValidationError{
+			Field:   "instanceDefaults.headless",
+			Message: fmt.Sprintf("both headless and mode are set; mode %q takes precedence", fc.InstanceDefaults.Mode),
+		})
+	}
 	if fc.InstanceDefaults.Mode != "" && fc.InstanceDefaults.Mode != "headless" && fc.InstanceDefaults.Mode != "headed" {
 		errs = append(errs, ValidationError{
 			Field:   "instanceDefaults.mode",

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"os"
@@ -36,6 +37,10 @@ import (
 )
 
 func RunDashboard(cfg *config.RuntimeConfig, version string) {
+	if !cfg.VerboseStartup {
+		slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	}
+
 	// Clean up orphaned Chrome processes from previous crashed runs
 	bridge.CleanupOrphanedChromeProcesses(cfg.ProfileDir)
 
@@ -87,6 +92,21 @@ func RunDashboard(cfg *config.RuntimeConfig, version string) {
 			Type:     evt.Type,
 			Instance: evt.Instance,
 		})
+	})
+
+	// Print machine-readable READY line when first instance starts.
+	readyOnce := &sync.Once{}
+	orch.OnEvent(func(evt orchestrator.InstanceEvent) {
+		if evt.Type == "instance.started" && evt.Instance != nil {
+			readyOnce.Do(func() {
+				if dashPort != "9867" {
+					fmt.Printf("READY port=%s\n", dashPort)
+				} else {
+					fmt.Println("READY")
+				}
+				fmt.Println("HINT: export PINCHTAB_SESSION=$(pinchtab session create --agent-id myagent) && pinchtab nav https://pinchtab.com --snap")
+			})
+		}
 	})
 
 	// Drop identity → instance bindings and the instance's scoped current
@@ -182,14 +202,16 @@ func RunDashboard(cfg *config.RuntimeConfig, version string) {
 		listenStatus = "running"
 	}
 
-	cli.PrintStartupBanner(cfg, cli.StartupBannerOptions{
-		Mode:         "server",
-		ListenAddr:   cfg.Bind + ":" + dashPort,
-		ListenStatus: listenStatus,
-		PublicURL:    fmt.Sprintf("http://localhost:%s", dashPort),
-		Strategy:     stratName,
-		Allocation:   allocPolicy,
-	})
+	if cfg.VerboseStartup {
+		cli.PrintStartupBanner(cfg, cli.StartupBannerOptions{
+			Mode:         "server",
+			ListenAddr:   cfg.Bind + ":" + dashPort,
+			ListenStatus: listenStatus,
+			PublicURL:    fmt.Sprintf("http://localhost:%s", dashPort),
+			Strategy:     stratName,
+			Allocation:   allocPolicy,
+		})
+	}
 
 	if listenStatus == "running" {
 		fmt.Println(cli.StyleStdout(cli.WarningStyle, fmt.Sprintf("  pinchtab already running as a daemon on port %s", dashPort)))
@@ -246,7 +268,9 @@ func RunDashboard(cfg *config.RuntimeConfig, version string) {
 			),
 		),
 	)
-	cli.LogSecurityWarnings(cfg)
+	if cfg.VerboseStartup {
+		cli.LogSecurityWarnings(cfg)
+	}
 
 	srv := &http.Server{
 		Addr:              cfg.Bind + ":" + dashPort,

--- a/schema/config.json
+++ b/schema/config.json
@@ -220,6 +220,10 @@
           ],
           "default": "headless"
         },
+        "headless": {
+          "$ref": "#/definitions/nullableBoolean",
+          "description": "Shorthand for mode. true = headless, false = headed. Ignored when mode is also set."
+        },
         "noRestore": {
           "$ref": "#/definitions/nullableBoolean"
         },

--- a/skills/pinchtab-coldstart/SKILL.md
+++ b/skills/pinchtab-coldstart/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: pinchtab-coldstart
+description: "Run the PinchTab cold-start test. Spawns a subagent that builds PinchTab from source, starts the server natively (no Docker), and executes groups 0-1 (14 steps) using only the skill docs. Use when asked to 'run cold start', 'cold-start test', or 'test the agent onboarding flow'."
+---
+
+# PinchTab Cold-Start Test
+
+Validate that an AI agent can go from zero to working with PinchTab using only the skill docs — no hand-holding.
+
+## Prerequisites
+
+Before spawning the subagent, clean the environment:
+
+```bash
+PROJECT_ROOT=$(git rev-parse --show-toplevel)
+pkill -f 'pinchtab' 2>/dev/null
+pkill -f 'Google Chrome.*pinchtab' 2>/dev/null
+sleep 2
+rm -f ~/.local/state/pinchtab/current-tab 2>/dev/null
+rm -f "$PROJECT_ROOT/pinchtab" 2>/dev/null
+lsof -ti:9867 2>/dev/null | xargs kill 2>/dev/null
+```
+
+Wait 2 seconds after cleanup before spawning the agent.
+
+## Execution
+
+Spawn a single subagent with the prompt below. Replace `{PROJECT_ROOT}` and `{TIMESTAMP}` with actual values.
+
+```
+You are running a PinchTab cold-start validation. Your working directory is {PROJECT_ROOT}.
+
+Start by reading the context file, then follow its instructions:
+
+1. Read `tests/coldstart/subagent-context.md` — your full instructions.
+2. Read the skill files it references.
+3. Read the group files it references.
+4. Execute all steps in groups 0 and 1.
+
+Report pass/fail for every step. Write your full results to `/tmp/pinchtab-coldstart-{TIMESTAMP}.md`.
+```
+
+## Interpreting results
+
+- **14/14 PASS**: The skill docs are sufficient for a cold start.
+- **Any failure**: Check what the agent got stuck on — that's a gap in the skill docs or the CLI ergonomics.
+
+Key things to look for in the report:
+- Did the agent use the default port (9867) or pick a custom one?
+- Did the agent read the server's READY output or poll health in a loop?
+- Did the agent use `./pinchtab` CLI or fall back to curl/HTTP API?
+- Did the agent modify `~/.pinchtab/config.json` or use a temp config with `PINCHTAB_CONFIG`?
+- Did step 1.2 (click follows link) pass without an eval workaround?
+
+## Comparing runs
+
+Track token usage and tool call counts across runs to measure improvements:
+
+| Metric | Good | Needs work |
+|--------|------|------------|
+| Total tokens | < 40k | > 50k |
+| Tool calls | < 40 | > 50 |
+| Port | 9867 (default) | Custom port |
+| Server wait | Read READY | Polled health |
+| API usage | CLI only | curl/HTTP fallback |

--- a/skills/pinchtab/SKILL.md
+++ b/skills/pinchtab/SKILL.md
@@ -27,7 +27,7 @@ CLI-first browser skill. Use `pinchtab` commands.
 
 ## Core Workflow
 
-1. Ensure the right profile/instance is selected when needed.
+1. Create a session: `export PINCHTAB_SESSION=$(pinchtab session create --agent-id myagent)` — do this once before any browser command.
 2. Navigate: `pinchtab nav <url> --snap` — auto-starts the local server if needed, then returns tab ID + interactive snapshot in one call.
 3. Interact: `pinchtab click <ref> --snap-diff` — returns OK + only changed elements (most token-efficient).
 4. For read-only observation: `pinchtab text` when you won't act on refs.
@@ -76,6 +76,20 @@ Pages showing "Just a moment..." etc.: `POST /solve {"maxAttempts":3}` (or `/tab
 
 Patterns: (1) one-off `pinchtab instance start`; (2) reuse profile `instance start --profile work --mode headed`, switch to headless after login; (3) HTTP `POST /profiles` then `POST /profiles/<name>/start`; (4) human-assisted headed login, agent reuses headless. Agent sessions: `pinchtab session create --agent-id <id>` or `POST /sessions` → set `PINCHTAB_SESSION=ses_...`.
 
+## Configuration
+
+Config file: `~/.pinchtab/config.json`. Edit it directly to change settings — no need for `PINCHTAB_CONFIG` or temp files.
+
+```bash
+pinchtab config show          # view current config
+pinchtab security             # review security posture
+```
+
+Key settings agents may need to change:
+- `security.allowEvaluate`: enable `eval` command (`true`/`false`)
+- `security.allowedDomains`: list of allowed hostnames (e.g. `["localhost", "127.0.0.1"]`)
+- `instanceDefaults.headless`: run Chrome headless (`true`) or headed (`false`)
+
 ## Essential Commands
 
 ### Server and targeting
@@ -85,6 +99,8 @@ pinchtab server | daemon install | health
 pinchtab instances | profiles
 pinchtab --server http://localhost:9868 snap -i -c  # target a specific instance
 ```
+
+`pinchtab server` prints `READY` to stdout when the browser instance is up and ready to accept commands. Read its output — it includes hints on how to get started (session creation, first nav).
 
 ### Navigation and tabs
 
@@ -98,9 +114,13 @@ pinchtab tab close <tab-id>
 pinchtab instance navigate <instance-id> <url>
 ```
 
-Tab state is automatic: `nav` persists the tab ID to a state file, and subsequent commands read it. Just run `pinchtab nav URL` then `pinchtab snap -i -c` — the tab is remembered. For explicit control, use `--tab <id>`.
+Anonymous commands share a single current tab — if anything else navigates that tab, your next command hits the wrong page. Always create a session before your first `nav`:
 
-**Parallel agents**: when multiple agents share the same browser instance, the automatic tab state file becomes a race condition — one agent's `nav` overwrites another's tab ID. Each agent must manage its own tab ID explicitly: open with `nav <url> --new-tab`, capture the tab ID from the output, and pass `--tab <id>` on every subsequent command (`snap`, `click`, `fill`, `text`, `eval`, `press`, `scroll`, `frame`, etc.).
+```bash
+export PINCHTAB_SESSION=$(pinchtab session create --agent-id myagent)
+```
+
+All subsequent commands use that session's dedicated tab automatically — no `--new-tab` or `--tab <id>` needed.
 
 ### Observation
 
@@ -189,14 +209,7 @@ pinchtab upload /absolute/path -s <css>
 
 ### HTTP API fallback
 
-Use curl only when CLI is unavailable. Instance port (e.g. 9867):
-
-- `POST /navigate` `{"url":"..."}`
-- `GET /snapshot?filter=interactive&format=compact`
-- `POST /action` `{"kind":"fill","selector":"e3","text":"..."}` — kinds: click (`waitNav:true`), fill, type, press, select, hover, scroll (`scrollX`/`scrollY`/`selector`), drag (`dragX`/`dragY`).
-- `POST /actions` — batch in one round-trip. Body: array or `{"actions":[...],"stopOnError":true,"tabId":"..."}`. Response has per-step `{index, success, result?, error?}`.
-- `GET /text`, `POST /solve` `{"maxAttempts":3}`.
-- Tab-scoped: `/tabs/TAB_ID/<endpoint>` for `navigate|snapshot|text|action|actions|screenshot|pdf|back|forward|close|wait|download|upload|handoff|resume|solve`. Auth: `Authorization: Bearer <token>`.
+Use curl only when the CLI is unavailable. See [api.md](./references/api.md) for full endpoint reference.
 
 ## Common Patterns
 

--- a/skills/pinchtab/references/commands.md
+++ b/skills/pinchtab/references/commands.md
@@ -44,7 +44,7 @@ Check if the server is running and healthy.
 ## Browser Commands
 
 ### `pinchtab nav <url>`
-Navigate the current tracked tab to a URL, or create one when no current tab is available. This is the browser command that auto-starts the default local server when it is not already running.
+Navigate the current tracked tab to a URL, or create one when no current tab is available. This is the browser command that auto-starts the default local server when it is not already running. Without a session, `nav` uses a shared current tab — set `PINCHTAB_SESSION` first to get an isolated tab.
 
 ```bash
 pinchtab nav https://pinchtab.com

--- a/tests/coldstart/subagent-context.md
+++ b/tests/coldstart/subagent-context.md
@@ -1,0 +1,62 @@
+# Cold-Start Subagent Context
+
+You are running PinchTab cold-start validation. Your job is to build PinchTab from source, start the server natively (no Docker), and execute groups 0-1 against local fixture HTML files.
+
+## What to read
+
+1. **PinchTab dev skill**: `skills/pinchtab-dev/SKILL.md` — how to build the project.
+2. **PinchTab skill**: `skills/pinchtab/SKILL.md` — full command reference, configuration, and patterns.
+3. **Group files**: `tests/optimization/group-00.md` and `tests/optimization/group-01.md` — step definitions and verification markers.
+
+## What NOT to read
+
+- `tests/tools/scripts/baseline.sh` — deterministic baseline; reading it defeats the purpose.
+- `tests/benchmark/` — separate benchmark lane, not your concern.
+
+## Environment
+
+- Project root: the git root (run `git rev-parse --show-toplevel` if needed)
+- Go, Python 3, Chrome, curl, and jq are available on the host
+- No Docker required — everything runs natively
+- Fixture HTML files: `tests/tools/fixtures/` (wiki.html, wiki-go.html, articles.html, dashboard.html, etc.)
+
+## Setup
+
+### 1. Build from source
+
+Use `./dev build` as described in the dev skill. The binary is placed at `./pinchtab` in the project root.
+
+### 2. Start fixture HTTP server
+
+The fixture pages need to be served over HTTP. Use Python's built-in server on a free port:
+
+```bash
+FIXTURE_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("",0)); print(s.getsockname()[1]); s.close()')
+python3 -m http.server $FIXTURE_PORT --directory tests/tools/fixtures --bind 127.0.0.1 &
+```
+
+### 3. Configure and start PinchTab
+
+Read the PinchTab skill to learn how to configure and start the server. You need:
+- A server with auth enabled
+- Chrome running in headed mode (not headless)
+- `localhost` in allowed domains so you can reach the fixture server
+- `allowEvaluate` enabled (some steps use eval)
+
+Start the server and **read its stdout** — it prints `READY` when the instance is up and a hint showing how to create a session and start navigating.
+
+Use `./pinchtab` CLI commands for everything — never use `./scripts/pt` (that is the Docker wrapper) and never use curl against the HTTP API.
+
+## Running steps
+
+Fixture URLs are `http://localhost:$FIXTURE_PORT/` — the group files reference `http://fixtures/` which is the Docker hostname. Replace `http://fixtures/` with `http://localhost:$FIXTURE_PORT/` in every command.
+
+Execute every step in groups 0 and 1. For each step:
+
+1. Run the appropriate PinchTab commands
+2. Verify the expected markers appear in the output
+3. Record pass/fail with the command used and output
+
+## Cleanup
+
+When finished, kill the fixture server and PinchTab server, remove any temp config, and delete the built binary.

--- a/tests/e2e/scenarios/cli/sessions-basic.sh
+++ b/tests/e2e/scenarios/cli/sessions-basic.sh
@@ -7,7 +7,7 @@ source "${GROUP_DIR}/../../helpers/cli.sh"
 # ─────────────────────────────────────────────────────────────────
 start_test "pinchtab session create"
 
-pt_ok session create --agent-id "e2e-agent" --label "e2e-test"
+pt_ok session create --agent-id "e2e-agent" --label "e2e-test" --json
 assert_output_contains "sessionToken" "output contains sessionToken"
 assert_output_contains "e2e-agent" "output contains agentId"
 assert_output_contains "active" "output contains status active"

--- a/tests/optimization/subagent-context.md
+++ b/tests/optimization/subagent-context.md
@@ -25,28 +25,7 @@ Always use `./scripts/pt ...` — never call `pinchtab` directly.
 
 The wrapper executes pinchtab inside the Docker service and forwards `PINCHTAB_TOKEN` and `PINCHTAB_SERVER` automatically.
 
-### Tab isolation (critical for parallel agents)
-
-Multiple subagents run in parallel against the same browser instance. The default tab state file is shared, so if you rely on it another agent's `nav` will overwrite your tab ID and your subsequent commands will hit the wrong tab or fail with "tab not found".
-
-**You must manage tab IDs explicitly:**
-
-1. On your first `nav`, use `--new-tab` to get a dedicated tab. Capture the tab ID from the output.
-2. Pass `--tab <your-tab-id>` on **every** subsequent command (`snap`, `click`, `fill`, `text`, `eval`, `press`, `scroll`, `frame`, etc.).
-3. Never rely on the automatic state file — always be explicit.
-
-Example:
-```bash
-# First navigation — open a new tab and capture the ID
-./scripts/pt nav "http://fixtures/wiki.html" --new-tab --snap
-# Output includes tab ID, e.g. A1B2C3D4...
-
-# All subsequent commands use --tab explicitly
-./scripts/pt click e3 --tab A1B2C3D4... --snap-diff
-./scripts/pt text --tab A1B2C3D4...
-```
-
-If you lose your tab (404 error), re-navigate with `--new-tab` and update your tab ID.
+Multiple subagents run in parallel against the same browser instance. Make sure your commands don't interfere with other agents' work.
 
 ## Recording
 

--- a/tests/tools/runner/internal/e2e/e2e_test.go
+++ b/tests/tools/runner/internal/e2e/e2e_test.go
@@ -260,7 +260,8 @@ func TestReportDataAddsFailureWhenSuiteExitsAfterPassedResults(t *testing.T) {
 	if err := os.MkdirAll(resultsDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(resultsDir, "output-api.log"), []byte("E2E_RESULT\tpassed\t12\t[browser-basic] browser: health\n"), 0o644); err != nil {
+	logContent := "E2E_RESULT\tpassed\t12\t[browser-basic] browser: health\n\x1b[0;34m▶ [sessions-basic] pinchtab session create\x1b[0m\njq: parse error: Invalid numeric literal at line 2, column 0\n"
+	if err := os.WriteFile(filepath.Join(resultsDir, "output-api.log"), []byte(logContent), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -271,6 +272,12 @@ func TestReportDataAddsFailureWhenSuiteExitsAfterPassedResults(t *testing.T) {
 	}
 	if got := data.Results[1].Name; got != "Suite exited with an error after the last emitted test result" {
 		t.Fatalf("unexpected synthetic failure name: %q", got)
+	}
+	if !strings.Contains(data.ErrorTail, "jq: parse error") {
+		t.Fatalf("expected ErrorTail to contain jq error, got: %q", data.ErrorTail)
+	}
+	if strings.Contains(data.ErrorTail, "\x1b") {
+		t.Fatalf("ErrorTail should not contain ANSI escapes: %q", data.ErrorTail)
 	}
 }
 
@@ -325,6 +332,34 @@ func TestPrintSuiteSummaryFromGoReportData(t *testing.T) {
 		"Suite wall time: 1.500s",
 		"Failed tests:",
 		"- [browser-basic] browser: bad",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("summary output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintSuiteSummaryShowsErrorTail(t *testing.T) {
+	var stdout bytes.Buffer
+	r := &Runner{stdout: &stdout}
+	data := suiteReportData{
+		Results: []suiteTestResult{
+			{Name: "[browser-basic] browser: health", Status: "passed", DurationMs: 12},
+			{Name: "Suite exited with an error after the last emitted test result", Status: "failed", DurationMs: 1500},
+		},
+		Passed:    1,
+		Failed:    1,
+		TotalMs:   1512,
+		ErrorTail: "▶ [sessions-basic] pinchtab session create\njq: parse error: Invalid numeric literal at line 2, column 0",
+	}
+
+	r.printSuiteSummary(suiteDef{Name: "cli-extended", RunSuite: "cli-extended"}, data, 1500*time.Millisecond)
+
+	out := stdout.String()
+	for _, want := range []string{
+		"Error output (last lines):",
+		"jq: parse error: Invalid numeric literal at line 2, column 0",
+		"[sessions-basic] pinchtab session create",
 	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("summary output missing %q:\n%s", want, out)

--- a/tests/tools/runner/internal/e2e/suite.go
+++ b/tests/tools/runner/internal/e2e/suite.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -475,10 +476,11 @@ type suiteTestResult struct {
 }
 
 type suiteReportData struct {
-	Results []suiteTestResult
-	Passed  int
-	Failed  int
-	TotalMs int64
+	Results   []suiteTestResult
+	Passed    int
+	Failed    int
+	TotalMs   int64
+	ErrorTail string
 }
 
 func (r *Runner) writeSuiteReports(def suiteDef, duration time.Duration, exitCode int) suiteReportData {
@@ -503,6 +505,7 @@ func (r *Runner) writeSuiteReports(def suiteDef, duration time.Duration, exitCod
 
 func (r *Runner) buildSuiteReportData(def suiteDef, duration time.Duration, exitCode int) suiteReportData {
 	results := r.parseSuiteResults(def)
+	var errorTail string
 	if exitCode != 0 && !hasFailedResult(results) {
 		name := "Suite failed before test results were emitted"
 		if len(results) > 0 {
@@ -513,14 +516,16 @@ func (r *Runner) buildSuiteReportData(def suiteDef, duration time.Duration, exit
 			Status:     "failed",
 			DurationMs: duration.Milliseconds(),
 		})
+		errorTail = r.extractOutputTail(def, 20)
 	}
 
 	passed, failed, totalMs := countSuiteResults(results)
 	return suiteReportData{
-		Results: results,
-		Passed:  passed,
-		Failed:  failed,
-		TotalMs: totalMs,
+		Results:   results,
+		Passed:    passed,
+		Failed:    failed,
+		TotalMs:   totalMs,
+		ErrorTail: errorTail,
 	}
 }
 
@@ -562,6 +567,34 @@ func cleanResultName(name string) string {
 	name = strings.TrimPrefix(name, "✅ ")
 	name = strings.TrimPrefix(name, "❌ ")
 	return name
+}
+
+var ansiEscapeRe = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
+
+func (r *Runner) extractOutputTail(def suiteDef, maxLines int) string {
+	data, err := os.ReadFile(filepath.Join(r.repoRoot, def.Output))
+	if err != nil {
+		return ""
+	}
+	lines := strings.Split(string(data), "\n")
+
+	var meaningful []string
+	for _, line := range lines {
+		stripped := ansiEscapeRe.ReplaceAllString(line, "")
+		stripped = strings.TrimSpace(stripped)
+		if stripped == "" || strings.HasPrefix(stripped, "E2E_RESULT") {
+			continue
+		}
+		meaningful = append(meaningful, stripped)
+	}
+
+	if len(meaningful) == 0 {
+		return ""
+	}
+	if len(meaningful) > maxLines {
+		meaningful = meaningful[len(meaningful)-maxLines:]
+	}
+	return strings.Join(meaningful, "\n")
 }
 
 func countSuiteResults(results []suiteTestResult) (passed, failed int, totalMs int64) {
@@ -634,6 +667,14 @@ func (r *Runner) printSuiteSummary(def suiteDef, data suiteReportData, duration 
 			if result.Status == "failed" {
 				_, _ = fmt.Fprintf(r.stdout, "  - %s\n", result.Name)
 			}
+		}
+	}
+
+	if data.ErrorTail != "" {
+		_, _ = fmt.Fprintln(r.stdout, "")
+		_, _ = fmt.Fprintln(r.stdout, "  Error output (last lines):")
+		for _, line := range strings.Split(data.ErrorTail, "\n") {
+			_, _ = fmt.Fprintf(r.stdout, "    %s\n", line)
 		}
 	}
 	_, _ = fmt.Fprintln(r.stdout, "")

--- a/tests/tools/runner/internal/opt/summarize.go
+++ b/tests/tools/runner/internal/opt/summarize.go
@@ -51,6 +51,8 @@ func RunSummarize(argv []string, stdout, stderr io.Writer) int {
 
 	steps, _ := report["steps"].([]any)
 	var answered, failed, skipped int
+	var totalDurationMs float64
+	var stepsWithDuration int
 	seen := make(map[string]string)
 	for _, s := range steps {
 		step, _ := s.(map[string]any)
@@ -62,6 +64,10 @@ func RunSummarize(argv []string, stdout, stderr io.Writer) int {
 			failed++
 		case "skip":
 			skipped++
+		}
+		if d, ok := step["duration_ms"].(float64); ok && d > 0 {
+			totalDurationMs += d
+			stepsWithDuration++
 		}
 		id, _ := step["id"].(string)
 		if id == "" {
@@ -176,6 +182,15 @@ func RunSummarize(argv []string, stdout, stderr io.Writer) int {
 	}
 	rows = append(rows, row{"Errors", "0", fmt.Sprintf("%d", failed)})
 
+	if stepsWithDuration > 0 {
+		avgMs := totalDurationMs / float64(stepsWithDuration)
+		rows = append(rows,
+			row{"", "", ""},
+			row{"Avg time/step", "", fmt.Sprintf("%.1fs", avgMs/1000)},
+			row{"Total step time", "", fmtDuration(totalDurationMs)},
+		)
+	}
+
 	if usage != nil {
 		rows = append(rows,
 			row{"", "", ""},
@@ -259,6 +274,21 @@ func RunSummarize(argv []string, stdout, stderr io.Writer) int {
 
 	_, _ = fmt.Fprintln(stdout)
 	return 0
+}
+
+func fmtDuration(ms float64) string {
+	totalSec := int(ms / 1000)
+	if totalSec < 60 {
+		return fmt.Sprintf("%ds", totalSec)
+	}
+	m := totalSec / 60
+	s := totalSec % 60
+	if m < 60 {
+		return fmt.Sprintf("%dm%02ds", m, s)
+	}
+	h := m / 60
+	m = m % 60
+	return fmt.Sprintf("%dh%02dm%02ds", h, m, s)
 }
 
 func fmtInt(n int64) string {

--- a/tests/tools/scripts/pt
+++ b/tests/tools/scripts/pt
@@ -69,6 +69,10 @@ if [[ -n "${PINCHTAB_SESSION:-}" ]]; then
   args+=(-e "PINCHTAB_SESSION=${PINCHTAB_SESSION}")
 fi
 
+if [[ -n "${PINCHTAB_AGENT_ID:-}" ]]; then
+  args+=(-e "PINCHTAB_AGENT_ID=${PINCHTAB_AGENT_ID}")
+fi
+
 args+=("${PINCHTAB_CONTAINER}" pinchtab "$@")
 
 exec "${args[@]}"


### PR DESCRIPTION
## Summary
- add a dedicated cold-start skill and subagent context for validating first-use agent onboarding
- improve CLI/runtime behavior for agent-driven local usage, including default base/token resolution and server-ensure flows
- update config loading, validation, and schema for the new startup/runtime behavior
- refresh PinchTab skill docs and command references to reflect the cold-start and startup workflow
- extend runner/E2E support so cold-start and startup-related behavior can be exercised more directly

## Why
This branch is aimed at a practical question: can an agent go from zero to productive PinchTab usage without hand-holding? That requires both a real cold-start harness and better local startup ergonomics so the default path is less brittle for agent-driven use.

## Notes
- this branch is broader than “runner tooling improvements” alone: it combines cold-start test infrastructure with local CLI/server startup ergonomics
- the cold-start harness is intentionally native/host-based rather than Docker-based, so it tests the real first-use path an agent would face
- local startup behavior is improved for the default local server flow; the goal is smoother agent onboarding, not magic for arbitrary remote servers

## Validation
- new `pinchtab-coldstart` skill and cold-start subagent context
- config/schema updates for the new runtime behavior
- runner/E2E updates for startup and cold-start related paths
- PinchTab skill/docs refreshed to match the new flow
