### PR TITLE
feat(security): add trustLoopbackProxy for system-proxy hosts

### DIFF
--- a/internal/config/config_file.go
+++ b/internal/config/config_file.go
@@ -132,6 +132,7 @@ func DefaultFileConfig() FileConfig {
 	uploadMaxFileBytes := DefaultUploadMaxFileBytes
 	uploadMaxTotalBytes := DefaultUploadMaxTotalBytes
 	maxRedirects := -1
+	trustLoopbackProxy := false
 	attachEnabled := false
 	activityEnabled := true
 	activitySessionIdleSec := 1800
@@ -194,6 +195,7 @@ func DefaultFileConfig() FileConfig {
 			UploadMaxFileBytes:     &uploadMaxFileBytes,
 			UploadMaxTotalBytes:    &uploadMaxTotalBytes,
 			MaxRedirects:           &maxRedirects,
+			TrustLoopbackProxy:     &trustLoopbackProxy,
 			Attach: AttachConfig{
 				Enabled:      &attachEnabled,
 				AllowHosts:   []string{"127.0.0.1", "localhost", "::1"},

--- a/internal/config/config_file_json.go
+++ b/internal/config/config_file_json.go
@@ -78,6 +78,7 @@ type securityConfigJSON struct {
 	MaxRedirects           *int           `json:"maxRedirects"`
 	TrustedProxyCIDRs      []string       `json:"trustedProxyCIDRs"`
 	TrustedResolveCIDRs    []string       `json:"trustedResolveCIDRs"`
+	TrustLoopbackProxy     *bool          `json:"trustLoopbackProxy"`
 	Attach                 attachJSON     `json:"attach"`
 	IDPI                   idpiConfigJSON `json:"idpi"`
 }

--- a/internal/config/config_file_marshal.go
+++ b/internal/config/config_file_marshal.go
@@ -110,6 +110,7 @@ func (fc FileConfig) MarshalJSON() ([]byte, error) {
 			MaxRedirects:           fc.Security.MaxRedirects,
 			TrustedProxyCIDRs:      copyStringSlice(fc.Security.TrustedProxyCIDRs),
 			TrustedResolveCIDRs:    copyStringSlice(fc.Security.TrustedResolveCIDRs),
+			TrustLoopbackProxy:     fc.Security.TrustLoopbackProxy,
 			Attach: attachJSON{
 				Enabled:      fc.Security.Attach.Enabled,
 				AllowHosts:   copyStringSlice(fc.Security.Attach.AllowHosts),
@@ -262,6 +263,7 @@ func FileConfigFromRuntime(cfg *RuntimeConfig) FileConfig {
 	uploadMaxFileBytes := cfg.EffectiveUploadMaxFileBytes()
 	uploadMaxTotalBytes := cfg.EffectiveUploadMaxTotalBytes()
 	maxRedirects := cfg.MaxRedirects
+	trustLoopbackProxy := cfg.TrustLoopbackProxy
 	attachEnabled := cfg.AttachEnabled
 	start := cfg.InstancePortStart
 	end := cfg.InstancePortEnd
@@ -361,6 +363,7 @@ func FileConfigFromRuntime(cfg *RuntimeConfig) FileConfig {
 			MaxRedirects:           &maxRedirects,
 			TrustedProxyCIDRs:      append([]string(nil), cfg.TrustedProxyCIDRs...),
 			TrustedResolveCIDRs:    append([]string(nil), cfg.TrustedResolveCIDRs...),
+			TrustLoopbackProxy:     &trustLoopbackProxy,
 			Attach: AttachConfig{
 				Enabled:      &attachEnabled,
 				AllowHosts:   append([]string(nil), cfg.AttachAllowHosts...),

--- a/internal/config/config_load.go
+++ b/internal/config/config_load.go
@@ -305,6 +305,9 @@ func applyFileConfig(cfg *RuntimeConfig, fc *FileConfig) {
 	cfg.AttachAllowSchemes = append([]string(nil), fc.Security.Attach.AllowSchemes...)
 	cfg.TrustedProxyCIDRs = append([]string(nil), fc.Security.TrustedProxyCIDRs...)
 	cfg.TrustedResolveCIDRs = append([]string(nil), fc.Security.TrustedResolveCIDRs...)
+	if fc.Security.TrustLoopbackProxy != nil {
+		cfg.TrustLoopbackProxy = *fc.Security.TrustLoopbackProxy
+	}
 	// IDPI – copy the whole struct; individual fields have safe zero-value defaults.
 	cfg.IDPI = fc.Security.IDPI
 	cfg.AllowedDomains = effectiveSecurityAllowedDomains(fc.Security)

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -42,6 +42,7 @@ type RuntimeConfig struct {
 	MaxRedirects           int      // Max HTTP redirects (-1=unlimited, 0=none, default=-1)
 	TrustedProxyCIDRs      []string // CIDRs/IPs whose RemoteIPAddress is trusted in navigation responses (e.g. internal proxy)
 	TrustedResolveCIDRs    []string // CIDRs/IPs allowed when a navigation target resolves to non-public addresses
+	TrustLoopbackProxy     bool     // when true, navigation responses with a loopback RemoteIPAddress (e.g. system HTTP/SOCKS proxy on 127.0.0.1) are not blocked; default false
 
 	// Browser/instance settings
 	Headless           bool
@@ -339,6 +340,7 @@ type SecurityConfig struct {
 	MaxRedirects           *int         `json:"maxRedirects,omitempty"`
 	TrustedProxyCIDRs      []string     `json:"trustedProxyCIDRs,omitempty"`
 	TrustedResolveCIDRs    []string     `json:"trustedResolveCIDRs,omitempty"`
+	TrustLoopbackProxy     *bool        `json:"trustLoopbackProxy,omitempty"`
 	Attach                 AttachConfig `json:"attach,omitempty"`
 	IDPI                   IDPIConfig   `json:"idpi,omitempty"`
 }

--- a/internal/config/editor_get.go
+++ b/internal/config/editor_get.go
@@ -242,6 +242,8 @@ func getSecurityField(s *SecurityConfig, field string) (string, error) {
 		return strings.Join(s.TrustedProxyCIDRs, ","), nil
 	case "trustedResolveCIDRs":
 		return strings.Join(s.TrustedResolveCIDRs, ","), nil
+	case "trustLoopbackProxy":
+		return formatBoolPtr(s.TrustLoopbackProxy), nil
 	default:
 		return "", fmt.Errorf("unknown field security.%s", field)
 	}

--- a/internal/config/editor_set.go
+++ b/internal/config/editor_set.go
@@ -384,6 +384,8 @@ func setSecurityField(s *SecurityConfig, field, value string) error {
 		s.AllowNetworkIntercept = &b
 	case "enableActionGuards":
 		s.EnableActionGuards = &b
+	case "trustLoopbackProxy":
+		s.TrustLoopbackProxy = &b
 	default:
 		return fmt.Errorf("unknown field security.%s", field)
 	}

--- a/internal/handlers/navigation.go
+++ b/internal/handlers/navigation.go
@@ -109,7 +109,7 @@ func (h *Handlers) HandleNavigate(w http.ResponseWriter, r *http.Request) {
 		httpx.Error(w, http.StatusForbidden, err)
 		return
 	}
-	trustedCIDRs := parseCIDRs(h.Config.TrustedProxyCIDRs)
+	trustedCIDRs := buildNavigateTrustedProxyCIDRs(h.Config)
 	h.recordNavigateRequest(r, req.TabID, req.URL)
 
 	// --- Lite engine fast path ---

--- a/internal/handlers/navigation_policy.go
+++ b/internal/handlers/navigation_policy.go
@@ -15,8 +15,38 @@ import (
 
 	"github.com/chromedp/cdproto/network"
 	"github.com/chromedp/chromedp"
+	"github.com/pinchtab/pinchtab/internal/config"
 	"github.com/pinchtab/pinchtab/internal/netguard"
 )
+
+// loopbackProxyCIDRs are the CIDRs implicitly trusted as legitimate proxy hops
+// when security.trustLoopbackProxy is enabled. Covers IPv4 and IPv6 loopback.
+var loopbackProxyCIDRs = func() []*net.IPNet {
+	cidrs := make([]*net.IPNet, 0, 2)
+	for _, s := range []string{"127.0.0.0/8", "::1/128"} {
+		if _, n, err := net.ParseCIDR(s); err == nil {
+			cidrs = append(cidrs, n)
+		}
+	}
+	return cidrs
+}()
+
+// buildNavigateTrustedProxyCIDRs returns the list of trusted CIDRs used by the
+// runtime navigation guard when checking the response RemoteIPAddress. It
+// merges security.trustedProxyCIDRs with the implicit loopback list when
+// security.trustLoopbackProxy is enabled, giving users a one-flag escape from
+// the SSRF guard tripping on a local HTTP/SOCKS proxy hop (e.g. macOS system
+// proxy on 127.0.0.1) without having to hand-craft a CIDR list.
+func buildNavigateTrustedProxyCIDRs(cfg *config.RuntimeConfig) []*net.IPNet {
+	if cfg == nil {
+		return nil
+	}
+	trusted := parseCIDRs(cfg.TrustedProxyCIDRs)
+	if cfg.TrustLoopbackProxy {
+		trusted = append(trusted, loopbackProxyCIDRs...)
+	}
+	return trusted
+}
 
 const maxNavigateURLLen = 8 << 10
 

--- a/internal/handlers/navigation_policy_test.go
+++ b/internal/handlers/navigation_policy_test.go
@@ -1,0 +1,93 @@
+package handlers
+
+import (
+	"net"
+	"testing"
+
+	"github.com/pinchtab/pinchtab/internal/config"
+)
+
+func TestBuildNavigateTrustedProxyCIDRs_NilConfig(t *testing.T) {
+	if got := buildNavigateTrustedProxyCIDRs(nil); got != nil {
+		t.Fatalf("buildNavigateTrustedProxyCIDRs(nil) = %v, want nil", got)
+	}
+}
+
+func TestBuildNavigateTrustedProxyCIDRs_FlagOff(t *testing.T) {
+	cfg := &config.RuntimeConfig{
+		TrustedProxyCIDRs:  []string{"10.0.0.0/8"},
+		TrustLoopbackProxy: false,
+	}
+	got := buildNavigateTrustedProxyCIDRs(cfg)
+	if len(got) != 1 {
+		t.Fatalf("got %d CIDRs, want 1 (only the configured one); got=%v", len(got), got)
+	}
+	if got[0].String() != "10.0.0.0/8" {
+		t.Errorf("got[0] = %s, want 10.0.0.0/8", got[0].String())
+	}
+	// Sanity: loopback must NOT be in the list when flag is off.
+	if cidrsContainIP(got, net.ParseIP("127.0.0.1")) {
+		t.Errorf("loopback 127.0.0.1 must not be trusted when TrustLoopbackProxy=false")
+	}
+}
+
+func TestBuildNavigateTrustedProxyCIDRs_FlagOn(t *testing.T) {
+	cfg := &config.RuntimeConfig{
+		TrustedProxyCIDRs:  []string{"10.0.0.0/8"},
+		TrustLoopbackProxy: true,
+	}
+	got := buildNavigateTrustedProxyCIDRs(cfg)
+	if !cidrsContainIP(got, net.ParseIP("127.0.0.1")) {
+		t.Errorf("127.0.0.1 must be trusted when TrustLoopbackProxy=true; got=%v", cidrStrings(got))
+	}
+	if !cidrsContainIP(got, net.ParseIP("::1")) {
+		t.Errorf("::1 must be trusted when TrustLoopbackProxy=true; got=%v", cidrStrings(got))
+	}
+	// Existing configured CIDRs must still be present.
+	if !cidrsContainIP(got, net.ParseIP("10.4.5.6")) {
+		t.Errorf("configured CIDR 10.0.0.0/8 must remain trusted; got=%v", cidrStrings(got))
+	}
+	// Public IP must NOT be trusted.
+	if cidrsContainIP(got, net.ParseIP("8.8.8.8")) {
+		t.Errorf("public IP 8.8.8.8 must not be trusted; got=%v", cidrStrings(got))
+	}
+}
+
+func TestValidateNavigateRemoteIPAddress_LoopbackProxyAllowed(t *testing.T) {
+	cfg := &config.RuntimeConfig{TrustLoopbackProxy: true}
+	trusted := buildNavigateTrustedProxyCIDRs(cfg)
+
+	for _, ip := range []string{"127.0.0.1", "127.255.255.254", "::1"} {
+		if err := validateNavigateRemoteIPAddress(ip, trusted, nil); err != nil {
+			t.Errorf("validateNavigateRemoteIPAddress(%q) with TrustLoopbackProxy=true returned %v, want nil", ip, err)
+		}
+	}
+}
+
+func TestValidateNavigateRemoteIPAddress_LoopbackProxyBlockedByDefault(t *testing.T) {
+	cfg := &config.RuntimeConfig{TrustLoopbackProxy: false}
+	trusted := buildNavigateTrustedProxyCIDRs(cfg)
+
+	for _, ip := range []string{"127.0.0.1", "::1"} {
+		if err := validateNavigateRemoteIPAddress(ip, trusted, nil); err == nil {
+			t.Errorf("validateNavigateRemoteIPAddress(%q) with TrustLoopbackProxy=false returned nil, want SSRF block", ip)
+		}
+	}
+}
+
+func cidrsContainIP(cidrs []*net.IPNet, ip net.IP) bool {
+	for _, c := range cidrs {
+		if c.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+func cidrStrings(cidrs []*net.IPNet) []string {
+	out := make([]string, len(cidrs))
+	for i, c := range cidrs {
+		out[i] = c.String()
+	}
+	return out
+}

--- a/internal/handlers/tab_lifecycle.go
+++ b/internal/handlers/tab_lifecycle.go
@@ -32,7 +32,7 @@ func (h *Handlers) HandleTab(w http.ResponseWriter, r *http.Request) {
 	case tabActionNew:
 		var target *validatedNavigateTarget
 		trustedResolveCIDRs := parseCIDRs(h.Config.TrustedResolveCIDRs)
-		trustedCIDRs := parseCIDRs(h.Config.TrustedProxyCIDRs)
+		trustedCIDRs := buildNavigateTrustedProxyCIDRs(h.Config)
 		if req.URL != "" && req.URL != "about:blank" {
 			if err := validateNavigateURL(req.URL); err != nil {
 				httpx.Error(w, 400, err)


### PR DESCRIPTION
## What Changed?

Adds a new boolean config `security.trustLoopbackProxy` (default `false`).
When enabled, the navigation runtime guard's `Network.responseReceived.remoteIPAddress`
check treats `127.0.0.0/8` and `::1/128` as trusted, alongside whatever is in
`security.trustedProxyCIDRs`. All other security layers (allowedDomains
whitelist, IDPI, attach scope, and the pre-flight `validateNavigateTarget`
DNS check) are unchanged.

## Why?

On macOS hosts running a system HTTP/SOCKS proxy (e.g. Clash on
`127.0.0.1:7897`), Chrome's NetworkService routes outbound traffic through
the proxy via `SCDynamicStore` and reports `remoteIPAddress=127.0.0.1` for
the response — even when the navigation target is a public,
`allowedDomains`-whitelisted host. The runtime guard then trips
`Error 403: navigation connected to blocked remote IP 127.0.0.1` *after* the
page has already loaded, so the CLI exits non-zero and HTTP returns 403, but
`/tabs/<id>/snapshot`, `screenshot`, etc. all still work against the same
tab. This is confusing for users and effectively unusable for any
agent-driven workflow on a system-proxy box.

Chrome's `--proxy-server=direct://` flag does **not** reliably bypass macOS
SCDynamicStore proxy on darwin, so an in-line Chrome flag is not a clean
workaround. Hand-editing `security.trustedProxyCIDRs` works but is poorly
discoverable. A named, opt-in `trustLoopbackProxy` flag is the smallest
ergonomic fix that keeps the guard's SSRF intent intact:

- DNS-rebinding defense remains: `validateNavigateTarget` still rejects
  hosts whose initial DNS resolution returns a loopback IP.
- The `attach host scope: local-only` and `loopback bind` server-side
  perimeter is unchanged.
- A target hostname must still be in `allowedDomains` to navigate at all.

## Testing

**Unit tests (new file `internal/handlers/navigation_policy_test.go`, 5 tests):**

- `TestBuildNavigateTrustedProxyCIDRs_NilConfig`
- `TestBuildNavigateTrustedProxyCIDRs_FlagOff` — configured CIDRs preserved, loopback NOT added
- `TestBuildNavigateTrustedProxyCIDRs_FlagOn` — `127.0.0.1`, `::1`, configured CIDRs all trusted; public IPs still rejected
- `TestValidateNavigateRemoteIPAddress_LoopbackProxyAllowed` — `127.0.0.1` / `127.255.255.254` / `::1` pass when flag on
- `TestValidateNavigateRemoteIPAddress_LoopbackProxyBlockedByDefault` — same IPs blocked when flag off

```bash
go test ./internal/handlers/ -run 'TestBuildNavigateTrustedProxyCIDRs|TestValidateNavigateRemoteIPAddress_Loopback' -v
# 5 PASS

go test ./internal/handlers/ ./internal/engine/ ./internal/netguard/ -count=1 -short
# 3 packages ok — no regressions
```

**Manual end-to-end (darwin-arm64, macOS system proxy at 127.0.0.1:7897 / Clash):**

```bash
# Before patch (any v0.10.x):
pinchtab nav https://www.aliyun.com --new-tab
# → Error 403: navigation connected to blocked remote IP 127.0.0.1

# After patch:
pinchtab config set security.trustLoopbackProxy true
pinchtab nav https://www.aliyun.com --new-tab
# → returns tab ID, page loads
pinchtab tab
# → title \"阿里云-计算，为了无法计算的价值\", url https://www.aliyun.com/
pinchtab screenshot --tab <id> --output /tmp/aliyun.png
# → Saved 194495-byte PNG of real homepage
```

- [x] Unit and/or Docker E2E tests added or updated
- [x] Manual testing completed (describe above)

## Checklist

**Automated (CI enforces):**

- [x] gofmt passes (`gofmt -l` on all 11 touched files: clean)
- [x] All tests pass (`go test ./internal/handlers/... ./internal/engine/... ./internal/netguard/... ./internal/config/... -count=1`)
- [x] Build succeeds (`go build -trimpath ./cmd/pinchtab`, 27 MB binary, ran end-to-end)

**Manual:**

- [x] Error handling explicit — no new error sites; existing `%w` wrapping in `validateNavigateRemoteIPAddress` preserved
- [x] No regressions in stealth/performance/persistence — only the trusted-CIDR set is augmented, no new CDP listeners or extra requests
- [ ] README/CHANGELOG — happy to add a one-line note under `security.*` config docs if the maintainers prefer
- [x] npm install works — no JS/postinstall changes; `cmd/pinchtab` only

## Impact

- **Backward-compatible.** Default `false` preserves current SSRF guard behavior bit-for-bit.
- **Opt-in only.** Users have to consciously run `pinchtab config set security.trustLoopbackProxy true` to relax the loopback check.
- **Surface area:** 11 files, +140/-2 lines (mostly config plumbing wiring through file/runtime/marshal/editor; the actual policy logic is one helper in `internal/handlers/navigation_policy.go`).
- **Adjacent design notes** the maintainers may want to weigh in on:
  1. Should this flag also be auto-enabled when `pinchtab security down` is invoked? Currently it's not — guards-down preset still blocks loopback proxies. Happy to wire it in if desired.
  2. The default `false` keeps strictness, but it would be reasonable to consider auto-detecting macOS SCDynamicStore proxy at server start and surfacing a hint in `pinchtab security` output: \"system proxy detected at <addr>; consider enabling security.trustLoopbackProxy\". Not in this PR; can submit as a follow-up if there's interest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)