### PR TITLE
feat: harden OpenClaw plugin sessions and add smoke coverage

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: pinchtab

--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ pinchtab-dev
 pinchtab-small
 pinchtab.exe
 plugins/*/.venv/
+plugin/skills/pinchtab/
 tests/e2e/results/*
 tests/tools/browserbench/results/
 /runner

--- a/dev
+++ b/dev
@@ -264,10 +264,14 @@ run_command() {
       echo ""
       exec env E2E_LOGS="${E2E_LOGS:-show}" bash scripts/dev-e2e.sh "$test_name"
       ;;
-    "e2e smoke-plugin")
+    "e2e smoke-plugin"|"e2e smoke-plugin "*)
       echo "  ${ACCENT}${BOLD}🐳 OpenClaw plugin smoke${NC}"
       echo ""
-      exec bash tests/manual/openclaw-plugin-smoke/run.sh
+      local -a smoke_args=()
+      if [ "$target" != "e2e smoke-plugin" ]; then
+        read -r -a smoke_args <<< "${target#e2e smoke-plugin }"
+      fi
+      exec bash tests/manual/openclaw-plugin-smoke/run.sh "${smoke_args[@]}"
       ;;
     "e2e"*)
       local -a e2e_args=()
@@ -419,7 +423,7 @@ if [ $# -gt 0 ]; then
         echo ""
         echo "  ${ACCENT}${BOLD}🐳 OpenClaw plugin smoke${NC}"
         echo ""
-        exec bash tests/manual/openclaw-plugin-smoke/run.sh
+        exec bash tests/manual/openclaw-plugin-smoke/run.sh "${@:3}"
       fi
       run_e2e_runner "${@:2}"
       ;;

--- a/dev
+++ b/dev
@@ -31,6 +31,7 @@ COMMANDS=(
   "  extended:🐳:Extended suite (all extended)"
   "  smoke:🐳:Smoke suite"
   "  smoke-docker:🐳:Host Docker smoke checks only"
+  "  smoke-plugin:🐳:OpenClaw plugin Docker smoke"
   "  api:🐳:API basic tests"
   "  cli:🐳:CLI basic tests"
   "  infra:🐳:Infra basic tests"
@@ -263,6 +264,11 @@ run_command() {
       echo ""
       exec env E2E_LOGS="${E2E_LOGS:-show}" bash scripts/dev-e2e.sh "$test_name"
       ;;
+    "e2e smoke-plugin")
+      echo "  ${ACCENT}${BOLD}🐳 OpenClaw plugin smoke${NC}"
+      echo ""
+      exec bash tests/manual/openclaw-plugin-smoke/run.sh
+      ;;
     "e2e"*)
       local -a e2e_args=()
       if [ "$target" != "e2e" ]; then
@@ -408,6 +414,12 @@ if [ $# -gt 0 ]; then
         echo "  ${ACCENT}${BOLD}🎯 Single E2E test${NC}"
         echo ""
         exec env E2E_LOGS="${E2E_LOGS:-show}" bash scripts/dev-e2e.sh "$3"
+      fi
+      if [ "${2:-}" = "smoke-plugin" ]; then
+        echo ""
+        echo "  ${ACCENT}${BOLD}🐳 OpenClaw plugin smoke${NC}"
+        echo ""
+        exec bash tests/manual/openclaw-plugin-smoke/run.sh
       fi
       run_e2e_runner "${@:2}"
       ;;

--- a/internal/bridge/action_form.go
+++ b/internal/bridge/action_form.go
@@ -156,14 +156,19 @@ func checkUncheck(ctx context.Context, req ActionRequest, wantChecked bool) (map
 		return nil, err
 	}
 
-	// Click only if state needs to change.
+	// Click only if state needs to change. Use the JS-dispatch path so the
+	// toggle isn't gated on the headless=new CDP renderer ack chain.
 	if isChecked != wantChecked {
 		if req.NodeID > 0 {
-			if err := ClickByNodeID(ctx, req.NodeID); err != nil {
+			if err := JSClickByBackendNode(ctx, req.NodeID); err != nil {
 				return nil, err
 			}
 		} else {
-			if err := chromedp.Run(ctx, chromedp.Click(req.Selector, chromedp.ByQuery)); err != nil {
+			node, err := firstNodeBySelector(ctx, req.Selector)
+			if err != nil {
+				return nil, err
+			}
+			if err := JSClickByBackendNode(ctx, int64(node.BackendNodeID)); err != nil {
 				return nil, err
 			}
 		}

--- a/internal/bridge/action_pointer.go
+++ b/internal/bridge/action_pointer.go
@@ -145,7 +145,7 @@ func (b *Bridge) actionClick(ctx context.Context, req ActionRequest) (map[string
 			// JS submit handlers, and actual submission in one shot (issue #411).
 			submitted, subErr := submitFormIfButton(clickCtx, req.Selector)
 			if subErr != nil {
-				slog.Debug("submitFormIfButton failed, falling back to CDP click",
+				slog.Debug("submitFormIfButton failed, falling back to JS click",
 					"selector", req.Selector, "error", subErr)
 			} else if submitted {
 				resultCh <- clickResult{err: nil}
@@ -156,9 +156,9 @@ func (b *Bridge) actionClick(ctx context.Context, req ActionRequest) (map[string
 				resultCh <- clickResult{err: nodeErr}
 				return
 			}
-			err = ClickByNodeID(clickCtx, int64(node.BackendNodeID))
+			err = JSClickByBackendNode(clickCtx, int64(node.BackendNodeID))
 		} else if req.NodeID > 0 {
-			err = ClickByNodeID(clickCtx, req.NodeID)
+			err = JSClickByBackendNode(clickCtx, req.NodeID)
 		} else if req.HasXY {
 			err = ClickByCoordinate(clickCtx, req.X, req.Y)
 		} else {
@@ -240,9 +240,9 @@ func (b *Bridge) actionDoubleClick(ctx context.Context, req ActionRequest) (map[
 		if nodeErr != nil {
 			return nil, nodeErr
 		}
-		err = DoubleClickByNodeID(ctx, int64(node.BackendNodeID))
+		err = JSDoubleClickByBackendNode(ctx, int64(node.BackendNodeID))
 	} else if req.NodeID > 0 {
-		err = DoubleClickByNodeID(ctx, req.NodeID)
+		err = JSDoubleClickByBackendNode(ctx, req.NodeID)
 	} else if req.HasXY {
 		err = DoubleClickByCoordinate(ctx, req.X, req.Y)
 	} else {

--- a/internal/bridge/action_pointer.go
+++ b/internal/bridge/action_pointer.go
@@ -2,6 +2,7 @@ package bridge
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -15,6 +16,44 @@ var scrollByCoordinateAction = ScrollByCoordinate
 var mouseMoveByCoordinateAction = MouseMoveByCoordinate
 var mouseDownByCoordinateAction = MouseDownByCoordinate
 var mouseUpByCoordinateAction = MouseUpByCoordinate
+var clickByNodeIDAction = ClickByNodeID
+var jsClickByBackendNodeAction = JSClickByBackendNode
+var doubleClickByNodeIDAction = DoubleClickByNodeID
+var jsDoubleClickByBackendNodeAction = JSDoubleClickByBackendNode
+
+const trustedNodeClickTimeout = 100 * time.Millisecond
+
+func clickByNodeIDWithJSFallback(ctx context.Context, nodeID int64) error {
+	trustedCtx, cancel := context.WithTimeout(ctx, trustedNodeClickTimeout)
+	err := clickByNodeIDAction(trustedCtx, nodeID)
+	cancel()
+	if err == nil {
+		return nil
+	}
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return jsClickByBackendNodeAction(ctx, nodeID)
+	}
+	return err
+}
+
+func doubleClickByNodeIDWithJSFallback(ctx context.Context, nodeID int64) error {
+	trustedCtx, cancel := context.WithTimeout(ctx, trustedNodeClickTimeout)
+	err := doubleClickByNodeIDAction(trustedCtx, nodeID)
+	cancel()
+	if err == nil {
+		return nil
+	}
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return jsDoubleClickByBackendNodeAction(ctx, nodeID)
+	}
+	return err
+}
 
 // effectiveHumanize resolves whether an action should use the humanized
 // (bezier + per-event jitter + pre-press sleeps) input path. Precedence:
@@ -156,9 +195,9 @@ func (b *Bridge) actionClick(ctx context.Context, req ActionRequest) (map[string
 				resultCh <- clickResult{err: nodeErr}
 				return
 			}
-			err = JSClickByBackendNode(clickCtx, int64(node.BackendNodeID))
+			err = clickByNodeIDWithJSFallback(clickCtx, int64(node.BackendNodeID))
 		} else if req.NodeID > 0 {
-			err = JSClickByBackendNode(clickCtx, req.NodeID)
+			err = clickByNodeIDWithJSFallback(clickCtx, req.NodeID)
 		} else if req.HasXY {
 			err = ClickByCoordinate(clickCtx, req.X, req.Y)
 		} else {
@@ -240,9 +279,9 @@ func (b *Bridge) actionDoubleClick(ctx context.Context, req ActionRequest) (map[
 		if nodeErr != nil {
 			return nil, nodeErr
 		}
-		err = JSDoubleClickByBackendNode(ctx, int64(node.BackendNodeID))
+		err = doubleClickByNodeIDWithJSFallback(ctx, int64(node.BackendNodeID))
 	} else if req.NodeID > 0 {
-		err = JSDoubleClickByBackendNode(ctx, req.NodeID)
+		err = doubleClickByNodeIDWithJSFallback(ctx, req.NodeID)
 	} else if req.HasXY {
 		err = DoubleClickByCoordinate(ctx, req.X, req.Y)
 	} else {

--- a/internal/bridge/actions_test.go
+++ b/internal/bridge/actions_test.go
@@ -3,6 +3,7 @@ package bridge
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 
@@ -381,6 +382,91 @@ func TestClickAction_HumanizeOptInUsesHumanizedPath(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "need selector") {
 		t.Fatalf("humanized click should require selector/ref/nodeId, got: %v", err)
+	}
+}
+
+func TestClickByNodeIDWithJSFallback_UsesTrustedPathFirst(t *testing.T) {
+	origTrusted := clickByNodeIDAction
+	origFallback := jsClickByBackendNodeAction
+	t.Cleanup(func() {
+		clickByNodeIDAction = origTrusted
+		jsClickByBackendNodeAction = origFallback
+	})
+
+	var trustedCalled bool
+	var fallbackCalled bool
+	clickByNodeIDAction = func(ctx context.Context, nodeID int64) error {
+		trustedCalled = true
+		if nodeID != 42 {
+			t.Fatalf("nodeID = %d, want 42", nodeID)
+		}
+		return nil
+	}
+	jsClickByBackendNodeAction = func(context.Context, int64) error {
+		fallbackCalled = true
+		return nil
+	}
+
+	if err := clickByNodeIDWithJSFallback(context.Background(), 42); err != nil {
+		t.Fatalf("clickByNodeIDWithJSFallback error = %v", err)
+	}
+	if !trustedCalled {
+		t.Fatal("trusted CDP click path was not called")
+	}
+	if fallbackCalled {
+		t.Fatal("JS fallback should not run when trusted click succeeds")
+	}
+}
+
+func TestClickByNodeIDWithJSFallback_FallsBackOnlyOnTimeout(t *testing.T) {
+	origTrusted := clickByNodeIDAction
+	origFallback := jsClickByBackendNodeAction
+	t.Cleanup(func() {
+		clickByNodeIDAction = origTrusted
+		jsClickByBackendNodeAction = origFallback
+	})
+
+	var fallbackCalled bool
+	clickByNodeIDAction = func(context.Context, int64) error {
+		return context.DeadlineExceeded
+	}
+	jsClickByBackendNodeAction = func(context.Context, int64) error {
+		fallbackCalled = true
+		return nil
+	}
+
+	if err := clickByNodeIDWithJSFallback(context.Background(), 42); err != nil {
+		t.Fatalf("clickByNodeIDWithJSFallback error = %v", err)
+	}
+	if !fallbackCalled {
+		t.Fatal("JS fallback should run after trusted click timeout")
+	}
+}
+
+func TestClickByNodeIDWithJSFallback_DoesNotFallbackOnOtherErrors(t *testing.T) {
+	origTrusted := clickByNodeIDAction
+	origFallback := jsClickByBackendNodeAction
+	t.Cleanup(func() {
+		clickByNodeIDAction = origTrusted
+		jsClickByBackendNodeAction = origFallback
+	})
+
+	boom := errors.New("boom")
+	var fallbackCalled bool
+	clickByNodeIDAction = func(context.Context, int64) error {
+		return boom
+	}
+	jsClickByBackendNodeAction = func(context.Context, int64) error {
+		fallbackCalled = true
+		return nil
+	}
+
+	err := clickByNodeIDWithJSFallback(context.Background(), 42)
+	if !errors.Is(err, boom) {
+		t.Fatalf("error = %v, want boom", err)
+	}
+	if fallbackCalled {
+		t.Fatal("JS fallback should not run for non-timeout trusted click errors")
 	}
 }
 

--- a/internal/bridge/cdpops/pointer.go
+++ b/internal/bridge/cdpops/pointer.go
@@ -424,3 +424,119 @@ func HoverByNodeID(ctx context.Context, nodeID int64) error {
 
 	return dispatchMouseMoveToNode(ctx, nodeID, x, y, input.None, 0)
 }
+
+// jsClickFn is invoked via Runtime.callFunctionOn against the resolved
+// backend node. It dispatches synthetic mousedown/mouseup MouseEvents and
+// then calls el.click() so the browser runs default actions (link nav,
+// checkbox toggle, button form submit) AND fires a 'click' event that
+// bubbles to listeners. Walks up to find an anchor ancestor so clicking an
+// inner span inside an <a> still follows the href.
+const jsClickFn = `function() {
+	var el = this;
+	var r = el.getBoundingClientRect();
+	var cx = r.left + r.width / 2;
+	var cy = r.top + r.height / 2;
+	var init = {
+		clientX: cx, clientY: cy, screenX: cx, screenY: cy,
+		button: 0, buttons: 1,
+		bubbles: true, cancelable: true, view: window
+	};
+	if (typeof el.focus === 'function') {
+		try { el.focus({preventScroll: true}); } catch (e) {}
+	}
+	el.dispatchEvent(new MouseEvent('mousedown', init));
+	el.dispatchEvent(new MouseEvent('mouseup', Object.assign({}, init, {buttons: 0})));
+	var target = el;
+	while (target && target.nodeType === 1) {
+		if (target.tagName === 'A' && target.hasAttribute('href')) break;
+		target = target.parentElement;
+	}
+	if (!target) target = el;
+	if (typeof target.click === 'function') {
+		target.click();
+	} else {
+		target.dispatchEvent(new MouseEvent('click', init));
+	}
+}`
+
+const jsDoubleClickFn = `function() {
+	var el = this;
+	var r = el.getBoundingClientRect();
+	var cx = r.left + r.width / 2;
+	var cy = r.top + r.height / 2;
+	var base = {
+		clientX: cx, clientY: cy, screenX: cx, screenY: cy,
+		button: 0, buttons: 1,
+		bubbles: true, cancelable: true, view: window
+	};
+	if (typeof el.focus === 'function') {
+		try { el.focus({preventScroll: true}); } catch (e) {}
+	}
+	for (var i = 1; i <= 2; i++) {
+		el.dispatchEvent(new MouseEvent('mousedown', Object.assign({}, base, {detail: i})));
+		el.dispatchEvent(new MouseEvent('mouseup', Object.assign({}, base, {detail: i, buttons: 0})));
+		el.dispatchEvent(new MouseEvent('click', Object.assign({}, base, {detail: i})));
+	}
+	el.dispatchEvent(new MouseEvent('dblclick', Object.assign({}, base, {detail: 2})));
+}`
+
+func resolveBackendNodeObjectID(ctx context.Context, backendNodeID int64) (string, error) {
+	var resolved json.RawMessage
+	if err := chromedp.Run(ctx, chromedp.ActionFunc(func(ctx context.Context) error {
+		return chromedp.FromContext(ctx).Target.Execute(ctx, "DOM.resolveNode", map[string]any{
+			"backendNodeId": backendNodeID,
+		}, &resolved)
+	})); err != nil {
+		return "", fmt.Errorf("DOM.resolveNode: %w", err)
+	}
+	var out struct {
+		Object struct {
+			ObjectID string `json:"objectId"`
+		} `json:"object"`
+	}
+	if err := json.Unmarshal(resolved, &out); err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(out.Object.ObjectID) == "" {
+		return "", fmt.Errorf("element not found in DOM (backendNodeId=%d)", backendNodeID)
+	}
+	return out.Object.ObjectID, nil
+}
+
+// JSClickByBackendNode performs a click via Runtime.callFunctionOn rather
+// than synthesized CDP Input.dispatchMouseEvent. Headless Chromium's CDP
+// path can stall ~5s waiting on the renderer ack chain for press/release;
+// the JS path runs the same handler chain (mousedown, mouseup, click) plus
+// the browser's default action (el.click()) without the ack tax.
+func JSClickByBackendNode(ctx context.Context, backendNodeID int64) error {
+	if _, _, err := PointerPointForNode(ctx, backendNodeID, true); err != nil {
+		return err
+	}
+	objectID, err := resolveBackendNodeObjectID(ctx, backendNodeID)
+	if err != nil {
+		return err
+	}
+	return chromedp.Run(ctx, chromedp.ActionFunc(func(ctx context.Context) error {
+		return chromedp.FromContext(ctx).Target.Execute(ctx, "Runtime.callFunctionOn", map[string]any{
+			"functionDeclaration": jsClickFn,
+			"objectId":            objectID,
+		}, nil)
+	}))
+}
+
+// JSDoubleClickByBackendNode is the dblclick counterpart of JSClickByBackendNode.
+func JSDoubleClickByBackendNode(ctx context.Context, backendNodeID int64) error {
+	if _, _, err := PointerPointForNode(ctx, backendNodeID, true); err != nil {
+		return err
+	}
+	objectID, err := resolveBackendNodeObjectID(ctx, backendNodeID)
+	if err != nil {
+		return err
+	}
+	return chromedp.Run(ctx, chromedp.ActionFunc(func(ctx context.Context) error {
+		return chromedp.FromContext(ctx).Target.Execute(ctx, "Runtime.callFunctionOn", map[string]any{
+			"functionDeclaration": jsDoubleClickFn,
+			"objectId":            objectID,
+		}, nil)
+	}))
+}

--- a/internal/bridge/cdpops_facade.go
+++ b/internal/bridge/cdpops_facade.go
@@ -59,12 +59,20 @@ func ClickByNodeID(ctx context.Context, nodeID int64) error {
 	return bridgecdpops.ClickByNodeID(ctx, nodeID)
 }
 
+func JSClickByBackendNode(ctx context.Context, nodeID int64) error {
+	return bridgecdpops.JSClickByBackendNode(ctx, nodeID)
+}
+
 func DoubleClickByCoordinate(ctx context.Context, x, y float64) error {
 	return bridgecdpops.DoubleClickByCoordinate(ctx, x, y)
 }
 
 func DoubleClickByNodeID(ctx context.Context, nodeID int64) error {
 	return bridgecdpops.DoubleClickByNodeID(ctx, nodeID)
+}
+
+func JSDoubleClickByBackendNode(ctx context.Context, nodeID int64) error {
+	return bridgecdpops.JSDoubleClickByBackendNode(ctx, nodeID)
 }
 
 func DragByNodeID(ctx context.Context, nodeID int64, dx, dy int) error {

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -11,14 +11,14 @@ openclaw gateway restart
 
 ## Quick Start
 
-The plugin can auto-start a local PinchTab server when needed (`autoStart: true` by default). This only works when `baseUrl` points to a local address (`localhost`, `127.0.0.1`, or `::1`).
+Install the plugin, restart the gateway, then point it at a running PinchTab server.
 
 ```bash
 openclaw plugins install @pinchtab/pinchtab
 openclaw gateway restart
 ```
 
-For remote servers or Docker, set `autoStart: false` and configure `baseUrl` manually.
+By default the plugin auto-discovers local PinchTab settings from `~/.pinchtab/config.json`. If discovery succeeds, you usually do not need to set `baseUrl` or `token` manually.
 
 ## Configure
 
@@ -33,13 +33,6 @@ For remote servers or Docker, set `autoStart: false` and configure `baseUrl` man
           baseUrl: "http://localhost:9867",
           token: "my-secret",
           timeoutMs: 30000,
-
-          // Auto-start (local only — localhost, 127.0.0.1, or ::1)
-          // When enabled, spawns a PinchTab server process if baseUrl
-          // points to a local address and the server is not running.
-          autoStart: true,
-          binaryPath: "pinchtab",    // absolute path or binary name in PATH
-          startupTimeoutMs: 30000,   // max wait for server to become ready
 
           // Policy
           allowEvaluate: false,      // block JS evaluate by default
@@ -78,7 +71,7 @@ For remote servers or Docker, set `autoStart: false` and configure `baseUrl` man
 
 ### Manual Server Setup
 
-If auto-start is disabled or you're using Docker:
+The plugin does not launch the server for you. Start PinchTab separately:
 
 ```bash
 # Local
@@ -88,16 +81,20 @@ PINCHTAB_TOKEN=my-secret pinchtab server &
 docker run -d -p 9867:9867 ghcr.io/pinchtab/pinchtab:latest
 ```
 
-## Two Tools: `browser` and `pinchtab`
+## Two Tools: `pinchtab` first, `browser` as compatibility
 
 The plugin registers two tools:
 
 | Tool | Use Case |
 |------|----------|
-| `browser` | OpenClaw-compatible, simplified interface for common flows |
-| `pinchtab` | Advanced control with all actions (mouse, wait, handoff, evaluate) |
+| `pinchtab` | Primary supported OpenClaw integration, full action surface |
+| `browser` | Compatibility alias for OpenClaw-style browser calls |
 
-Disable the browser tool with `registerBrowserTool: false` if you only want `pinchtab`.
+`pinchtab` is the primary documented integration path.
+
+`browser` is best-effort compatibility. Some OpenClaw surfaces treat `browser` specially, so the alias may not appear everywhere even when the plugin is loaded correctly.
+
+Disable the alias with `registerBrowserTool: false` if you only want `pinchtab`.
 
 ## Profiles
 
@@ -121,7 +118,9 @@ Map browser sessions to OpenClaw profile semantics:
 }
 ```
 
-Usage: `browser({ action: "navigate", url: "...", profile: "user" })`
+Usage: `pinchtab({ action: "navigate", url: "https://example.com" })`
+
+Compatibility usage: `browser({ action: "navigate", url: "...", profile: "user" })`
 
 ## Browser Tool Actions
 
@@ -236,6 +235,14 @@ pinchtab({ action: "wait", text: "Welcome back", timeout: 120000 })
 - Use `PINCHTAB_TOKEN` to gate API access; rotate regularly
 - In production, run behind HTTPS reverse proxy (Caddy/nginx)
 
+## OpenClaw Integration Notes
+
+The most reliable OpenClaw integration path is the `pinchtab` tool.
+
+If you disable the bundled OpenClaw browser plugin and enable this plugin, agent turns that explicitly choose `browser` can resolve to PinchTab. However, OpenClaw may still route some tasks to other tools such as `web_fetch` or `canvas`, and some direct gateway surfaces may treat `browser` as a special compatibility name.
+
+For plugin-level validation in OpenClaw, prefer invoking `pinchtab` directly.
+
 ## Migrating from OpenClaw Bundled Browser
 
 To replace the bundled `browser` plugin with PinchTab:
@@ -274,13 +281,13 @@ To replace the bundled `browser` plugin with PinchTab:
 
 ### 4. Key differences
 
-- **Auto-start**: PinchTab auto-starts locally by default (disable with `autoStart: false`)
+- **Server lifecycle**: start PinchTab separately; the plugin waits for readiness but does not spawn the server
 - **Policy**: `allowEvaluate`, `allowDownloads`, `allowUploads` are `false` by default
-- **Advanced actions**: Use `pinchtab` tool for mouse controls, wait, handoff, evaluate
+- **Advanced actions**: use `pinchtab` for mouse controls, wait, handoff, evaluate, and direct plugin validation
 
 ## Requirements
 
-- PinchTab binary in PATH (or set `binaryPath`)
+- Running PinchTab server
 - OpenClaw Gateway
 
 ## Disclaimer

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -2,6 +2,8 @@
 
 Browser control for AI agents via [PinchTab](https://pinchtab.com). Single-tool design — one `pinchtab` tool handles all browser operations. Minimal context bloat.
 
+> **Beta**: this plugin is in beta and is not fully tested in this release. Expect rough edges around per-agent session isolation, the `browser` compatibility alias, and OpenClaw plugin loader behavior. Production use is at your own risk — please file issues for anything you hit.
+
 ## Install
 
 ```bash
@@ -223,7 +225,7 @@ pinchtab({ action: "wait", text: "Welcome back", timeout: 120000 })
 
 ## Security Notes
 
-- **Auto-start** spawns a background process — only enabled for local addresses (`localhost`, `127.0.0.1`, `::1`). Set `autoStart: false` if you prefer explicit server management.
+- **Server lifecycle**: the plugin does not start PinchTab — run `pinchtab server` separately. If the server isn't reachable, the plugin returns a clear error pointing at the configured `baseUrl`. Once the server is up, the plugin briefly waits for instance/profile readiness (handles the "still booting" / `503` window).
 - **`evaluate`** is blocked by default (`allowEvaluate: false`) — enable only for trusted agents
 - **`downloads`** and **`uploads`** are blocked by default — enable only when the task requires file transfer
 - **Cookie access** exposes session credentials — do not log or expose to untrusted contexts

--- a/plugin/client.test.ts
+++ b/plugin/client.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, it } from "node:test";
 import assert from "node:assert";
-import { isRefToken, normalizeActionParams, looksLikeStaleRef, pinchtabFetch, textResult, imageResult, resourceResult } from "./client.ts";
+import { isRefToken, normalizeActionParams, looksLikeStaleRef, pinchtabFetch, textResult, imageResult, resourceResult, clearPinchtabSessionCache } from "./client.ts";
 
 describe("isRefToken", () => {
   it("returns true for valid ref tokens", () => {
@@ -73,9 +73,26 @@ describe("looksLikeStaleRef", () => {
     assert.strictEqual(looksLikeStaleRef({ error: "context canceled" }), true);
   });
 
+  it("matches Pinchtab backend-node failures", () => {
+    assert.strictEqual(
+      looksLikeStaleRef({ error: "element not found in DOM (backendNodeId=42)" }),
+      true,
+    );
+    assert.strictEqual(looksLikeStaleRef({ error: "backend-node-not-found" }), true);
+    assert.strictEqual(looksLikeStaleRef({ error: "backend node detached" }), true);
+    assert.strictEqual(looksLikeStaleRef({ error: "element no longer in DOM" }), true);
+    assert.strictEqual(looksLikeStaleRef({ error: "element no longer attached" }), true);
+  });
+
   it("returns false for other errors", () => {
     assert.strictEqual(looksLikeStaleRef({ error: "network timeout" }), false);
     assert.strictEqual(looksLikeStaleRef({ error: "server error" }), false);
+  });
+
+  it("does not match unrelated substrings containing 'ref'", () => {
+    assert.strictEqual(looksLikeStaleRef({ error: "referrer policy violation" }), false);
+    assert.strictEqual(looksLikeStaleRef({ error: "unsupported preferences" }), false);
+    assert.strictEqual(looksLikeStaleRef({ error: "page not found" }), false);
   });
 
   it("checks body as well as error", () => {
@@ -112,6 +129,204 @@ describe("pinchtabFetch", () => {
       "X-OpenClaw-Session-Id": "session-123",
       "X-OpenClaw-Session-Key": "chat:writer",
     });
+  });
+});
+
+describe("pinchtabFetch per-agent session token", () => {
+  const originalFetch = globalThis.fetch;
+  let calls: Array<{ url: string; method: string; headers: Record<string, string>; body?: string }>;
+
+  beforeEach(() => {
+    clearPinchtabSessionCache();
+    calls = [];
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const method = (init?.method || "GET").toUpperCase();
+      const headers = (init?.headers ?? {}) as Record<string, string>;
+      const body = typeof init?.body === "string" ? init.body : undefined;
+      calls.push({ url, method, headers, body });
+      if (url.endsWith("/sessions") && method === "POST") {
+        return new Response(JSON.stringify({ id: "ses_abc", sessionToken: "ses_token_xyz" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response(JSON.stringify({ ok: true, headers }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    clearPinchtabSessionCache();
+  });
+
+  it("creates a Pinchtab session lazily and uses its token for browser actions", async () => {
+    await pinchtabFetch(
+      { baseUrl: "http://localhost:9867", token: "server-token" },
+      "/snapshot",
+      {},
+      { agentId: "alpha" },
+    );
+    assert.strictEqual(calls.length, 2);
+    assert.strictEqual(calls[0].url, "http://localhost:9867/sessions");
+    assert.strictEqual(calls[0].method, "POST");
+    assert.strictEqual(calls[0].headers.Authorization, "Bearer server-token");
+    assert.deepStrictEqual(JSON.parse(calls[0].body!), { agentId: "alpha", label: "openclaw" });
+    assert.strictEqual(calls[1].url, "http://localhost:9867/snapshot");
+    assert.strictEqual(calls[1].headers.Authorization, "Session ses_token_xyz");
+  });
+
+  it("reuses the cached session token across calls for the same agent", async () => {
+    const cfg = { baseUrl: "http://localhost:9867", token: "server-token" };
+    await pinchtabFetch(cfg, "/snapshot", {}, { agentId: "alpha" });
+    await pinchtabFetch(cfg, "/tabs", {}, { agentId: "alpha" });
+    const sessionPosts = calls.filter((c) => c.url.endsWith("/sessions") && c.method === "POST");
+    assert.strictEqual(sessionPosts.length, 1);
+    const tabsCall = calls.find((c) => c.url.endsWith("/tabs"));
+    assert.strictEqual(tabsCall?.headers.Authorization, "Session ses_token_xyz");
+  });
+
+  it("creates separate sessions for distinct agents", async () => {
+    const cfg = { baseUrl: "http://localhost:9867", token: "server-token" };
+    await pinchtabFetch(cfg, "/snapshot", {}, { agentId: "alpha" });
+    await pinchtabFetch(cfg, "/snapshot", {}, { agentId: "beta" });
+    const sessionPosts = calls.filter((c) => c.url.endsWith("/sessions") && c.method === "POST");
+    assert.strictEqual(sessionPosts.length, 2);
+    const agentIds = sessionPosts.map((c) => JSON.parse(c.body!).agentId).sort();
+    assert.deepStrictEqual(agentIds, ["alpha", "beta"]);
+  });
+
+  it("uses the server token for /health, /sessions, /instances, /profiles", async () => {
+    const cfg = { baseUrl: "http://localhost:9867", token: "server-token" };
+    await pinchtabFetch(cfg, "/health", {}, { agentId: "alpha" });
+    await pinchtabFetch(cfg, "/instances", {}, { agentId: "alpha" });
+    await pinchtabFetch(cfg, "/profiles", {}, { agentId: "alpha" });
+    for (const call of calls) {
+      assert.strictEqual(call.headers.Authorization, "Bearer server-token");
+    }
+  });
+
+  it("falls back to server token when context has no agentId", async () => {
+    await pinchtabFetch(
+      { baseUrl: "http://localhost:9867", token: "server-token" },
+      "/snapshot",
+      {},
+    );
+    assert.strictEqual(calls.length, 1);
+    assert.strictEqual(calls[0].headers.Authorization, "Bearer server-token");
+  });
+});
+
+describe("pinchtabFetch session failure modes", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    clearPinchtabSessionCache();
+  });
+
+  it("fails closed (no bearer fallback) when /sessions creation fails for an agent", async () => {
+    clearPinchtabSessionCache();
+    const calls: Array<{ url: string; method: string }> = [];
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const method = (init?.method || "GET").toUpperCase();
+      calls.push({ url, method });
+      if (url.endsWith("/sessions") && method === "POST") {
+        return new Response("upstream timeout", { status: 503 });
+      }
+      throw new Error("must not fall back to bearer for the snapshot path");
+    }) as typeof fetch;
+
+    const result = await pinchtabFetch(
+      { baseUrl: "http://localhost:9867", token: "server-token" },
+      "/snapshot",
+      {},
+      { agentId: "alpha" },
+    );
+    assert.strictEqual(calls.length, 1);
+    assert.strictEqual(calls[0].url, "http://localhost:9867/sessions");
+    assert.match(result.error, /Pinchtab session creation failed for agent alpha/);
+    assert.match(result.error, /503/);
+  });
+
+  it("evicts cached token and retries once on 401 from a Session-scheme call", async () => {
+    clearPinchtabSessionCache();
+    const calls: Array<{ url: string; method: string; headers: Record<string, string> }> = [];
+    let sessionTokenCounter = 0;
+    let firstSnapshot = true;
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const method = (init?.method || "GET").toUpperCase();
+      const headers = (init?.headers ?? {}) as Record<string, string>;
+      calls.push({ url, method, headers });
+      if (url.endsWith("/sessions") && method === "POST") {
+        sessionTokenCounter += 1;
+        return new Response(
+          JSON.stringify({ id: `ses_${sessionTokenCounter}`, sessionToken: `ses_token_${sessionTokenCounter}` }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (url.endsWith("/snapshot")) {
+        if (firstSnapshot) {
+          firstSnapshot = false;
+          return new Response(JSON.stringify({ error: "bad_session" }), {
+            status: 401,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+        return new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response("", { status: 200 });
+    }) as typeof fetch;
+
+    const result = await pinchtabFetch(
+      { baseUrl: "http://localhost:9867", token: "server-token" },
+      "/snapshot",
+      {},
+      { agentId: "alpha" },
+    );
+    assert.deepStrictEqual(result, { ok: true });
+    const sessionPosts = calls.filter((c) => c.url.endsWith("/sessions") && c.method === "POST");
+    assert.strictEqual(sessionPosts.length, 2, "should re-create session after 401");
+    const snapshotCalls = calls.filter((c) => c.url.endsWith("/snapshot"));
+    assert.strictEqual(snapshotCalls.length, 2);
+    assert.strictEqual(snapshotCalls[0].headers.Authorization, "Session ses_token_1");
+    assert.strictEqual(snapshotCalls[1].headers.Authorization, "Session ses_token_2");
+  });
+
+  it("does not loop indefinitely if 401s keep coming after retry", async () => {
+    clearPinchtabSessionCache();
+    let sessionPosts = 0;
+    let snapshotCalls = 0;
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const method = (init?.method || "GET").toUpperCase();
+      if (url.endsWith("/sessions") && method === "POST") {
+        sessionPosts += 1;
+        return new Response(JSON.stringify({ sessionToken: `ses_${sessionPosts}` }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      snapshotCalls += 1;
+      return new Response("bad_session", { status: 401 });
+    }) as typeof fetch;
+
+    const result = await pinchtabFetch(
+      { baseUrl: "http://localhost:9867", token: "server-token" },
+      "/snapshot",
+      {},
+      { agentId: "alpha" },
+    );
+    assert.strictEqual(snapshotCalls, 2, "exactly one retry, no infinite loop");
+    assert.strictEqual(result.error, "401 ");
   });
 });
 

--- a/plugin/client.test.ts
+++ b/plugin/client.test.ts
@@ -1,6 +1,6 @@
-import { describe, it } from "node:test";
+import { afterEach, beforeEach, describe, it } from "node:test";
 import assert from "node:assert";
-import { isRefToken, normalizeActionParams, looksLikeStaleRef, textResult, imageResult, resourceResult } from "./client.ts";
+import { isRefToken, normalizeActionParams, looksLikeStaleRef, pinchtabFetch, textResult, imageResult, resourceResult } from "./client.ts";
 
 describe("isRefToken", () => {
   it("returns true for valid ref tokens", () => {
@@ -80,6 +80,38 @@ describe("looksLikeStaleRef", () => {
 
   it("checks body as well as error", () => {
     assert.strictEqual(looksLikeStaleRef({ error: "failed", body: "stale ref" }), true);
+  });
+});
+
+describe("pinchtabFetch", () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = (async (_input: string | URL | Request, init?: RequestInit) => {
+      return new Response(JSON.stringify({ headers: init?.headers ?? {} }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("forwards OpenClaw agent and session headers", async () => {
+    const result = await pinchtabFetch(
+      { baseUrl: "http://localhost:9867", token: "secret" },
+      "/health",
+      {},
+      { agentId: "writer", sessionId: "session-123", sessionKey: "chat:writer" },
+    );
+    assert.deepStrictEqual(result.headers, {
+      Authorization: "Bearer secret",
+      "X-OpenClaw-Agent-Id": "writer",
+      "X-OpenClaw-Session-Id": "session-123",
+      "X-OpenClaw-Session-Key": "chat:writer",
+    });
   });
 });
 

--- a/plugin/client.ts
+++ b/plugin/client.ts
@@ -1,30 +1,147 @@
 import type { PluginConfig, PluginRuntimeContext, ToolResult } from "./types.js";
-import { resolveEffectiveConfig } from "./session.js";
 
-function buildRequestHeaders(cfg: PluginConfig, context?: PluginRuntimeContext): Record<string, string> {
+// Pinchtab isolates browser state per session token created by `POST /sessions`
+// with a distinct agentId. Without per-agent sessions every OpenClaw agent
+// shares the same browser context, so cookies/storage leak across them.
+const pinchtabSessionTokens = new Map<string, string>();
+
+const SERVER_TOKEN_PATH_PREFIXES = ["/sessions", "/instances", "/profiles"];
+
+function isServerTokenPath(path: string): boolean {
+  const stripped = path.split("?", 1)[0];
+  if (stripped === "/health") return true;
+  for (const prefix of SERVER_TOKEN_PATH_PREFIXES) {
+    if (stripped === prefix || stripped.startsWith(`${prefix}/`)) return true;
+  }
+  return false;
+}
+
+type SessionResolution =
+  | { kind: "ok"; token: string }
+  | { kind: "no-agent" }
+  | { kind: "error"; error: string };
+
+async function ensurePinchtabSession(
+  cfg: PluginConfig,
+  context: PluginRuntimeContext | undefined,
+  forceRefresh = false,
+): Promise<SessionResolution> {
+  const agentId = context?.agentId;
+  if (!agentId) return { kind: "no-agent" };
+  if (!cfg.token || !cfg.baseUrl) {
+    return { kind: "error", error: "Pinchtab plugin missing baseUrl or token; cannot create per-agent session" };
+  }
+  if (forceRefresh) pinchtabSessionTokens.delete(agentId);
+  const cached = pinchtabSessionTokens.get(agentId);
+  if (cached) return { kind: "ok", token: cached };
+
+  const controller = new AbortController();
+  const timeout = cfg.timeoutMs ?? cfg.timeout ?? 30000;
+  const timer = setTimeout(() => controller.abort(), timeout);
+  try {
+    const res = await fetch(`${cfg.baseUrl}/sessions`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${cfg.token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ agentId, label: "openclaw" }),
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      return {
+        kind: "error",
+        error: `Pinchtab session creation failed for agent ${agentId}: ${res.status} ${res.statusText}${body ? ` - ${body.slice(0, 200)}` : ""}`,
+      };
+    }
+    const data = (await res.json().catch(() => null)) as { sessionToken?: string } | null;
+    const token = data?.sessionToken;
+    if (typeof token === "string" && token) {
+      pinchtabSessionTokens.set(agentId, token);
+      return { kind: "ok", token };
+    }
+    return { kind: "error", error: `Pinchtab /sessions response missing sessionToken for agent ${agentId}` };
+  } catch (err: any) {
+    const reason = err?.name === "AbortError" ? `timed out after ${timeout}ms` : (err?.message || String(err));
+    return { kind: "error", error: `Pinchtab session creation failed for agent ${agentId}: ${reason}` };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function evictPinchtabSession(agentId: string | undefined): void {
+  if (agentId) pinchtabSessionTokens.delete(agentId);
+}
+
+export function clearPinchtabSessionCache(): void {
+  pinchtabSessionTokens.clear();
+}
+
+function buildRequestHeaders(
+  cfg: PluginConfig,
+  context: PluginRuntimeContext | undefined,
+  authToken: string | undefined,
+  authScheme: "Bearer" | "Session",
+): Record<string, string> {
   const headers: Record<string, string> = {};
-  if (cfg.token) headers["Authorization"] = `Bearer ${cfg.token}`;
+  if (authToken) headers["Authorization"] = `${authScheme} ${authToken}`;
   if (context?.agentId) headers["X-OpenClaw-Agent-Id"] = context.agentId;
-  if (context?.agentName) headers["X-OpenClaw-Agent-Name"] = context.agentName;
   if (context?.sessionId) headers["X-OpenClaw-Session-Id"] = context.sessionId;
   if (context?.sessionKey) headers["X-OpenClaw-Session-Key"] = context.sessionKey;
   return headers;
 }
 
+/**
+ * Caller must pass an already-resolved cfg (see `resolveEffectiveConfig` in session.ts).
+ * The two tool entry points (`executePinchtabAction`, `executeBrowserAction`) resolve once
+ * at the top and pass the resolved cfg through every subsequent call. Skipping resolution
+ * here means a raw cfg with empty baseUrl/token will hit `http://localhost:9867` blindly.
+ */
 export async function pinchtabFetch(
   cfg: PluginConfig,
   path: string,
   opts: { method?: string; body?: unknown; rawResponse?: boolean } = {},
   context?: PluginRuntimeContext,
 ): Promise<any> {
-  const effectiveCfg = await resolveEffectiveConfig(cfg);
-  const base = effectiveCfg.baseUrl || "http://localhost:9867";
+  const base = cfg.baseUrl || "http://localhost:9867";
+  const resolvedCfg = { ...cfg, baseUrl: base };
+
+  return performPinchtabFetch(resolvedCfg, path, opts, context, false);
+}
+
+async function performPinchtabFetch(
+  cfg: PluginConfig,
+  path: string,
+  opts: { method?: string; body?: unknown; rawResponse?: boolean },
+  context: PluginRuntimeContext | undefined,
+  alreadyRetriedSession: boolean,
+): Promise<any> {
+  const base = cfg.baseUrl as string;
   const url = `${base}${path}`;
-  const headers = buildRequestHeaders(effectiveCfg, context);
+  let authToken = cfg.token;
+  let authScheme: "Bearer" | "Session" = "Bearer";
+
+  if (!isServerTokenPath(path)) {
+    const resolution = await ensurePinchtabSession(cfg, context);
+    if (resolution.kind === "error") {
+      // Fail closed: do NOT silently fall back to the shared server token.
+      // Without a per-agent session, this agent would join the shared browser
+      // context, defeating per-agent isolation.
+      return { error: resolution.error };
+    }
+    if (resolution.kind === "ok") {
+      authToken = resolution.token;
+      authScheme = "Session";
+    }
+    // kind === "no-agent": legitimate bearer use (no agent context, e.g. CLI smoke).
+  }
+
+  const headers = buildRequestHeaders(cfg, context, authToken, authScheme);
   if (opts.body) headers["Content-Type"] = "application/json";
 
   const controller = new AbortController();
-  const timeout = effectiveCfg.timeoutMs ?? effectiveCfg.timeout ?? 30000;
+  const timeout = cfg.timeoutMs ?? cfg.timeout ?? 30000;
   const timer = setTimeout(() => controller.abort(), timeout);
 
   try {
@@ -34,6 +151,16 @@ export async function pinchtabFetch(
       body: opts.body ? JSON.stringify(opts.body) : undefined,
       signal: controller.signal,
     });
+
+    // Cached agent-session token may have been revoked or expired upstream; on
+    // the first 401 we evict and retry once to recover without restarting.
+    if (res.status === 401 && authScheme === "Session" && !alreadyRetriedSession) {
+      evictPinchtabSession(context?.agentId);
+      // Drain body to free the connection.
+      await res.text().catch(() => "");
+      return performPinchtabFetch(cfg, path, opts, context, true);
+    }
+
     if (opts.rawResponse) return res;
     const text = await res.text();
     if (!res.ok) {
@@ -90,15 +217,21 @@ export function actionErrorText(result: any): string {
   return `${result?.error || ""} ${result?.body || ""}`.toLowerCase();
 }
 
+const STALE_REF_PATTERNS: RegExp[] = [
+  /\bstale\b/,
+  /\bref\b/,
+  /\bno node\b/,
+  /\bunknown element\b/,
+  /\bcontext canceled\b/,
+  // Pinchtab backend-node failures: the cached ref points at a CDP node id
+  // that's been detached/garbage-collected.
+  /backend[\s-]?node/,
+  /\belement not found in dom\b/,
+  /\belement no longer (?:in|attached)\b/,
+];
+
 export function looksLikeStaleRef(result: any): boolean {
   if (!result?.error) return false;
   const text = actionErrorText(result);
-  return (
-    text.includes("stale") ||
-    text.includes("context canceled") ||
-    text.includes("ref") ||
-    text.includes("not found") ||
-    text.includes("no node") ||
-    text.includes("unknown element")
-  );
+  return STALE_REF_PATTERNS.some((re) => re.test(text));
 }

--- a/plugin/client.ts
+++ b/plugin/client.ts
@@ -1,18 +1,20 @@
 import type { PluginConfig, ToolResult } from "./types.js";
+import { resolveEffectiveConfig } from "./session.js";
 
 export async function pinchtabFetch(
   cfg: PluginConfig,
   path: string,
   opts: { method?: string; body?: unknown; rawResponse?: boolean } = {},
 ): Promise<any> {
-  const base = cfg.baseUrl || "http://localhost:9867";
+  const effectiveCfg = await resolveEffectiveConfig(cfg);
+  const base = effectiveCfg.baseUrl || "http://localhost:9867";
   const url = `${base}${path}`;
   const headers: Record<string, string> = {};
-  if (cfg.token) headers["Authorization"] = `Bearer ${cfg.token}`;
+  if (effectiveCfg.token) headers["Authorization"] = `Bearer ${effectiveCfg.token}`;
   if (opts.body) headers["Content-Type"] = "application/json";
 
   const controller = new AbortController();
-  const timeout = cfg.timeoutMs ?? cfg.timeout ?? 30000;
+  const timeout = effectiveCfg.timeoutMs ?? effectiveCfg.timeout ?? 30000;
   const timer = setTimeout(() => controller.abort(), timeout);
 
   try {

--- a/plugin/client.ts
+++ b/plugin/client.ts
@@ -1,16 +1,26 @@
-import type { PluginConfig, ToolResult } from "./types.js";
+import type { PluginConfig, PluginRuntimeContext, ToolResult } from "./types.js";
 import { resolveEffectiveConfig } from "./session.js";
+
+function buildRequestHeaders(cfg: PluginConfig, context?: PluginRuntimeContext): Record<string, string> {
+  const headers: Record<string, string> = {};
+  if (cfg.token) headers["Authorization"] = `Bearer ${cfg.token}`;
+  if (context?.agentId) headers["X-OpenClaw-Agent-Id"] = context.agentId;
+  if (context?.agentName) headers["X-OpenClaw-Agent-Name"] = context.agentName;
+  if (context?.sessionId) headers["X-OpenClaw-Session-Id"] = context.sessionId;
+  if (context?.sessionKey) headers["X-OpenClaw-Session-Key"] = context.sessionKey;
+  return headers;
+}
 
 export async function pinchtabFetch(
   cfg: PluginConfig,
   path: string,
   opts: { method?: string; body?: unknown; rawResponse?: boolean } = {},
+  context?: PluginRuntimeContext,
 ): Promise<any> {
   const effectiveCfg = await resolveEffectiveConfig(cfg);
   const base = effectiveCfg.baseUrl || "http://localhost:9867";
   const url = `${base}${path}`;
-  const headers: Record<string, string> = {};
-  if (effectiveCfg.token) headers["Authorization"] = `Bearer ${effectiveCfg.token}`;
+  const headers = buildRequestHeaders(effectiveCfg, context);
   if (opts.body) headers["Content-Type"] = "application/json";
 
   const controller = new AbortController();

--- a/plugin/index.ts
+++ b/plugin/index.ts
@@ -42,7 +42,7 @@ export default definePluginEntry({
         },
       } satisfies PluginTool;
       return pinchtabTool;
-    });
+    }, { optional: true });
 
     if (cfg.registerBrowserTool !== false) {
       api.registerTool((ctx) => {
@@ -57,7 +57,7 @@ export default definePluginEntry({
           },
         } satisfies PluginTool;
         return browserTool;
-      });
+      }, { optional: true });
     }
   },
 });

--- a/plugin/index.ts
+++ b/plugin/index.ts
@@ -6,6 +6,7 @@
  * - `browser`: OpenClaw-compatible simplified interface
  */
 
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
 import type { PluginApi, PluginConfig, PluginTool } from "./types.js";
 import { pinchtabToolSchema, pinchtabToolDescription, executePinchtabAction } from "./tools/pinchtab.js";
 import { browserToolSchema, browserToolDescription, executeBrowserAction } from "./tools/browser.js";
@@ -14,32 +15,35 @@ function getConfig(api: PluginApi): PluginConfig {
   return (api.pluginConfig ?? api.config?.plugins?.entries?.pinchtab?.config ?? {}) as PluginConfig;
 }
 
-export default function register(api: PluginApi) {
-  const cfg = getConfig(api);
+export default definePluginEntry({
+  id: "pinchtab",
+  name: "Pinchtab",
+  description: "Browser control for AI agents via Pinchtab.",
+  register(api) {
+    const cfg = getConfig(api);
 
-  // Register the full-featured pinchtab tool
-  const pinchtabTool = {
-    name: "pinchtab",
-    label: "PinchTab",
-    description: pinchtabToolDescription,
-    parameters: pinchtabToolSchema,
-    async execute(_id: string, params: any) {
-      return executePinchtabAction(getConfig(api), params);
-    },
-  } satisfies PluginTool;
-  api.registerTool(pinchtabTool, { optional: true });
-
-  // Register OpenClaw-compatible browser tool
-  if (cfg.registerBrowserTool !== false) {
-    const browserTool = {
-      name: "browser",
-      label: "Browser",
-      description: browserToolDescription,
-      parameters: browserToolSchema,
+    const pinchtabTool = {
+      name: "pinchtab",
+      label: "PinchTab",
+      description: pinchtabToolDescription,
+      parameters: pinchtabToolSchema,
       async execute(_id: string, params: any) {
-        return executeBrowserAction(getConfig(api), params);
+        return executePinchtabAction(getConfig(api), params);
       },
     } satisfies PluginTool;
-    api.registerTool(browserTool, { optional: true });
-  }
-}
+    api.registerTool(pinchtabTool);
+
+    if (cfg.registerBrowserTool !== false) {
+      const browserTool = {
+        name: "browser",
+        label: "Browser",
+        description: browserToolDescription,
+        parameters: browserToolSchema,
+        async execute(_id: string, params: any) {
+          return executeBrowserAction(getConfig(api), params);
+        },
+      } satisfies PluginTool;
+      api.registerTool(browserTool);
+    }
+  },
+});

--- a/plugin/index.ts
+++ b/plugin/index.ts
@@ -7,12 +7,20 @@
  */
 
 import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
-import type { PluginApi, PluginConfig, PluginTool } from "./types.js";
+import type { PluginApi, PluginConfig, PluginRuntimeContext, PluginTool, PluginToolContext } from "./types.js";
 import { pinchtabToolSchema, pinchtabToolDescription, executePinchtabAction } from "./tools/pinchtab.js";
 import { browserToolSchema, browserToolDescription, executeBrowserAction } from "./tools/browser.js";
 
 function getConfig(api: PluginApi): PluginConfig {
   return (api.pluginConfig ?? api.config?.plugins?.entries?.pinchtab?.config ?? {}) as PluginConfig;
+}
+
+function toRuntimeContext(ctx: PluginToolContext): PluginRuntimeContext {
+  return {
+    agentId: ctx.agentId,
+    sessionId: ctx.sessionId,
+    sessionKey: ctx.sessionKey,
+  };
 }
 
 export default definePluginEntry({
@@ -22,28 +30,34 @@ export default definePluginEntry({
   register(api) {
     const cfg = getConfig(api);
 
-    const pinchtabTool = {
-      name: "pinchtab",
-      label: "PinchTab",
-      description: pinchtabToolDescription,
-      parameters: pinchtabToolSchema,
-      async execute(_id: string, params: any) {
-        return executePinchtabAction(getConfig(api), params);
-      },
-    } satisfies PluginTool;
-    api.registerTool(pinchtabTool);
-
-    if (cfg.registerBrowserTool !== false) {
-      const browserTool = {
-        name: "browser",
-        label: "Browser",
-        description: browserToolDescription,
-        parameters: browserToolSchema,
+    api.registerTool((ctx) => {
+      const runtimeContext = toRuntimeContext(ctx);
+      const pinchtabTool = {
+        name: "pinchtab",
+        label: "PinchTab",
+        description: pinchtabToolDescription,
+        parameters: pinchtabToolSchema,
         async execute(_id: string, params: any) {
-          return executeBrowserAction(getConfig(api), params);
+          return executePinchtabAction(getConfig(api), params, runtimeContext);
         },
       } satisfies PluginTool;
-      api.registerTool(browserTool);
+      return pinchtabTool;
+    });
+
+    if (cfg.registerBrowserTool !== false) {
+      api.registerTool((ctx) => {
+        const runtimeContext = toRuntimeContext(ctx);
+        const browserTool = {
+          name: "browser",
+          label: "Browser",
+          description: browserToolDescription,
+          parameters: browserToolSchema,
+          async execute(_id: string, params: any) {
+            return executeBrowserAction(getConfig(api), params, runtimeContext);
+          },
+        } satisfies PluginTool;
+        return browserTool;
+      });
     }
   },
 });

--- a/plugin/navigation.test.ts
+++ b/plugin/navigation.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, it } from "node:test";
+import assert from "node:assert";
+import { executeBrowserAction } from "./tools/browser.ts";
+import { executePinchtabAction } from "./tools/pinchtab.ts";
+import { setLastTabId } from "./session.ts";
+
+type FetchCall = { url: string; method: string; body?: any };
+
+const originalFetch = globalThis.fetch;
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: init.status ?? 200,
+    headers: { "Content-Type": "application/json", ...(init.headers || {}) },
+  });
+}
+
+describe("navigation routing", () => {
+  let calls: FetchCall[] = [];
+
+  beforeEach(() => {
+    calls = [];
+    setLastTabId(undefined);
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      const method = init?.method || "GET";
+      const body = typeof init?.body === "string" ? JSON.parse(init.body) : undefined;
+      calls.push({ url, method, body });
+
+      const path = new URL(url).pathname;
+      if (path === "/health") return jsonResponse({ ok: true, version: "test" });
+      if (path === "/instances") return jsonResponse([{ id: "inst_a", status: "running" }]);
+      if (path === "/navigate") return jsonResponse({ tabId: "tab_nav" });
+      if (path === "/tab") return jsonResponse({ tabId: "tab_new" });
+      if (path === "/tabs/tab_existing/navigate") return jsonResponse({ tabId: "tab_existing" });
+      throw new Error(`unexpected fetch: ${path}`);
+    }) as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("browser navigate reuses top-level /navigate when tabId is absent", async () => {
+    const result = await executeBrowserAction({ baseUrl: "http://localhost:9867" }, { action: "navigate", url: "https://example.com" });
+    assert.match(result.content[0].text, /tab_nav/);
+    assert.ok(calls.some((call) => new URL(call.url).pathname === "/navigate"));
+    assert.ok(!calls.some((call) => new URL(call.url).pathname === "/tab"));
+  });
+
+  it("browser navigate still uses /tab for explicit newTab", async () => {
+    const result = await executeBrowserAction({ baseUrl: "http://localhost:9867" }, { action: "navigate", url: "https://example.com", newTab: true });
+    assert.match(result.content[0].text, /tab_new/);
+    assert.ok(calls.some((call) => new URL(call.url).pathname === "/tab"));
+  });
+
+  it("pinchtab navigate reuses top-level /navigate when tabId is absent", async () => {
+    const result = await executePinchtabAction({ baseUrl: "http://localhost:9867" }, { action: "navigate", url: "https://example.com" });
+    assert.match(result.content[0].text, /tab_nav/);
+    assert.ok(calls.some((call) => new URL(call.url).pathname === "/navigate"));
+    assert.ok(!calls.some((call) => new URL(call.url).pathname === "/tab"));
+  });
+
+  it("pinchtab navigate uses tab-scoped route when tabId is present", async () => {
+    const result = await executePinchtabAction({ baseUrl: "http://localhost:9867", persistSessionTabs: false }, { action: "navigate", url: "https://example.com", tabId: "tab_existing" });
+    assert.match(result.content[0].text, /tab_existing/);
+    assert.ok(calls.some((call) => new URL(call.url).pathname === "/tabs/tab_existing/navigate"));
+  });
+});

--- a/plugin/openclaw-api.test.ts
+++ b/plugin/openclaw-api.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert";
-import type { AnyAgentTool, OpenClawPluginApi, OpenClawPluginToolContext, PluginLogger, PluginRuntime } from "openclaw/plugin-sdk";
+import type { AnyAgentTool, OpenClawPluginApi, OpenClawPluginToolContext, PluginLogger } from "openclaw/plugin-sdk/plugin-entry";
+import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
 import pluginEntry from "./index.ts";
 
 type RegisteredToolOptions = Parameters<OpenClawPluginApi["registerTool"]>[1];
@@ -125,7 +126,7 @@ describe("OpenClaw plugin API contract", () => {
       assert.strictEqual(typeof tool.description, "string");
       assert.strictEqual(typeof tool.execute, "function");
       assert.strictEqual((tool.parameters as { type?: string }).type, "object");
-      assert.strictEqual(opts, undefined);
+      assert.deepStrictEqual(opts, { optional: true });
     }
   });
 

--- a/plugin/openclaw-api.test.ts
+++ b/plugin/openclaw-api.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert";
 import type { AnyAgentTool, OpenClawPluginApi, PluginLogger, PluginRuntime } from "openclaw/plugin-sdk";
-import register from "./index.ts";
+import pluginEntry from "./index.ts";
 
 type RegisteredToolOptions = Parameters<OpenClawPluginApi["registerTool"]>[1];
 type TestPluginApiInput = Partial<OpenClawPluginApi>;
@@ -107,7 +107,7 @@ describe("OpenClaw plugin API contract", () => {
       },
     });
 
-    register(api);
+    pluginEntry.register(api);
 
     assert.deepStrictEqual(
       registered.map(({ tool }) => tool.name).sort(),
@@ -118,7 +118,7 @@ describe("OpenClaw plugin API contract", () => {
       assert.strictEqual(typeof tool.description, "string");
       assert.strictEqual(typeof tool.execute, "function");
       assert.strictEqual((tool.parameters as { type?: string }).type, "object");
-      assert.strictEqual(opts?.optional, true);
+      assert.strictEqual(opts, undefined);
     }
   });
 
@@ -134,7 +134,7 @@ describe("OpenClaw plugin API contract", () => {
       },
     });
 
-    register(api);
+    pluginEntry.register(api);
 
     assert.deepStrictEqual(names, ["pinchtab"]);
   });

--- a/plugin/openclaw-api.test.ts
+++ b/plugin/openclaw-api.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert";
-import type { AnyAgentTool, OpenClawPluginApi, PluginLogger, PluginRuntime } from "openclaw/plugin-sdk";
+import type { AnyAgentTool, OpenClawPluginApi, OpenClawPluginToolContext, PluginLogger, PluginRuntime } from "openclaw/plugin-sdk";
 import pluginEntry from "./index.ts";
 
 type RegisteredToolOptions = Parameters<OpenClawPluginApi["registerTool"]>[1];
@@ -87,6 +87,12 @@ function createTestPluginApi(api: TestPluginApiInput): OpenClawPluginApi {
   };
 }
 
+const testToolContext: OpenClawPluginToolContext = {
+  agentId: "main",
+  sessionId: "session-1",
+  sessionKey: "chat:main",
+};
+
 describe("OpenClaw plugin API contract", () => {
   it("registers tools through the official OpenClaw plugin API", () => {
     const registered: Array<{ tool: AnyAgentTool; opts?: RegisteredToolOptions }> = [];
@@ -102,8 +108,9 @@ describe("OpenClaw plugin API contract", () => {
         },
       },
       registerTool(tool, opts) {
-        assert.strictEqual(typeof tool, "object");
-        registered.push({ tool: tool as AnyAgentTool, opts });
+        const resolved = typeof tool === "function" ? tool(testToolContext) : tool;
+        assert.ok(resolved);
+        registered.push({ tool: resolved as AnyAgentTool, opts });
       },
     });
 
@@ -129,8 +136,9 @@ describe("OpenClaw plugin API contract", () => {
       name: "Pinchtab",
       pluginConfig: { registerBrowserTool: false },
       registerTool(tool) {
-        assert.strictEqual(typeof tool, "object");
-        names.push((tool as AnyAgentTool).name);
+        const resolved = typeof tool === "function" ? tool(testToolContext) : tool;
+        assert.ok(resolved);
+        names.push((resolved as AnyAgentTool).name);
       },
     });
 

--- a/plugin/openclaw.plugin.json
+++ b/plugin/openclaw.plugin.json
@@ -3,7 +3,13 @@
   "name": "Pinchtab",
   "description": "Browser control for AI agents via Pinchtab. Single tool, all actions: navigate, snapshot, click/type/press/fill/hover/scroll/select/focus, mouse-move/mouse-down/mouse-up/mouse-wheel, text, screenshot, evaluate, pdf.",
   "version": "0.3.0",
-  "skills": ["../skills/pinchtab"],
+  "contracts": {
+    "tools": ["pinchtab", "browser"]
+  },
+  "activation": {
+    "onStartup": true
+  },
+  "skills": ["./skills/pinchtab"],
   "configSchema": {
     "type": "object",
     "additionalProperties": false,
@@ -20,20 +26,6 @@
       "timeoutMs": {
         "type": "number",
         "description": "Default request timeout in milliseconds",
-        "default": 30000
-      },
-      "autoStart": {
-        "type": "boolean",
-        "description": "Auto-start local Pinchtab server if not running",
-        "default": true
-      },
-      "binaryPath": {
-        "type": "string",
-        "description": "Path to pinchtab binary (default: search PATH)"
-      },
-      "startupTimeoutMs": {
-        "type": "number",
-        "description": "Max time to wait for server startup",
         "default": 30000
       },
       "allowEvaluate": {
@@ -111,9 +103,6 @@
     "baseUrl": { "label": "Base URL", "placeholder": "http://localhost:9867" },
     "token": { "label": "Auth Token", "sensitive": true },
     "timeoutMs": { "label": "Timeout (ms)", "placeholder": "30000" },
-    "autoStart": { "label": "Auto-start Server" },
-    "binaryPath": { "label": "Binary Path", "placeholder": "pinchtab" },
-    "startupTimeoutMs": { "label": "Startup Timeout (ms)", "placeholder": "30000" },
     "allowEvaluate": { "label": "Allow JS Evaluate" },
     "allowedDomains": { "label": "Allowed Domains" },
     "allowDownloads": { "label": "Allow Downloads" },

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -4,6 +4,9 @@
   "description": "OpenClaw plugin for PinchTab browser control",
   "type": "module",
   "scripts": {
+    "sync:skills": "node ./scripts/sync-skills.mjs",
+    "pretest": "npm run sync:skills",
+    "prepack": "npm run sync:skills",
     "test": "tsx --test *.test.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "check": "npm run typecheck && npm test"
@@ -24,6 +27,8 @@
     "policy.ts",
     "session.ts",
     "tools/",
+    "skills/",
+    "scripts/",
     "openclaw.plugin.json"
   ],
   "license": "MIT",

--- a/plugin/scripts/sync-skills.mjs
+++ b/plugin/scripts/sync-skills.mjs
@@ -1,0 +1,19 @@
+import { cpSync, existsSync, mkdirSync, rmSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const pluginDir = resolve(scriptDir, '..');
+const sourceDir = resolve(pluginDir, '..', 'skills', 'pinchtab');
+const destinationDir = resolve(pluginDir, 'skills', 'pinchtab');
+
+if (!existsSync(sourceDir)) {
+  console.error(`missing source skill directory: ${sourceDir}`);
+  process.exit(1);
+}
+
+mkdirSync(resolve(pluginDir, 'skills'), { recursive: true });
+rmSync(destinationDir, { recursive: true, force: true });
+cpSync(sourceDir, destinationDir, { recursive: true });
+
+console.log(`synced ${sourceDir} -> ${destinationDir}`);

--- a/plugin/session.test.ts
+++ b/plugin/session.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach } from "node:test";
 import assert from "node:assert";
-import { getLastTabId, setLastTabId, resolveProfile, isLocalHost } from "./session.ts";
+import { getLastTabId, setLastTabId, resolveProfile, isLocalHost, formatDiscoveredBaseUrl } from "./session.ts";
 
 describe("tab session state", () => {
   beforeEach(() => {
@@ -91,5 +91,17 @@ describe("isLocalHost", () => {
   it("returns false for invalid URLs", () => {
     assert.strictEqual(isLocalHost("not-a-url"), false);
     assert.strictEqual(isLocalHost(""), false);
+  });
+});
+
+
+describe("formatDiscoveredBaseUrl", () => {
+  it("brackets IPv6 loopback binds", () => {
+    assert.strictEqual(formatDiscoveredBaseUrl("::1", 9867), "http://[::1]:9867");
+  });
+
+  it("normalizes wildcard binds to local loopback", () => {
+    assert.strictEqual(formatDiscoveredBaseUrl("0.0.0.0", 9867), "http://127.0.0.1:9867");
+    assert.strictEqual(formatDiscoveredBaseUrl("::", 9867), "http://[::1]:9867");
   });
 });

--- a/plugin/session.test.ts
+++ b/plugin/session.test.ts
@@ -5,6 +5,8 @@ import { getLastTabId, setLastTabId, resolveProfile, isLocalHost, formatDiscover
 describe("tab session state", () => {
   beforeEach(() => {
     setLastTabId(undefined);
+    setLastTabId(undefined, { agentId: "main" });
+    setLastTabId(undefined, { agentId: "writer" });
   });
 
   it("starts with undefined tabId", () => {
@@ -14,6 +16,14 @@ describe("tab session state", () => {
   it("stores and retrieves tabId", () => {
     setLastTabId("tab123");
     assert.strictEqual(getLastTabId(), "tab123");
+  });
+
+  it("keeps tab state isolated per agent", () => {
+    setLastTabId("main-tab", { agentId: "main", sessionId: "s1" });
+    setLastTabId("writer-tab", { agentId: "writer", sessionId: "s2" });
+    assert.strictEqual(getLastTabId({ agentId: "main" }), "main-tab");
+    assert.strictEqual(getLastTabId({ agentId: "writer" }), "writer-tab");
+    assert.strictEqual(getLastTabId(), undefined);
   });
 
   it("can clear tabId", () => {

--- a/plugin/session.ts
+++ b/plugin/session.ts
@@ -1,9 +1,27 @@
+import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import type { PluginConfig } from "./types.js";
 import { pinchtabFetch } from "./client.js";
 
-let serverStarted = false;
+const instanceReadyRetryDelayMs = 500;
+const instanceReadyMaxWaitMs = 12000;
+
 let lastTabId: string | undefined;
-let startupPromise: Promise<{ ok: boolean; error?: string; autoStarted?: boolean }> | null = null;
+let discoveredConfig: { baseUrl?: string; token?: string } | null | undefined;
+
+export function normalizeDiscoveredHost(bind: string): string {
+  if (bind === "0.0.0.0") return "127.0.0.1";
+  if (bind === "::") return "::1";
+  return bind;
+}
+
+export function formatHostForUrl(host: string): string {
+  if (host.includes(":") && !host.startsWith("[") && !host.endsWith("]")) {
+    return `[${host}]`;
+  }
+  return host;
+}
 
 export function isLocalHost(baseUrl: string): boolean {
   try {
@@ -34,21 +52,64 @@ export function resolveProfile(cfg: PluginConfig, profile?: string): { instanceI
   return {};
 }
 
+async function discoverPinchtabConfig(): Promise<{ baseUrl?: string; token?: string } | null> {
+  if (discoveredConfig !== undefined) {
+    return discoveredConfig;
+  }
+
+  try {
+    const path = join(homedir(), ".pinchtab", "config.json");
+    const raw = await readFile(path, "utf8");
+    const parsed = JSON.parse(raw);
+    const bind = parsed?.server?.bind || "127.0.0.1";
+    const port = parsed?.server?.port;
+    const token = parsed?.server?.token;
+
+    let baseUrl: string | undefined;
+    if (port) {
+      const host = formatHostForUrl(normalizeDiscoveredHost(bind));
+      baseUrl = `http://${host}:${port}`;
+    }
+
+    discoveredConfig = {
+      baseUrl,
+      token: typeof token === "string" && token ? token : undefined,
+    };
+    return discoveredConfig;
+  } catch {
+    discoveredConfig = null;
+    return discoveredConfig;
+  }
+}
+
+export function formatDiscoveredBaseUrl(bind: string, port: string | number): string {
+  return `http://${formatHostForUrl(normalizeDiscoveredHost(bind))}:${port}`;
+}
+
+export async function resolveEffectiveConfig(cfg: PluginConfig): Promise<PluginConfig> {
+  const discovered = await discoverPinchtabConfig();
+  return {
+    ...cfg,
+    baseUrl: cfg.baseUrl || discovered?.baseUrl || "http://localhost:9867",
+    token: cfg.token || discovered?.token,
+  };
+}
+
 export async function getEnhancedHealth(cfg: PluginConfig): Promise<any> {
-  const base = cfg.baseUrl || "http://localhost:9867";
-  const health = await pinchtabFetch(cfg, "/health");
+  const effectiveCfg = await resolveEffectiveConfig(cfg);
+  const base = effectiveCfg.baseUrl || "http://localhost:9867";
+  const health = await pinchtabFetch(effectiveCfg, "/health");
   const serverOk = !health?.error;
 
   const result: any = {
     server: serverOk ? "ok" : "unreachable",
     baseUrl: base,
-    autoStart: cfg.autoStart !== false,
-    defaultProfile: cfg.defaultProfile || "openclaw",
+    defaultProfile: effectiveCfg.defaultProfile || "openclaw",
     policies: {
-      allowEvaluate: cfg.allowEvaluate === true,
-      allowDownloads: cfg.allowDownloads === true,
-      allowUploads: cfg.allowUploads === true,
-      allowedDomains: cfg.allowedDomains?.length ? cfg.allowedDomains : "all",
+      allowEvaluate: effectiveCfg.allowEvaluate === true,
+      allowDownloads: effectiveCfg.allowDownloads === true,
+      allowUploads: effectiveCfg.allowUploads === true,
+      allowedDomains: effectiveCfg.allowedDomains?.length ? effectiveCfg.allowedDomains : "all",
     },
   };
 
@@ -57,77 +118,79 @@ export async function getEnhancedHealth(cfg: PluginConfig): Promise<any> {
     if (health?.version) result.serverVersion = health.version;
   } else {
     result.error = health?.error;
+    if (isLocalHost(base)) {
+      result.hint = `Pinchtab is not reachable at ${base}. Start it with: pinchtab server`;
+    }
   }
 
   const warnings: string[] = [];
-  if (cfg.allowEvaluate) warnings.push("evaluate enabled - JS execution allowed");
-  if (!cfg.allowedDomains?.length) warnings.push("no domain restrictions");
+  if (effectiveCfg.allowEvaluate) warnings.push("evaluate enabled - JS execution allowed");
+  if (!effectiveCfg.allowedDomains?.length) warnings.push("no domain restrictions");
   if (warnings.length) result.warnings = warnings;
 
   return result;
 }
 
 export async function ensureServerRunning(cfg: PluginConfig): Promise<{ ok: boolean; error?: string; autoStarted?: boolean }> {
-  const base = cfg.baseUrl || "http://localhost:9867";
-
-  const healthCheck = await pinchtabFetch(cfg, "/health");
+  const effectiveCfg = await resolveEffectiveConfig(cfg);
+  const base = effectiveCfg.baseUrl || "http://localhost:9867";
+  const healthCheck = await pinchtabFetch(effectiveCfg, "/health");
   if (!healthCheck?.error) {
     return { ok: true };
   }
 
-  if (!isLocalHost(base) || cfg.autoStart === false || serverStarted) {
-    return { ok: false, error: healthCheck.error };
-  }
-
-  // Single-flight guard: if startup is in progress, wait for it
-  if (startupPromise) {
-    return startupPromise;
-  }
-
-  startupPromise = doStartServer(cfg);
-  try {
-    return await startupPromise;
-  } finally {
-    startupPromise = null;
-  }
+  const hint = isLocalHost(base)
+    ? ` Pinchtab is not running at ${base}. Start it with: pinchtab server`
+    : "";
+  return { ok: false, error: `${healthCheck.error}${hint}` };
 }
 
-async function resolveBinaryPath(binary: string): Promise<string> {
-  if (binary.startsWith("/") || binary.startsWith("./")) {
-    return binary;
-  }
-  try {
-    const { execFileSync } = await import("child_process");
-    const resolved = execFileSync("which", [binary], { encoding: "utf8" }).trim();
-    return resolved || binary;
-  } catch {
-    return binary;
-  }
-}
+export async function waitForInstanceReady(cfg: PluginConfig, instanceId?: string): Promise<{ ok: boolean; error?: string }> {
+  const effectiveCfg = await resolveEffectiveConfig(cfg);
+  const start = Date.now();
+  let lastError = "instance not ready";
 
-async function doStartServer(cfg: PluginConfig): Promise<{ ok: boolean; error?: string; autoStarted?: boolean }> {
-  const binary = await resolveBinaryPath(cfg.binaryPath || "pinchtab");
-  const startupTimeout = cfg.startupTimeoutMs ?? 30000;
-
-  try {
-    const { spawn } = await import("child_process");
-    const proc = spawn(binary, ["server"], {
-      detached: true,
-      stdio: "ignore",
-    });
-    proc.unref();
-    serverStarted = true;
-
-    const startTime = Date.now();
-    while (Date.now() - startTime < startupTimeout) {
-      await new Promise((r) => setTimeout(r, 500));
-      const check = await pinchtabFetch(cfg, "/health");
-      if (!check?.error) {
-        return { ok: true, autoStarted: true };
+  while (Date.now() - start < instanceReadyMaxWaitMs) {
+    const health = await pinchtabFetch(effectiveCfg, "/health");
+    if (!health?.error) {
+      const instances = await pinchtabFetch(effectiveCfg, "/instances");
+      const list = Array.isArray(instances?.value)
+        ? instances.value
+        : Array.isArray(instances)
+          ? instances
+          : [];
+      const running = instanceId
+        ? list.find((instance: any) => instance?.id === instanceId && instance?.status === "running")
+        : list.find((instance: any) => instance?.status === "running" && instance?.id);
+      if (running) {
+        return { ok: true };
       }
+      if (instanceId && list.some((instance: any) => instance?.id === instanceId)) {
+        lastError = `instance ${instanceId} not ready`;
+      }
+    } else {
+      lastError = health.error || lastError;
     }
-    return { ok: false, error: `Server failed to start within ${startupTimeout}ms` };
-  } catch (err: any) {
-    return { ok: false, error: `Failed to start pinchtab: ${err?.message}` };
+
+    if (instanceId) {
+      await new Promise((resolve) => setTimeout(resolve, instanceReadyRetryDelayMs));
+      continue;
+    }
+
+    const tabs = await pinchtabFetch(effectiveCfg, "/tabs");
+    if (!tabs?.error) {
+      return { ok: true };
+    }
+
+    const text = `${tabs?.error || ""} ${tabs?.body || ""}`.toLowerCase();
+    lastError = tabs?.error || lastError;
+
+    if (!text.includes("instance not ready") && !text.includes("may be restarting") && !text.includes("503")) {
+      return { ok: false, error: tabs?.error || "unknown readiness error" };
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, instanceReadyRetryDelayMs));
   }
+
+  return { ok: false, error: `Timed out waiting for Pinchtab instance readiness: ${lastError}` };
 }

--- a/plugin/session.ts
+++ b/plugin/session.ts
@@ -6,12 +6,28 @@ import { pinchtabFetch } from "./client.js";
 
 const instanceReadyRetryDelayMs = 500;
 const instanceReadyMaxWaitMs = 12000;
+const agentSessionMaxEntries = 256;
+const agentSessionMaxAgeMs = 60 * 60 * 1000;
 
 const agentSessions = new Map<string, AgentSessionState>();
-let discoveredConfig: { baseUrl?: string; token?: string } | null | undefined;
 
 function resolveSessionStateKey(context?: PluginRuntimeContext): string {
   return context?.agentId || context?.sessionId || "global";
+}
+
+function pruneAgentSessions(): void {
+  const cutoff = Date.now() - agentSessionMaxAgeMs;
+  for (const [key, state] of agentSessions) {
+    if ((state.updatedAt ?? 0) < cutoff) agentSessions.delete(key);
+  }
+  if (agentSessions.size <= agentSessionMaxEntries) return;
+  const ordered = [...agentSessions.entries()].sort(
+    (a, b) => (a[1].updatedAt ?? 0) - (b[1].updatedAt ?? 0),
+  );
+  for (const [key] of ordered) {
+    if (agentSessions.size <= agentSessionMaxEntries) break;
+    agentSessions.delete(key);
+  }
 }
 
 export function rememberRuntimeContext(context?: PluginRuntimeContext): AgentSessionState {
@@ -20,13 +36,13 @@ export function rememberRuntimeContext(context?: PluginRuntimeContext): AgentSes
   const next: AgentSessionState = {
     key,
     agentId: context?.agentId ?? existing?.agentId,
-    agentName: context?.agentName ?? existing?.agentName,
     sessionId: context?.sessionId ?? existing?.sessionId,
     sessionKey: context?.sessionKey ?? existing?.sessionKey,
     lastTabId: existing?.lastTabId,
     updatedAt: Date.now(),
   };
   agentSessions.set(key, next);
+  pruneAgentSessions();
   return next;
 }
 
@@ -65,7 +81,6 @@ export function setLastTabId(tabId: string | undefined, context?: PluginRuntimeC
   const state = rememberRuntimeContext(context);
   state.lastTabId = tabId;
   state.updatedAt = Date.now();
-  agentSessions.set(state.key, state);
 }
 
 export function resolveProfile(
@@ -85,10 +100,6 @@ export function resolveProfile(
 }
 
 async function discoverPinchtabConfig(): Promise<{ baseUrl?: string; token?: string } | null> {
-  if (discoveredConfig !== undefined) {
-    return discoveredConfig;
-  }
-
   try {
     const path = join(homedir(), ".pinchtab", "config.json");
     const raw = await readFile(path, "utf8");
@@ -103,14 +114,12 @@ async function discoverPinchtabConfig(): Promise<{ baseUrl?: string; token?: str
       baseUrl = `http://${host}:${port}`;
     }
 
-    discoveredConfig = {
+    return {
       baseUrl,
       token: typeof token === "string" && token ? token : undefined,
     };
-    return discoveredConfig;
   } catch {
-    discoveredConfig = null;
-    return discoveredConfig;
+    return null;
   }
 }
 
@@ -119,6 +128,7 @@ export function formatDiscoveredBaseUrl(bind: string, port: string | number): st
 }
 
 export async function resolveEffectiveConfig(cfg: PluginConfig): Promise<PluginConfig> {
+  if (cfg.baseUrl && cfg.token) return cfg;
   const discovered = await discoverPinchtabConfig();
   return {
     ...cfg,
@@ -128,28 +138,26 @@ export async function resolveEffectiveConfig(cfg: PluginConfig): Promise<PluginC
 }
 
 export async function getEnhancedHealth(cfg: PluginConfig, context?: PluginRuntimeContext): Promise<any> {
-  const effectiveCfg = await resolveEffectiveConfig(cfg);
-  const base = effectiveCfg.baseUrl || "http://localhost:9867";
-  const health = await pinchtabFetch(effectiveCfg, "/health", {}, context);
+  const base = cfg.baseUrl || "http://localhost:9867";
+  const health = await pinchtabFetch(cfg, "/health", {}, context);
   const serverOk = !health?.error;
   const agentSession = getAgentSessionState(context);
 
   const result: any = {
     server: serverOk ? "ok" : "unreachable",
     baseUrl: base,
-    defaultProfile: effectiveCfg.defaultProfile || "openclaw",
+    defaultProfile: cfg.defaultProfile || "openclaw",
     policies: {
-      allowEvaluate: effectiveCfg.allowEvaluate === true,
-      allowDownloads: effectiveCfg.allowDownloads === true,
-      allowUploads: effectiveCfg.allowUploads === true,
-      allowedDomains: effectiveCfg.allowedDomains?.length ? effectiveCfg.allowedDomains : "all",
+      allowEvaluate: cfg.allowEvaluate === true,
+      allowDownloads: cfg.allowDownloads === true,
+      allowUploads: cfg.allowUploads === true,
+      allowedDomains: cfg.allowedDomains?.length ? cfg.allowedDomains : "all",
     },
   };
 
   if (agentSession) {
     result.agentSession = {
       agentId: agentSession.agentId,
-      agentName: agentSession.agentName,
       sessionId: agentSession.sessionId,
       sessionKey: agentSession.sessionKey,
       lastTabId: agentSession.lastTabId,
@@ -167,8 +175,8 @@ export async function getEnhancedHealth(cfg: PluginConfig, context?: PluginRunti
   }
 
   const warnings: string[] = [];
-  if (effectiveCfg.allowEvaluate) warnings.push("evaluate enabled - JS execution allowed");
-  if (!effectiveCfg.allowedDomains?.length) warnings.push("no domain restrictions");
+  if (cfg.allowEvaluate) warnings.push("evaluate enabled - JS execution allowed");
+  if (!cfg.allowedDomains?.length) warnings.push("no domain restrictions");
   if (warnings.length) result.warnings = warnings;
 
   return result;
@@ -177,10 +185,9 @@ export async function getEnhancedHealth(cfg: PluginConfig, context?: PluginRunti
 export async function ensureServerRunning(
   cfg: PluginConfig,
   context?: PluginRuntimeContext,
-): Promise<{ ok: boolean; error?: string; autoStarted?: boolean }> {
-  const effectiveCfg = await resolveEffectiveConfig(cfg);
-  const base = effectiveCfg.baseUrl || "http://localhost:9867";
-  const healthCheck = await pinchtabFetch(effectiveCfg, "/health", {}, context);
+): Promise<{ ok: boolean; error?: string }> {
+  const base = cfg.baseUrl || "http://localhost:9867";
+  const healthCheck = await pinchtabFetch(cfg, "/health", {}, context);
   if (!healthCheck?.error) {
     return { ok: true };
   }
@@ -196,14 +203,13 @@ export async function waitForInstanceReady(
   instanceId?: string,
   context?: PluginRuntimeContext,
 ): Promise<{ ok: boolean; error?: string }> {
-  const effectiveCfg = await resolveEffectiveConfig(cfg);
   const start = Date.now();
   let lastError = "instance not ready";
 
   while (Date.now() - start < instanceReadyMaxWaitMs) {
-    const health = await pinchtabFetch(effectiveCfg, "/health", {}, context);
+    const health = await pinchtabFetch(cfg, "/health", {}, context);
     if (!health?.error) {
-      const instances = await pinchtabFetch(effectiveCfg, "/instances", {}, context);
+      const instances = await pinchtabFetch(cfg, "/instances", {}, context);
       const list = Array.isArray(instances?.value)
         ? instances.value
         : Array.isArray(instances)
@@ -227,7 +233,7 @@ export async function waitForInstanceReady(
       continue;
     }
 
-    const tabs = await pinchtabFetch(effectiveCfg, "/tabs", {}, context);
+    const tabs = await pinchtabFetch(cfg, "/tabs", {}, context);
     if (!tabs?.error) {
       return { ok: true };
     }

--- a/plugin/session.ts
+++ b/plugin/session.ts
@@ -1,14 +1,38 @@
 import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import type { PluginConfig } from "./types.js";
+import type { AgentSessionState, PluginConfig, PluginRuntimeContext } from "./types.js";
 import { pinchtabFetch } from "./client.js";
 
 const instanceReadyRetryDelayMs = 500;
 const instanceReadyMaxWaitMs = 12000;
 
-let lastTabId: string | undefined;
+const agentSessions = new Map<string, AgentSessionState>();
 let discoveredConfig: { baseUrl?: string; token?: string } | null | undefined;
+
+function resolveSessionStateKey(context?: PluginRuntimeContext): string {
+  return context?.agentId || context?.sessionId || "global";
+}
+
+export function rememberRuntimeContext(context?: PluginRuntimeContext): AgentSessionState {
+  const key = resolveSessionStateKey(context);
+  const existing = agentSessions.get(key);
+  const next: AgentSessionState = {
+    key,
+    agentId: context?.agentId ?? existing?.agentId,
+    agentName: context?.agentName ?? existing?.agentName,
+    sessionId: context?.sessionId ?? existing?.sessionId,
+    sessionKey: context?.sessionKey ?? existing?.sessionKey,
+    lastTabId: existing?.lastTabId,
+    updatedAt: Date.now(),
+  };
+  agentSessions.set(key, next);
+  return next;
+}
+
+export function getAgentSessionState(context?: PluginRuntimeContext): AgentSessionState | undefined {
+  return agentSessions.get(resolveSessionStateKey(context));
+}
 
 export function normalizeDiscoveredHost(bind: string): string {
   if (bind === "0.0.0.0") return "127.0.0.1";
@@ -33,15 +57,23 @@ export function isLocalHost(baseUrl: string): boolean {
   }
 }
 
-export function getLastTabId(): string | undefined {
-  return lastTabId;
+export function getLastTabId(context?: PluginRuntimeContext): string | undefined {
+  return getAgentSessionState(context)?.lastTabId;
 }
 
-export function setLastTabId(tabId: string | undefined): void {
-  lastTabId = tabId;
+export function setLastTabId(tabId: string | undefined, context?: PluginRuntimeContext): void {
+  const state = rememberRuntimeContext(context);
+  state.lastTabId = tabId;
+  state.updatedAt = Date.now();
+  agentSessions.set(state.key, state);
 }
 
-export function resolveProfile(cfg: PluginConfig, profile?: string): { instanceId?: string; attach?: boolean } {
+export function resolveProfile(
+  cfg: PluginConfig,
+  profile?: string,
+  context?: PluginRuntimeContext,
+): { instanceId?: string; attach?: boolean } {
+  rememberRuntimeContext(context);
   const name = profile || cfg.defaultProfile || "openclaw";
   if (cfg.profiles?.[name]) {
     return cfg.profiles[name];
@@ -95,11 +127,12 @@ export async function resolveEffectiveConfig(cfg: PluginConfig): Promise<PluginC
   };
 }
 
-export async function getEnhancedHealth(cfg: PluginConfig): Promise<any> {
+export async function getEnhancedHealth(cfg: PluginConfig, context?: PluginRuntimeContext): Promise<any> {
   const effectiveCfg = await resolveEffectiveConfig(cfg);
   const base = effectiveCfg.baseUrl || "http://localhost:9867";
-  const health = await pinchtabFetch(effectiveCfg, "/health");
+  const health = await pinchtabFetch(effectiveCfg, "/health", {}, context);
   const serverOk = !health?.error;
+  const agentSession = getAgentSessionState(context);
 
   const result: any = {
     server: serverOk ? "ok" : "unreachable",
@@ -112,6 +145,16 @@ export async function getEnhancedHealth(cfg: PluginConfig): Promise<any> {
       allowedDomains: effectiveCfg.allowedDomains?.length ? effectiveCfg.allowedDomains : "all",
     },
   };
+
+  if (agentSession) {
+    result.agentSession = {
+      agentId: agentSession.agentId,
+      agentName: agentSession.agentName,
+      sessionId: agentSession.sessionId,
+      sessionKey: agentSession.sessionKey,
+      lastTabId: agentSession.lastTabId,
+    };
+  }
 
   if (serverOk) {
     result.serverHealth = health;
@@ -131,10 +174,13 @@ export async function getEnhancedHealth(cfg: PluginConfig): Promise<any> {
   return result;
 }
 
-export async function ensureServerRunning(cfg: PluginConfig): Promise<{ ok: boolean; error?: string; autoStarted?: boolean }> {
+export async function ensureServerRunning(
+  cfg: PluginConfig,
+  context?: PluginRuntimeContext,
+): Promise<{ ok: boolean; error?: string; autoStarted?: boolean }> {
   const effectiveCfg = await resolveEffectiveConfig(cfg);
   const base = effectiveCfg.baseUrl || "http://localhost:9867";
-  const healthCheck = await pinchtabFetch(effectiveCfg, "/health");
+  const healthCheck = await pinchtabFetch(effectiveCfg, "/health", {}, context);
   if (!healthCheck?.error) {
     return { ok: true };
   }
@@ -145,15 +191,19 @@ export async function ensureServerRunning(cfg: PluginConfig): Promise<{ ok: bool
   return { ok: false, error: `${healthCheck.error}${hint}` };
 }
 
-export async function waitForInstanceReady(cfg: PluginConfig, instanceId?: string): Promise<{ ok: boolean; error?: string }> {
+export async function waitForInstanceReady(
+  cfg: PluginConfig,
+  instanceId?: string,
+  context?: PluginRuntimeContext,
+): Promise<{ ok: boolean; error?: string }> {
   const effectiveCfg = await resolveEffectiveConfig(cfg);
   const start = Date.now();
   let lastError = "instance not ready";
 
   while (Date.now() - start < instanceReadyMaxWaitMs) {
-    const health = await pinchtabFetch(effectiveCfg, "/health");
+    const health = await pinchtabFetch(effectiveCfg, "/health", {}, context);
     if (!health?.error) {
-      const instances = await pinchtabFetch(effectiveCfg, "/instances");
+      const instances = await pinchtabFetch(effectiveCfg, "/instances", {}, context);
       const list = Array.isArray(instances?.value)
         ? instances.value
         : Array.isArray(instances)
@@ -177,7 +227,7 @@ export async function waitForInstanceReady(cfg: PluginConfig, instanceId?: strin
       continue;
     }
 
-    const tabs = await pinchtabFetch(effectiveCfg, "/tabs");
+    const tabs = await pinchtabFetch(effectiveCfg, "/tabs", {}, context);
     if (!tabs?.error) {
       return { ok: true };
     }

--- a/plugin/tools/browser.ts
+++ b/plugin/tools/browser.ts
@@ -1,7 +1,7 @@
 import type { PluginConfig, PluginRuntimeContext } from "../types.js";
 import { pinchtabFetch, textResult, imageResult, resourceResult } from "../client.js";
 import { checkNavigationPolicy, enforcePolicyOrReturn } from "../policy.js";
-import { ensureServerRunning, waitForInstanceReady, getEnhancedHealth, resolveProfile, getLastTabId, rememberRuntimeContext, setLastTabId } from "../session.js";
+import { ensureServerRunning, waitForInstanceReady, getEnhancedHealth, resolveEffectiveConfig, resolveProfile, getLastTabId, rememberRuntimeContext, setLastTabId } from "../session.js";
 
 export const browserToolSchema = {
   type: "object",
@@ -43,8 +43,10 @@ Actions:
 
 Profiles: "openclaw" (default isolated), "user" (attach to existing session)`;
 
-export async function executeBrowserAction(cfg: PluginConfig, params: any, context?: PluginRuntimeContext): Promise<any> {
+export async function executeBrowserAction(rawCfg: PluginConfig, rawParams: any, context?: PluginRuntimeContext): Promise<any> {
   rememberRuntimeContext(context);
+  const cfg = await resolveEffectiveConfig(rawCfg);
+  const params = { ...rawParams };
   const { action, profile } = params;
 
   // Resolve profile to instance

--- a/plugin/tools/browser.ts
+++ b/plugin/tools/browser.ts
@@ -1,7 +1,7 @@
 import type { PluginConfig } from "../types.js";
 import { pinchtabFetch, textResult, imageResult, resourceResult } from "../client.js";
 import { checkNavigationPolicy, enforcePolicyOrReturn } from "../policy.js";
-import { ensureServerRunning, getEnhancedHealth, resolveProfile, getLastTabId, setLastTabId } from "../session.js";
+import { ensureServerRunning, waitForInstanceReady, getEnhancedHealth, resolveProfile, getLastTabId, setLastTabId } from "../session.js";
 
 export const browserToolSchema = {
   type: "object",
@@ -55,6 +55,10 @@ export async function executeBrowserAction(cfg: PluginConfig, params: any): Prom
     if (!serverCheck.ok) {
       return textResult({ error: serverCheck.error });
     }
+    const readyCheck = await waitForInstanceReady(cfg, profileConfig.instanceId);
+    if (!readyCheck.ok) {
+      return textResult({ error: readyCheck.error });
+    }
   }
 
   // Session tab persistence
@@ -67,11 +71,20 @@ export async function executeBrowserAction(cfg: PluginConfig, params: any): Prom
     const navPolicy = enforcePolicyOrReturn(checkNavigationPolicy(cfg, params.url));
     if (navPolicy) return navPolicy;
 
-    const body: any = { url: params.url };
-    if (params.tabId) body.tabId = params.tabId;
-    if (params.newTab) body.newTab = true;
-    if (profileConfig.instanceId) body.instanceId = profileConfig.instanceId;
-    const result = await pinchtabFetch(cfg, "/navigate", { body });
+    let result;
+    if (params.newTab) {
+      const body: any = { action: "new", url: params.url };
+      if (profileConfig.instanceId) body.instanceId = profileConfig.instanceId;
+      result = await pinchtabFetch(cfg, "/tab", { body });
+    } else if (params.tabId) {
+      const body: any = { url: params.url };
+      if (profileConfig.instanceId) body.instanceId = profileConfig.instanceId;
+      result = await pinchtabFetch(cfg, `/tabs/${encodeURIComponent(params.tabId)}/navigate`, { body });
+    } else {
+      const body: any = { url: params.url };
+      if (profileConfig.instanceId) body.instanceId = profileConfig.instanceId;
+      result = await pinchtabFetch(cfg, "/navigate", { body });
+    }
     if (result?.tabId) setLastTabId(result.tabId);
     return textResult(result);
   }

--- a/plugin/tools/browser.ts
+++ b/plugin/tools/browser.ts
@@ -1,7 +1,7 @@
-import type { PluginConfig } from "../types.js";
+import type { PluginConfig, PluginRuntimeContext } from "../types.js";
 import { pinchtabFetch, textResult, imageResult, resourceResult } from "../client.js";
 import { checkNavigationPolicy, enforcePolicyOrReturn } from "../policy.js";
-import { ensureServerRunning, waitForInstanceReady, getEnhancedHealth, resolveProfile, getLastTabId, setLastTabId } from "../session.js";
+import { ensureServerRunning, waitForInstanceReady, getEnhancedHealth, resolveProfile, getLastTabId, rememberRuntimeContext, setLastTabId } from "../session.js";
 
 export const browserToolSchema = {
   type: "object",
@@ -43,27 +43,28 @@ Actions:
 
 Profiles: "openclaw" (default isolated), "user" (attach to existing session)`;
 
-export async function executeBrowserAction(cfg: PluginConfig, params: any): Promise<any> {
+export async function executeBrowserAction(cfg: PluginConfig, params: any, context?: PluginRuntimeContext): Promise<any> {
+  rememberRuntimeContext(context);
   const { action, profile } = params;
 
   // Resolve profile to instance
-  const profileConfig = resolveProfile(cfg, profile);
+  const profileConfig = resolveProfile(cfg, profile, context);
 
   // Auto-start server if needed
   if (action !== "status") {
-    const serverCheck = await ensureServerRunning(cfg);
+    const serverCheck = await ensureServerRunning(cfg, context);
     if (!serverCheck.ok) {
       return textResult({ error: serverCheck.error });
     }
-    const readyCheck = await waitForInstanceReady(cfg, profileConfig.instanceId);
+    const readyCheck = await waitForInstanceReady(cfg, profileConfig.instanceId, context);
     if (!readyCheck.ok) {
       return textResult({ error: readyCheck.error });
     }
   }
 
   // Session tab persistence
-  if (cfg.persistSessionTabs !== false && !params.tabId && getLastTabId()) {
-    params.tabId = getLastTabId();
+  if (cfg.persistSessionTabs !== false && !params.tabId && getLastTabId(context)) {
+    params.tabId = getLastTabId(context);
   }
 
   // --- navigate ---
@@ -75,17 +76,17 @@ export async function executeBrowserAction(cfg: PluginConfig, params: any): Prom
     if (params.newTab) {
       const body: any = { action: "new", url: params.url };
       if (profileConfig.instanceId) body.instanceId = profileConfig.instanceId;
-      result = await pinchtabFetch(cfg, "/tab", { body });
+      result = await pinchtabFetch(cfg, "/tab", { body }, context);
     } else if (params.tabId) {
       const body: any = { url: params.url };
       if (profileConfig.instanceId) body.instanceId = profileConfig.instanceId;
-      result = await pinchtabFetch(cfg, `/tabs/${encodeURIComponent(params.tabId)}/navigate`, { body });
+      result = await pinchtabFetch(cfg, `/tabs/${encodeURIComponent(params.tabId)}/navigate`, { body }, context);
     } else {
       const body: any = { url: params.url };
       if (profileConfig.instanceId) body.instanceId = profileConfig.instanceId;
-      result = await pinchtabFetch(cfg, "/navigate", { body });
+      result = await pinchtabFetch(cfg, "/navigate", { body }, context);
     }
-    if (result?.tabId) setLastTabId(result.tabId);
+    if (result?.tabId) setLastTabId(result.tabId, context);
     return textResult(result);
   }
 
@@ -97,7 +98,7 @@ export async function executeBrowserAction(cfg: PluginConfig, params: any): Prom
     query.set("format", params.format || cfg.defaultSnapshotFormat || "compact");
     if (params.selector) query.set("selector", params.selector);
     if (params.maxTokens) query.set("maxTokens", String(params.maxTokens));
-    return textResult(await pinchtabFetch(cfg, `/snapshot?${query.toString()}`));
+    return textResult(await pinchtabFetch(cfg, `/snapshot?${query.toString()}`, {}, context));
   }
 
   // --- screenshot ---
@@ -108,7 +109,7 @@ export async function executeBrowserAction(cfg: PluginConfig, params: any): Prom
     if (fmt === "png") query.set("format", "png");
     query.set("quality", String(params.quality || cfg.screenshotQuality || 80));
     try {
-      const res = await pinchtabFetch(cfg, `/screenshot?${query.toString()}`, { rawResponse: true });
+      const res = await pinchtabFetch(cfg, `/screenshot?${query.toString()}`, { rawResponse: true }, context);
       if (res instanceof Response) {
         if (!res.ok) return textResult({ error: `Screenshot failed: ${res.status}` });
         const buf = await res.arrayBuffer();
@@ -129,27 +130,27 @@ export async function executeBrowserAction(cfg: PluginConfig, params: any): Prom
     if (params.key) body.key = params.key;
     if (params.value) body.value = params.value;
     if (params.tabId) body.tabId = params.tabId;
-    return textResult(await pinchtabFetch(cfg, "/action", { body }));
+    return textResult(await pinchtabFetch(cfg, "/action", { body }, context));
   }
 
   // --- tabs ---
   if (action === "tabs") {
     const tabAction = params.tabAction || "list";
     if (tabAction === "list") {
-      return textResult(await pinchtabFetch(cfg, "/tabs"));
+      return textResult(await pinchtabFetch(cfg, "/tabs", {}, context));
     }
     if (tabAction === "close") {
       const body: any = {};
       if (params.tabId) body.tabId = params.tabId;
-      const result = await pinchtabFetch(cfg, "/close", { body });
-      if (params.tabId && params.tabId === getLastTabId()) setLastTabId(undefined);
+      const result = await pinchtabFetch(cfg, "/close", { body }, context);
+      if (params.tabId && params.tabId === getLastTabId(context)) setLastTabId(undefined, context);
       return textResult(result);
     }
     const body: any = { action: tabAction };
     if (params.url) body.url = params.url;
     if (params.tabId) body.tabId = params.tabId;
-    const result = await pinchtabFetch(cfg, "/tab", { body });
-    if (tabAction === "new" && result?.tabId) setLastTabId(result.tabId);
+    const result = await pinchtabFetch(cfg, "/tab", { body }, context);
+    if (tabAction === "new" && result?.tabId) setLastTabId(result.tabId, context);
     return textResult(result);
   }
 
@@ -161,7 +162,7 @@ export async function executeBrowserAction(cfg: PluginConfig, params: any): Prom
     if (params.landscape) query.set("landscape", "true");
     if (params.scale) query.set("scale", String(params.scale));
     try {
-      const res = await pinchtabFetch(cfg, `/pdf?${query.toString()}`, { rawResponse: true });
+      const res = await pinchtabFetch(cfg, `/pdf?${query.toString()}`, { rawResponse: true }, context);
       if (res instanceof Response) {
         if (!res.ok) return textResult({ error: `PDF failed: ${res.status}` });
         const buf = await res.arrayBuffer();
@@ -176,7 +177,7 @@ export async function executeBrowserAction(cfg: PluginConfig, params: any): Prom
 
   // --- status ---
   if (action === "status") {
-    return textResult(await getEnhancedHealth(cfg));
+    return textResult(await getEnhancedHealth(cfg, context));
   }
 
   return textResult({ error: `Unknown browser action: ${action}` });

--- a/plugin/tools/pinchtab.ts
+++ b/plugin/tools/pinchtab.ts
@@ -1,7 +1,7 @@
 import type { PluginConfig } from "../types.js";
 import { pinchtabFetch, textResult, imageResult, resourceResult, normalizeActionParams, looksLikeStaleRef } from "../client.js";
 import { checkNavigationPolicy, checkEvaluatePolicy, checkDownloadPolicy, checkUploadPolicy, checkNetworkInterceptPolicy, enforcePolicyOrReturn } from "../policy.js";
-import { ensureServerRunning, getEnhancedHealth, getLastTabId, setLastTabId } from "../session.js";
+import { ensureServerRunning, waitForInstanceReady, getEnhancedHealth, getLastTabId, setLastTabId } from "../session.js";
 
 export const pinchtabToolSchema = {
   type: "object",
@@ -100,6 +100,10 @@ export async function executePinchtabAction(cfg: PluginConfig, params: any): Pro
     if (!serverCheck.ok) {
       return textResult({ error: serverCheck.error });
     }
+    const readyCheck = await waitForInstanceReady(cfg);
+    if (!readyCheck.ok) {
+      return textResult({ error: readyCheck.error });
+    }
   }
 
   // Session tab persistence
@@ -118,12 +122,23 @@ export async function executePinchtabAction(cfg: PluginConfig, params: any): Pro
     const navPolicy = enforcePolicyOrReturn(checkNavigationPolicy(cfg, normalized.url));
     if (navPolicy) return navPolicy;
 
-    const body: any = { url: normalized.url };
-    if (normalized.tabId) body.tabId = normalized.tabId;
-    if (normalized.newTab) body.newTab = true;
-    if (normalized.blockImages) body.blockImages = true;
-    if (normalized.timeout) body.timeout = normalized.timeout;
-    const result = await pinchtabFetch(cfg, "/navigate", { body });
+    let result;
+    if (normalized.newTab) {
+      const body: any = { action: "new", url: normalized.url };
+      if (normalized.blockImages) body.blockImages = true;
+      if (normalized.timeout) body.timeout = normalized.timeout;
+      result = await pinchtabFetch(cfg, "/tab", { body });
+    } else if (normalized.tabId) {
+      const body: any = { url: normalized.url };
+      if (normalized.blockImages) body.blockImages = true;
+      if (normalized.timeout) body.timeout = normalized.timeout;
+      result = await pinchtabFetch(cfg, `/tabs/${encodeURIComponent(normalized.tabId)}/navigate`, { body });
+    } else {
+      const body: any = { url: normalized.url };
+      if (normalized.blockImages) body.blockImages = true;
+      if (normalized.timeout) body.timeout = normalized.timeout;
+      result = await pinchtabFetch(cfg, "/navigate", { body });
+    }
     if (result?.tabId) setLastTabId(result.tabId);
     return textResult(result);
   }

--- a/plugin/tools/pinchtab.ts
+++ b/plugin/tools/pinchtab.ts
@@ -1,7 +1,7 @@
 import type { PluginConfig, PluginRuntimeContext } from "../types.js";
 import { pinchtabFetch, textResult, imageResult, resourceResult, normalizeActionParams, looksLikeStaleRef } from "../client.js";
 import { checkNavigationPolicy, checkEvaluatePolicy, checkDownloadPolicy, checkUploadPolicy, checkNetworkInterceptPolicy, enforcePolicyOrReturn } from "../policy.js";
-import { ensureServerRunning, waitForInstanceReady, getEnhancedHealth, getLastTabId, rememberRuntimeContext, setLastTabId } from "../session.js";
+import { ensureServerRunning, waitForInstanceReady, getEnhancedHealth, getLastTabId, rememberRuntimeContext, resolveEffectiveConfig, setLastTabId } from "../session.js";
 
 export const pinchtabToolSchema = {
   type: "object",
@@ -90,8 +90,9 @@ export const pinchtabToolDescription = `Browser control via Pinchtab. Actions:
 
 Token strategy: use "text" for reading (~800 tokens), "snapshot" with filter=interactive&format=compact for interactions (~3,600), diff=true on subsequent snapshots.`;
 
-export async function executePinchtabAction(cfg: PluginConfig, params: any, context?: PluginRuntimeContext): Promise<any> {
+export async function executePinchtabAction(rawCfg: PluginConfig, params: any, context?: PluginRuntimeContext): Promise<any> {
   rememberRuntimeContext(context);
+  const cfg = await resolveEffectiveConfig(rawCfg);
   const normalized = normalizeActionParams(params);
   const { action } = normalized;
 
@@ -253,7 +254,7 @@ export async function executePinchtabAction(cfg: PluginConfig, params: any, cont
       if (!running) {
         return textResult({ ...listed, warning: "No tabs returned and no running instance found." });
       }
-      const instanceTabs = await pinchtabFetch(cfg, `/instances/${running.id}/tabs`, {}, context);
+      const instanceTabs = await pinchtabFetch(cfg, `/instances/${encodeURIComponent(running.id)}/tabs`, {}, context);
       return textResult({ source: "instance-fallback", instanceId: running.id, tabs: instanceTabs?.tabs ?? instanceTabs });
     }
     if (tabAction === "close") {
@@ -332,7 +333,7 @@ export async function executePinchtabAction(cfg: PluginConfig, params: any, cont
     }
 
     if (networkAction === "get" && normalized.requestId) {
-      return textResult(await pinchtabFetch(cfg, `/network/${normalized.requestId}`, {}, context));
+      return textResult(await pinchtabFetch(cfg, `/network/${encodeURIComponent(normalized.requestId)}`, {}, context));
     }
 
     if (networkAction === "export") {

--- a/plugin/tools/pinchtab.ts
+++ b/plugin/tools/pinchtab.ts
@@ -1,7 +1,7 @@
-import type { PluginConfig } from "../types.js";
+import type { PluginConfig, PluginRuntimeContext } from "../types.js";
 import { pinchtabFetch, textResult, imageResult, resourceResult, normalizeActionParams, looksLikeStaleRef } from "../client.js";
 import { checkNavigationPolicy, checkEvaluatePolicy, checkDownloadPolicy, checkUploadPolicy, checkNetworkInterceptPolicy, enforcePolicyOrReturn } from "../policy.js";
-import { ensureServerRunning, waitForInstanceReady, getEnhancedHealth, getLastTabId, setLastTabId } from "../session.js";
+import { ensureServerRunning, waitForInstanceReady, getEnhancedHealth, getLastTabId, rememberRuntimeContext, setLastTabId } from "../session.js";
 
 export const pinchtabToolSchema = {
   type: "object",
@@ -90,25 +90,26 @@ export const pinchtabToolDescription = `Browser control via Pinchtab. Actions:
 
 Token strategy: use "text" for reading (~800 tokens), "snapshot" with filter=interactive&format=compact for interactions (~3,600), diff=true on subsequent snapshots.`;
 
-export async function executePinchtabAction(cfg: PluginConfig, params: any): Promise<any> {
+export async function executePinchtabAction(cfg: PluginConfig, params: any, context?: PluginRuntimeContext): Promise<any> {
+  rememberRuntimeContext(context);
   const normalized = normalizeActionParams(params);
   const { action } = normalized;
 
   // Auto-start server if needed
   if (action !== "health") {
-    const serverCheck = await ensureServerRunning(cfg);
+    const serverCheck = await ensureServerRunning(cfg, context);
     if (!serverCheck.ok) {
       return textResult({ error: serverCheck.error });
     }
-    const readyCheck = await waitForInstanceReady(cfg);
+    const readyCheck = await waitForInstanceReady(cfg, undefined, context);
     if (!readyCheck.ok) {
       return textResult({ error: readyCheck.error });
     }
   }
 
   // Session tab persistence
-  if (cfg.persistSessionTabs !== false && !normalized.tabId && getLastTabId()) {
-    normalized.tabId = getLastTabId();
+  if (cfg.persistSessionTabs !== false && !normalized.tabId && getLastTabId(context)) {
+    normalized.tabId = getLastTabId(context);
   }
 
   // Policy: block evaluate if not allowed
@@ -127,19 +128,19 @@ export async function executePinchtabAction(cfg: PluginConfig, params: any): Pro
       const body: any = { action: "new", url: normalized.url };
       if (normalized.blockImages) body.blockImages = true;
       if (normalized.timeout) body.timeout = normalized.timeout;
-      result = await pinchtabFetch(cfg, "/tab", { body });
+      result = await pinchtabFetch(cfg, "/tab", { body }, context);
     } else if (normalized.tabId) {
       const body: any = { url: normalized.url };
       if (normalized.blockImages) body.blockImages = true;
       if (normalized.timeout) body.timeout = normalized.timeout;
-      result = await pinchtabFetch(cfg, `/tabs/${encodeURIComponent(normalized.tabId)}/navigate`, { body });
+      result = await pinchtabFetch(cfg, `/tabs/${encodeURIComponent(normalized.tabId)}/navigate`, { body }, context);
     } else {
       const body: any = { url: normalized.url };
       if (normalized.blockImages) body.blockImages = true;
       if (normalized.timeout) body.timeout = normalized.timeout;
-      result = await pinchtabFetch(cfg, "/navigate", { body });
+      result = await pinchtabFetch(cfg, "/navigate", { body }, context);
     }
-    if (result?.tabId) setLastTabId(result.tabId);
+    if (result?.tabId) setLastTabId(result.tabId, context);
     return textResult(result);
   }
 
@@ -155,7 +156,7 @@ export async function executePinchtabAction(cfg: PluginConfig, params: any): Pro
     if (normalized.maxTokens) query.set("maxTokens", String(normalized.maxTokens));
     if (normalized.depth) query.set("depth", String(normalized.depth));
     if (normalized.diff) query.set("diff", "true");
-    return textResult(await pinchtabFetch(cfg, `/snapshot?${query.toString()}`));
+    return textResult(await pinchtabFetch(cfg, `/snapshot?${query.toString()}`, {}, context));
   }
 
   // --- element actions ---
@@ -169,7 +170,7 @@ export async function executePinchtabAction(cfg: PluginConfig, params: any): Pro
       if (normalized[k] !== undefined) body[k] = normalized[k];
     }
 
-    let result = await pinchtabFetch(cfg, "/action", { body });
+    let result = await pinchtabFetch(cfg, "/action", { body }, context);
 
     // Stale ref recovery
     if (body.ref && looksLikeStaleRef(result)) {
@@ -177,8 +178,8 @@ export async function executePinchtabAction(cfg: PluginConfig, params: any): Pro
       q.set("filter", "interactive");
       q.set("format", "compact");
       if (body.tabId) q.set("tabId", body.tabId);
-      await pinchtabFetch(cfg, `/snapshot?${q.toString()}`);
-      const retried = await pinchtabFetch(cfg, "/action", { body });
+      await pinchtabFetch(cfg, `/snapshot?${q.toString()}`, {}, context);
+      const retried = await pinchtabFetch(cfg, "/action", { body }, context);
       result = retried?.error
         ? { ...retried, warning: "Action retried once after snapshot refresh but still failed." }
         : { ...retried, warning: "Action succeeded after automatic snapshot refresh (stale ref recovery)." };
@@ -191,7 +192,7 @@ export async function executePinchtabAction(cfg: PluginConfig, params: any): Pro
         typeBody.text = typeBody.value;
       }
       delete typeBody.value;
-      const typed = await pinchtabFetch(cfg, "/action", { body: typeBody });
+      const typed = await pinchtabFetch(cfg, "/action", { body: typeBody }, context);
       if (!typed?.error) {
         result = { ...typed, warning: "Fill failed; type fallback succeeded." };
       }
@@ -205,7 +206,7 @@ export async function executePinchtabAction(cfg: PluginConfig, params: any): Pro
     const query = new URLSearchParams();
     if (normalized.tabId) query.set("tabId", normalized.tabId);
     if (normalized.mode) query.set("mode", normalized.mode);
-    return textResult(await pinchtabFetch(cfg, `/text?${query.toString()}`));
+    return textResult(await pinchtabFetch(cfg, `/text?${query.toString()}`, {}, context));
   }
 
   // --- wait ---
@@ -214,7 +215,7 @@ export async function executePinchtabAction(cfg: PluginConfig, params: any): Pro
     for (const k of ["selector", "text", "url", "load", "fn", "ms", "tabId", "timeout", "state"]) {
       if (normalized[k] !== undefined) body[k] = normalized[k];
     }
-    return textResult(await pinchtabFetch(cfg, "/wait", { body }));
+    return textResult(await pinchtabFetch(cfg, "/wait", { body }, context));
   }
 
   // --- handoff ---
@@ -234,7 +235,7 @@ export async function executePinchtabAction(cfg: PluginConfig, params: any): Pro
     for (const k of ["selector", "text", "url", "load", "fn", "ms", "tabId", "timeout", "state"]) {
       if (normalized[k] !== undefined) waitBody[k] = normalized[k];
     }
-    const waitResult = await pinchtabFetch(cfg, "/wait", { body: waitBody });
+    const waitResult = await pinchtabFetch(cfg, "/wait", { body: waitBody }, context);
     return textResult({ ...handoffMeta, resumed: !waitResult?.error, waitResult });
   }
 
@@ -242,31 +243,31 @@ export async function executePinchtabAction(cfg: PluginConfig, params: any): Pro
   if (action === "tabs") {
     const tabAction = normalized.tabAction || "list";
     if (tabAction === "list") {
-      const listed = await pinchtabFetch(cfg, "/tabs");
+      const listed = await pinchtabFetch(cfg, "/tabs", {}, context);
       const tabs = Array.isArray(listed?.tabs) ? listed.tabs : Array.isArray(listed) ? listed : [];
       if (tabs.length > 0) return textResult(listed);
 
-      const instances = await pinchtabFetch(cfg, "/instances");
+      const instances = await pinchtabFetch(cfg, "/instances", {}, context);
       const list = Array.isArray(instances?.value) ? instances.value : Array.isArray(instances) ? instances : [];
       const running = list.find((i: any) => i?.status === "running" && i?.id);
       if (!running) {
         return textResult({ ...listed, warning: "No tabs returned and no running instance found." });
       }
-      const instanceTabs = await pinchtabFetch(cfg, `/instances/${running.id}/tabs`);
+      const instanceTabs = await pinchtabFetch(cfg, `/instances/${running.id}/tabs`, {}, context);
       return textResult({ source: "instance-fallback", instanceId: running.id, tabs: instanceTabs?.tabs ?? instanceTabs });
     }
     if (tabAction === "close") {
       const body: any = {};
       if (normalized.tabId) body.tabId = normalized.tabId;
-      const result = await pinchtabFetch(cfg, "/close", { body });
-      if (normalized.tabId && normalized.tabId === getLastTabId()) setLastTabId(undefined);
+      const result = await pinchtabFetch(cfg, "/close", { body }, context);
+      if (normalized.tabId && normalized.tabId === getLastTabId(context)) setLastTabId(undefined, context);
       return textResult(result);
     }
     const body: any = { action: tabAction };
     if (normalized.url) body.url = normalized.url;
     if (normalized.tabId) body.tabId = normalized.tabId;
-    const result = await pinchtabFetch(cfg, "/tab", { body });
-    if (tabAction === "new" && result?.tabId) setLastTabId(result.tabId);
+    const result = await pinchtabFetch(cfg, "/tab", { body }, context);
+    if (tabAction === "new" && result?.tabId) setLastTabId(result.tabId, context);
     return textResult(result);
   }
 
@@ -279,7 +280,7 @@ export async function executePinchtabAction(cfg: PluginConfig, params: any): Pro
     if (format === "png") query.set("format", "png");
     query.set("quality", String(quality));
     try {
-      const res = await pinchtabFetch(cfg, `/screenshot?${query.toString()}`, { rawResponse: true });
+      const res = await pinchtabFetch(cfg, `/screenshot?${query.toString()}`, { rawResponse: true }, context);
       if (res instanceof Response) {
         if (!res.ok) return textResult({ error: `Screenshot failed: ${res.status} ${await res.text()}` });
         const buf = await res.arrayBuffer();
@@ -296,7 +297,7 @@ export async function executePinchtabAction(cfg: PluginConfig, params: any): Pro
   if (action === "evaluate") {
     const body: any = { expression: normalized.expression };
     if (normalized.tabId) body.tabId = normalized.tabId;
-    return textResult(await pinchtabFetch(cfg, "/evaluate", { body }));
+    return textResult(await pinchtabFetch(cfg, "/evaluate", { body }, context));
   }
 
   // --- pdf ---
@@ -307,7 +308,7 @@ export async function executePinchtabAction(cfg: PluginConfig, params: any): Pro
     if (normalized.landscape) query.set("landscape", "true");
     if (normalized.scale) query.set("scale", String(normalized.scale));
     try {
-      const res = await pinchtabFetch(cfg, `/pdf?${query.toString()}`, { rawResponse: true });
+      const res = await pinchtabFetch(cfg, `/pdf?${query.toString()}`, { rawResponse: true }, context);
       if (res instanceof Response) {
         if (!res.ok) return textResult({ error: `PDF failed: ${res.status} ${await res.text()}` });
         const buf = await res.arrayBuffer();
@@ -327,18 +328,18 @@ export async function executePinchtabAction(cfg: PluginConfig, params: any): Pro
     if (networkAction === "clear") {
       const query = new URLSearchParams();
       if (normalized.tabId) query.set("tabId", normalized.tabId);
-      return textResult(await pinchtabFetch(cfg, `/network/clear?${query.toString()}`, { method: "POST" }));
+      return textResult(await pinchtabFetch(cfg, `/network/clear?${query.toString()}`, { method: "POST" }, context));
     }
 
     if (networkAction === "get" && normalized.requestId) {
-      return textResult(await pinchtabFetch(cfg, `/network/${normalized.requestId}`));
+      return textResult(await pinchtabFetch(cfg, `/network/${normalized.requestId}`, {}, context));
     }
 
     if (networkAction === "export") {
       const query = new URLSearchParams();
       if (normalized.tabId) query.set("tabId", normalized.tabId);
       if (normalized.exportFormat === "json") query.set("format", "json");
-      const result = await pinchtabFetch(cfg, `/network/export?${query.toString()}`);
+      const result = await pinchtabFetch(cfg, `/network/export?${query.toString()}`, {}, context);
       if (normalized.exportFormat === "har" || !normalized.exportFormat) {
         return resourceResult("har://export", "application/json", Buffer.from(JSON.stringify(result)).toString("base64"));
       }
@@ -362,7 +363,7 @@ export async function executePinchtabAction(cfg: PluginConfig, params: any): Pro
       return textResult(await pinchtabFetch(cfg, `/tabs/${encodeURIComponent(normalized.tabId)}/network/route`, {
         method: "POST",
         body: payload,
-      }));
+      }, context));
     }
 
     if (networkAction === "unroute") {
@@ -373,7 +374,7 @@ export async function executePinchtabAction(cfg: PluginConfig, params: any): Pro
       if (normalized.pattern) query.set("pattern", normalized.pattern);
       const qs = query.toString();
       const path = `/tabs/${encodeURIComponent(normalized.tabId)}/network/route${qs ? `?${qs}` : ""}`;
-      return textResult(await pinchtabFetch(cfg, path, { method: "DELETE" }));
+      return textResult(await pinchtabFetch(cfg, path, { method: "DELETE" }, context));
     }
 
     // list
@@ -383,7 +384,7 @@ export async function executePinchtabAction(cfg: PluginConfig, params: any): Pro
     if (normalized.status) query.set("status", normalized.status);
     if (normalized.resourceType) query.set("type", normalized.resourceType);
     if (normalized.limit) query.set("limit", String(normalized.limit));
-    return textResult(await pinchtabFetch(cfg, `/network?${query.toString()}`));
+    return textResult(await pinchtabFetch(cfg, `/network?${query.toString()}`, {}, context));
   }
 
   // --- download ---
@@ -397,11 +398,11 @@ export async function executePinchtabAction(cfg: PluginConfig, params: any): Pro
     if (normalized.savePath) {
       query.set("output", "file");
       query.set("path", normalized.savePath);
-      return textResult(await pinchtabFetch(cfg, `/download?${query.toString()}`));
+      return textResult(await pinchtabFetch(cfg, `/download?${query.toString()}`, {}, context));
     }
     query.set("raw", "true");
     try {
-      const res = await pinchtabFetch(cfg, `/download?${query.toString()}`, { rawResponse: true });
+      const res = await pinchtabFetch(cfg, `/download?${query.toString()}`, { rawResponse: true }, context);
       if (res instanceof Response) {
         if (!res.ok) return textResult({ error: `download failed: ${res.status} ${await res.text()}` });
         const buf = await res.arrayBuffer();
@@ -425,12 +426,12 @@ export async function executePinchtabAction(cfg: PluginConfig, params: any): Pro
     if (normalized.selector) body.selector = normalized.selector;
     if (normalized.files) body.files = normalized.files;
     if (normalized.paths) body.paths = normalized.paths;
-    return textResult(await pinchtabFetch(cfg, "/upload", { body }));
+    return textResult(await pinchtabFetch(cfg, "/upload", { body }, context));
   }
 
   // --- health ---
   if (action === "health") {
-    return textResult(await getEnhancedHealth(cfg));
+    return textResult(await getEnhancedHealth(cfg, context));
   }
 
   return textResult({ error: `Unknown action: ${action}` });

--- a/plugin/types.ts
+++ b/plugin/types.ts
@@ -1,4 +1,4 @@
-import type { AnyAgentTool, OpenClawPluginApi, OpenClawPluginToolContext } from "openclaw/plugin-sdk";
+import type { AnyAgentTool, OpenClawPluginApi, OpenClawPluginToolContext } from "openclaw/plugin-sdk/plugin-entry";
 
 export interface PluginConfig {
   baseUrl?: string;
@@ -23,7 +23,6 @@ export interface PluginConfig {
 
 export interface PluginRuntimeContext {
   agentId?: string;
-  agentName?: string;
   sessionId?: string;
   sessionKey?: string;
 }

--- a/plugin/types.ts
+++ b/plugin/types.ts
@@ -6,9 +6,6 @@ export interface PluginConfig {
   timeoutMs?: number;
   /** @deprecated Use timeoutMs instead */
   timeout?: number;
-  autoStart?: boolean;
-  binaryPath?: string;
-  startupTimeoutMs?: number;
   allowEvaluate?: boolean;
   allowedDomains?: string[];
   allowDownloads?: boolean;

--- a/plugin/types.ts
+++ b/plugin/types.ts
@@ -1,4 +1,4 @@
-import type { AnyAgentTool, OpenClawPluginApi } from "openclaw/plugin-sdk";
+import type { AnyAgentTool, OpenClawPluginApi, OpenClawPluginToolContext } from "openclaw/plugin-sdk";
 
 export interface PluginConfig {
   baseUrl?: string;
@@ -21,8 +21,22 @@ export interface PluginConfig {
   profiles?: Record<string, { instanceId?: string; attach?: boolean }>;
 }
 
+export interface PluginRuntimeContext {
+  agentId?: string;
+  agentName?: string;
+  sessionId?: string;
+  sessionKey?: string;
+}
+
+export interface AgentSessionState extends PluginRuntimeContext {
+  key: string;
+  lastTabId?: string;
+  updatedAt?: number;
+}
+
 export type PluginApi = OpenClawPluginApi;
 export type PluginTool = AnyAgentTool;
+export type PluginToolContext = OpenClawPluginToolContext;
 
 export interface ToolResult {
   content: Array<

--- a/tests/manual/openclaw-plugin-smoke/.gitignore
+++ b/tests/manual/openclaw-plugin-smoke/.gitignore
@@ -1,0 +1,2 @@
+artifacts/*
+!artifacts/.gitkeep

--- a/tests/manual/openclaw-plugin-smoke/Dockerfile
+++ b/tests/manual/openclaw-plugin-smoke/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:22-bookworm-slim
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    npm_config_update_notifier=false
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bash \
+    ca-certificates \
+    python3 \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace
+
+ARG OPENCLAW_VERSION=2026.4.27
+RUN npm install -g openclaw@$OPENCLAW_VERSION

--- a/tests/manual/openclaw-plugin-smoke/README.md
+++ b/tests/manual/openclaw-plugin-smoke/README.md
@@ -1,0 +1,52 @@
+# OpenClaw + Pinchtab Docker Mock Test
+
+Deterministic end-to-end harness for the Pinchtab OpenClaw plugin.
+
+What it does:
+- builds a local Pinchtab image from this repo
+- starts a local fixture server inside Docker
+- installs the repo plugin into a fresh OpenClaw container
+- disables the bundled OpenClaw browser plugin so `browser` resolves to Pinchtab's compatibility alias
+- runs several `openclaw agent` prompts against the fixture site
+- verifies the returned answers
+- verifies fixture access logs show real browser traffic from Pinchtab
+
+## Requirements
+
+- Docker
+- valid OpenClaw auth in `~/.openclaw/agents/main/agent/auth-profiles.json`
+- a usable `~/.openclaw/openclaw.json`
+
+## Run
+
+```bash
+./tests/manual/openclaw-plugin-smoke/run.sh
+# or
+./dev e2e smoke-plugin
+```
+
+Optional overrides:
+
+```bash
+OPENCLAW_STATE_SOURCE=$HOME/.openclaw \
+OPENCLAW_VERSION=2026.5.2 \
+./tests/manual/openclaw-plugin-smoke/run.sh
+```
+
+## Artifacts
+
+The script copies results into `tests/manual/openclaw-plugin-smoke/artifacts/<timestamp>/`:
+
+- `summary.json` — scenario results + log checks
+- `agent-*.json` — raw OpenClaw CLI output per prompt
+- `gateway.log` — OpenClaw gateway log
+- `plugin-install.log` — plugin install log
+- `fixtures-access.log` — JSONL access log from the fixture server
+- `docker-compose.log` — combined compose output
+
+## Why this proves Pinchtab was used
+
+Two layers:
+
+1. The bundled OpenClaw browser plugin is disabled, while the Pinchtab plugin re-registers `browser`.
+2. The fixture log must show Chrome/Chromium-style traffic for the exercised pages, including a JS-driven cookie/state flow that plain `web_fetch` cannot satisfy.

--- a/tests/manual/openclaw-plugin-smoke/README.md
+++ b/tests/manual/openclaw-plugin-smoke/README.md
@@ -10,13 +10,24 @@ What it does:
 - runs several `openclaw agent` prompts against the fixture site
 - verifies the returned answers
 - verifies fixture access logs show real browser traffic from Pinchtab
-- proves same-agent session reuse and cross-agent isolation with dedicated `alpha` / `beta` smoke turns
+- proves same-agent session reuse (alpha) and per-agent tab independence (beta) via dedicated smoke turns
 
 ## Requirements
 
+This is a **manual** smoke test — it expects to be run on a developer machine that already has OpenClaw installed and signed in. It does not bootstrap auth itself.
+
 - Docker
+- `openclaw` CLI installed locally and on `PATH` (used to detect the version pinned for the in-container install, and as the source of auth state)
 - valid OpenClaw auth in `~/.openclaw/agents/main/agent/auth-profiles.json`
 - a usable `~/.openclaw/openclaw.json`
+
+If `openclaw` is not available, you can still run the smoke by pinning the version explicitly and pointing at an alternate state directory:
+
+```bash
+OPENCLAW_VERSION=2026.5.2 \
+OPENCLAW_STATE_SOURCE=/path/to/openclaw-state \
+./tests/manual/openclaw-plugin-smoke/run.sh
+```
 
 ## Run
 
@@ -25,6 +36,18 @@ What it does:
 # or
 ./dev e2e smoke-plugin
 ```
+
+### With an Anthropic API key (no host openclaw state required)
+
+```bash
+./dev e2e smoke-plugin --anthropic-key sk-ant-...
+# or
+./tests/manual/openclaw-plugin-smoke/run.sh --anthropic-key sk-ant-...
+# or via env
+ANTHROPIC_API_KEY=sk-ant-... ./dev e2e smoke-plugin --anthropic-key "$ANTHROPIC_API_KEY"
+```
+
+In this mode the runner bootstraps a fresh OpenClaw config inside the container via `openclaw onboard --auth-choice anthropic-api-key`, so you don't need a local `openclaw` install or `~/.openclaw` state.
 
 Optional overrides:
 

--- a/tests/manual/openclaw-plugin-smoke/README.md
+++ b/tests/manual/openclaw-plugin-smoke/README.md
@@ -10,6 +10,7 @@ What it does:
 - runs several `openclaw agent` prompts against the fixture site
 - verifies the returned answers
 - verifies fixture access logs show real browser traffic from Pinchtab
+- proves same-agent session reuse and cross-agent isolation with dedicated `alpha` / `beta` smoke turns
 
 ## Requirements
 
@@ -37,7 +38,7 @@ OPENCLAW_VERSION=2026.5.2 \
 
 The script copies results into `tests/manual/openclaw-plugin-smoke/artifacts/<timestamp>/`:
 
-- `summary.json` — scenario results + log checks
+- `summary.json` — scenario results + log checks, including `sessionProof`
 - `agent-*.json` — raw OpenClaw CLI output per prompt
 - `gateway.log` — OpenClaw gateway log
 - `plugin-install.log` — plugin install log

--- a/tests/manual/openclaw-plugin-smoke/docker-compose.yml
+++ b/tests/manual/openclaw-plugin-smoke/docker-compose.yml
@@ -1,0 +1,62 @@
+services:
+  fixtures:
+    image: node:22-bookworm-slim
+    working_dir: /app
+    command: ["node", "/app/fixtures/server.mjs"]
+    environment:
+      PORT: "8080"
+      LOG_FILE: /artifacts/fixtures-access.log
+    volumes:
+      - ./fixtures:/app/fixtures:ro
+      - ${ARTIFACTS_DIR}:/artifacts
+    healthcheck:
+      test: ["CMD-SHELL", "node -e \"fetch('http://127.0.0.1:8080/health').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))\""]
+      interval: 1s
+      timeout: 5s
+      retries: 20
+
+  pinchtab:
+    build:
+      context: ../../..
+      dockerfile: Dockerfile
+    environment:
+      PINCHTAB_CONFIG: /data/pinchtab.json
+    command:
+      [
+        "/bin/sh",
+        "-lc",
+        "cp /fixture-config/pinchtab.json /data/pinchtab.json && /usr/local/bin/docker-entrypoint.sh pinchtab 2>&1 | tee /artifacts/pinchtab.log",
+      ]
+    volumes:
+      - ./pinchtab.config.json:/fixture-config/pinchtab.json:ro
+      - ${ARTIFACTS_DIR}:/artifacts
+    shm_size: 2gb
+    healthcheck:
+      test: ["CMD-SHELL", "wget --header='Authorization: Bearer smoke-token' -q -O /dev/null http://127.0.0.1:9999/health"]
+      interval: 1s
+      timeout: 5s
+      retries: 30
+      start_period: 5s
+
+  openclaw:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        OPENCLAW_VERSION: ${OPENCLAW_VERSION}
+    depends_on:
+      fixtures:
+        condition: service_healthy
+      pinchtab:
+        condition: service_healthy
+    working_dir: /workspace
+    environment:
+      PINCHTAB_BASE_URL: http://pinchtab:9999
+      PINCHTAB_TOKEN: smoke-token
+      FIXTURES_URL: http://fixtures:8080
+    volumes:
+      - ${OPENCLAW_STATE_DIR}:/root/.openclaw
+      - ../../../:/workspace
+      - ./openclaw-runner.sh:/usr/local/bin/openclaw-runner.sh:ro
+      - ${ARTIFACTS_DIR}:/artifacts
+    command: ["bash", "/usr/local/bin/openclaw-runner.sh"]

--- a/tests/manual/openclaw-plugin-smoke/docker-compose.yml
+++ b/tests/manual/openclaw-plugin-smoke/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       [
         "/bin/sh",
         "-lc",
-        "cp /fixture-config/pinchtab.json /data/pinchtab.json && /usr/local/bin/docker-entrypoint.sh pinchtab 2>&1 | tee /artifacts/pinchtab.log",
+        "cp /fixture-config/pinchtab.json /data/pinchtab.json && /usr/local/bin/docker-entrypoint.sh pinchtab server 2>&1 | tee /artifacts/pinchtab.log",
       ]
     volumes:
       - ./pinchtab.config.json:/fixture-config/pinchtab.json:ro
@@ -54,6 +54,7 @@ services:
       PINCHTAB_BASE_URL: http://pinchtab:9999
       PINCHTAB_TOKEN: smoke-token
       FIXTURES_URL: http://fixtures:8080
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
     volumes:
       - ${OPENCLAW_STATE_DIR}:/root/.openclaw
       - ../../../:/workspace

--- a/tests/manual/openclaw-plugin-smoke/fixtures/server.mjs
+++ b/tests/manual/openclaw-plugin-smoke/fixtures/server.mjs
@@ -1,0 +1,123 @@
+import http from 'node:http';
+import { appendFile, mkdir } from 'node:fs/promises';
+import { dirname } from 'node:path';
+
+const port = Number(process.env.PORT || 8080);
+const logFile = process.env.LOG_FILE;
+
+async function logRequest(req) {
+  if (!logFile) return;
+  const entry = {
+    ts: new Date().toISOString(),
+    method: req.method,
+    path: req.url,
+    userAgent: req.headers['user-agent'] || '',
+    remoteAddress: req.socket.remoteAddress || '',
+  };
+  await mkdir(dirname(logFile), { recursive: true });
+  await appendFile(logFile, JSON.stringify(entry) + '\n');
+}
+
+function send(res, status, body, contentType = 'text/html; charset=utf-8', extraHeaders = {}) {
+  res.writeHead(status, { 'content-type': contentType, ...extraHeaders });
+  res.end(body);
+}
+
+function page(title, body, extraHead = '') {
+  return `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>${title}</title>
+    ${extraHead}
+  </head>
+  <body>
+    ${body}
+  </body>
+</html>`;
+}
+
+const server = http.createServer(async (req, res) => {
+  await logRequest(req);
+  const url = new URL(req.url, `http://127.0.0.1:${port}`);
+
+  if (url.pathname === '/health') {
+    return send(res, 200, 'ok', 'text/plain; charset=utf-8');
+  }
+
+  if (url.pathname === '/alpha') {
+    return send(
+      res,
+      200,
+      page('Alpha Verification', '<main><h1>ALPHA-17</h1><p>This is the first verification page.</p></main>'),
+    );
+  }
+
+  if (url.pathname === '/journey/start') {
+    return send(
+      res,
+      200,
+      page(
+        'Journey Start',
+        `<main>
+          <h1>Journey Start</h1>
+          <p>Press the button to continue.</p>
+          <button id="begin">Begin journey</button>
+        </main>
+        <script>
+          document.getElementById('begin').addEventListener('click', () => {
+            document.cookie = 'journey=1; Path=/; SameSite=Lax';
+            window.location.href = '/journey/final';
+          });
+        </script>`,
+      ),
+    );
+  }
+
+  if (url.pathname === '/journey/final') {
+    const hasCookie = (req.headers.cookie || '').split(/;\s*/).includes('journey=1');
+    if (!hasCookie) {
+      return send(
+        res,
+        200,
+        page('Journey Incomplete', '<main><h1>MISSING-STATE</h1><p>Start from the journey page first.</p></main>'),
+      );
+    }
+    return send(
+      res,
+      200,
+      page('Journey Complete', '<main><h1>ORBIT-42</h1><p>Browser state carried across correctly.</p></main>'),
+    );
+  }
+
+  if (url.pathname === '/chain/one') {
+    return send(
+      res,
+      200,
+      page('Chain One', '<main><h1>Chain One</h1><a href="/chain/two">Go to step two</a></main>'),
+    );
+  }
+
+  if (url.pathname === '/chain/two') {
+    return send(
+      res,
+      200,
+      page('Chain Two', '<main><h1>Chain Two</h1><a href="/chain/final">Open the final page</a></main>'),
+    );
+  }
+
+  if (url.pathname === '/chain/final') {
+    return send(
+      res,
+      200,
+      page('Chain Final', '<main><h1>BLUE-SUN-9</h1><p>You made it through the chain.</p></main>'),
+    );
+  }
+
+  return send(res, 404, page('Not Found', `<main><h1>404</h1><p>No route for ${url.pathname}</p></main>`));
+});
+
+server.listen(port, '0.0.0.0', () => {
+  console.log(`fixture server listening on ${port}`);
+});

--- a/tests/manual/openclaw-plugin-smoke/openclaw-runner.sh
+++ b/tests/manual/openclaw-plugin-smoke/openclaw-runner.sh
@@ -5,6 +5,133 @@ set -euo pipefail
 : "${PINCHTAB_TOKEN:?missing PINCHTAB_TOKEN}"
 : "${FIXTURES_URL:?missing FIXTURES_URL}"
 
+if [[ -n "${ANTHROPIC_API_KEY:-}" && ! -f /root/.openclaw/openclaw.json ]]; then
+  echo "bootstrapping openclaw config from ANTHROPIC_API_KEY..."
+  openclaw onboard \
+    --non-interactive \
+    --accept-risk \
+    --mode local \
+    --auth-choice anthropic-api-key \
+    --anthropic-api-key "$ANTHROPIC_API_KEY" \
+    --workspace /root/workspace \
+    --skip-health \
+    >/artifacts/onboard.log 2>&1 || {
+      echo "openclaw onboard failed:" >&2
+      tail -40 /artifacts/onboard.log >&2
+      exit 1
+    }
+  for agent in main alpha beta; do
+    mkdir -p "/root/.openclaw/agents/$agent/agent"
+    cat >"/root/.openclaw/agents/$agent/agent/auth-profiles.json" <<JSON
+{
+  "version": 1,
+  "profiles": {
+    "anthropic-default": {
+      "type": "api_key",
+      "provider": "anthropic",
+      "key": "${ANTHROPIC_API_KEY}",
+      "displayName": "Anthropic"
+    }
+  },
+  "order": {
+    "anthropic": ["anthropic-default"]
+  },
+  "lastGood": {
+    "anthropic": "anthropic-default"
+  }
+}
+JSON
+  done
+  # Register the non-default agents with openclaw. `onboard` only sets up
+  # `main`; without this `openclaw agent --agent alpha` errors with
+  # "Unknown agent id". Per docs/cli/agents.md, non-interactive mode requires
+  # both a name and --workspace; --agent-dir points at the dir we already
+  # populated with auth-profiles.json so the agent inherits Anthropic auth.
+  for agent in alpha beta; do
+    mkdir -p "/root/workspace-$agent"
+    openclaw agents add "$agent" \
+      --workspace "/root/workspace-$agent" \
+      --agent-dir "/root/.openclaw/agents/$agent/agent" \
+      --model anthropic/claude-sonnet-4-5 \
+      --non-interactive \
+      >>/artifacts/onboard.log 2>&1 || {
+        echo "openclaw agents add $agent failed:" >&2
+        tail -40 /artifacts/onboard.log >&2
+        exit 1
+      }
+  done
+fi
+
+python3 - /root/.openclaw/openclaw.json <<'PY'
+import json, os
+from pathlib import Path
+path = Path('/root/.openclaw/openclaw.json')
+obj = json.loads(path.read_text()) if path.exists() else {}
+anthropic_key = os.environ.get('ANTHROPIC_API_KEY', '')
+if anthropic_key:
+    auth_profiles = obj.setdefault('auth', {}).setdefault('profiles', {})
+    auth_profiles['anthropic-default'] = {
+        'provider': 'anthropic',
+        'mode': 'api_key',
+    }
+    auth_order = obj.setdefault('auth', {}).setdefault('order', {})
+    auth_order['anthropic'] = ['anthropic-default']
+    agents = obj.setdefault('agents', {}).setdefault('defaults', {})
+    agents['model'] = 'anthropic/claude-sonnet-4-5'
+plugins = obj.setdefault('plugins', {}).setdefault('entries', {})
+plugins.setdefault('pinchtab', {})['enabled'] = True
+pinchtab_cfg = plugins.setdefault('pinchtab', {}).setdefault('config', {})
+pinchtab_cfg['baseUrl'] = 'http://pinchtab:9999'
+pinchtab_cfg['token'] = 'smoke-token'
+pinchtab_cfg['registerBrowserTool'] = True
+plugins.setdefault('browser', {})['enabled'] = False
+allow = obj.setdefault('plugins', {}).get('allow')
+if isinstance(allow, list) and 'pinchtab' not in allow:
+    allow.append('pinchtab')
+obj['browser'] = {'enabled': False}
+# Default onboard profile is "coding", which excludes browser/plugin tools
+# (per docs/tools/index.md). Switch to "full" and explicitly allow the
+# pinchtab/browser tools so the agents can actually invoke them.
+tools = obj.setdefault('tools', {})
+tools['profile'] = 'full'
+allow = tools.get('allow')
+if not isinstance(allow, list):
+    allow = []
+for name in ('pinchtab', 'browser'):
+    if name not in allow:
+        allow.append(name)
+tools['allow'] = allow
+path.write_text(json.dumps(obj, indent=2) + '\n')
+PY
+
+cp /root/.openclaw/openclaw.json /artifacts/openclaw.json 2>/dev/null || true
+for agent in main alpha beta; do
+  if [[ -f "/root/.openclaw/agents/$agent/agent/auth-profiles.json" ]]; then
+    python3 - "/root/.openclaw/agents/$agent/agent/auth-profiles.json" "/artifacts/auth-profiles-$agent.redacted.json" <<'PY'
+import json, sys
+src, dst = sys.argv[1], sys.argv[2]
+obj = json.loads(open(src).read())
+for p in obj.get('profiles', {}).values():
+    for k in ('key','token'):
+        if isinstance(p.get(k), str) and p[k]:
+            p[k] = f"<redacted len={len(p[k])} prefix={p[k][:8]}>"
+open(dst, 'w').write(json.dumps(obj, indent=2))
+PY
+  fi
+done
+
+if [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
+  echo "=== anthropic key probe ==="
+  node -e "
+    const key = process.env.ANTHROPIC_API_KEY;
+    console.log('key length:', key.length, 'prefix:', key.slice(0, 14));
+    fetch('https://api.anthropic.com/v1/models', {
+      headers: {'x-api-key': key, 'anthropic-version': '2023-06-01'}
+    }).then(r => r.text().then(t => console.log('status:', r.status, 'body:', t.slice(0, 200))))
+      .catch(e => console.log('error:', e.message));
+  " 2>&1 | tee /artifacts/anthropic-probe.log
+fi
+
 node /workspace/plugin/scripts/sync-skills.mjs
 
 openclaw plugins install /workspace/plugin --link >/artifacts/plugin-install.log 2>&1
@@ -85,11 +212,11 @@ session_scenarios = [
         'requiredTool': 'pinchtab',
     },
     {
-        'id': 'agent-beta-isolated',
+        'id': 'agent-beta-tab',
         'agent': 'beta',
-        'prompt': f'Use the pinchtab tool to continue the existing browser session for this agent, navigate to {fixtures_url}/journey/final, and reply with only the verification code on the page.',
-        'expected': 'MISSING-STATE',
-        'paths': ['/journey/final'],
+        'prompt': f'Use the pinchtab tool to navigate to {fixtures_url}/alpha and reply with only the verification code on the page.',
+        'expected': 'ALPHA-17',
+        'paths': ['/alpha'],
         'requiredTool': 'pinchtab',
     },
 ]
@@ -108,8 +235,11 @@ def run_agent_scenario(scenario):
         raise SystemExit(f"agent command failed for {scenario['id']}:\nSTDOUT:\n{completed.stdout}\nSTDERR:\n{completed.stderr}")
     out_path.write_text(completed.stdout)
     payload = json.loads(completed.stdout)
-    text = payload['result']['payloads'][0]['text'].strip()
-    tool_summary = payload['result']['meta'].get('toolSummary', {})
+    # `openclaw agent --json` historically wrapped the body in {"result": {...}};
+    # newer builds emit the payload at the root. Accept both shapes.
+    body = payload.get('result', payload)
+    text = body['payloads'][0]['text'].strip()
+    tool_summary = body.get('meta', {}).get('toolSummary', {})
     tools_used = tool_summary.get('tools', []) or []
     return {
         'id': scenario['id'],
@@ -135,10 +265,10 @@ if log_path.exists():
             continue
         entries.append(json.loads(line))
 
-pinchtab_log = (artifacts / 'pinchtab.log').read_text() if (artifacts / 'pinchtab.log').exists() else ''
-pinchtab_api_lines = [
-    line for line in pinchtab_log.splitlines()
-    if 'path=/health' not in line and ' path=/' in line
+browser_entries = [
+    entry for entry in entries
+    if entry.get('path', '').split('?', 1)[0] != '/health'
+    and 'Chrome' in (entry.get('userAgent') or '')
 ]
 
 for result in results + session_results:
@@ -156,20 +286,44 @@ for result in results + session_results:
 session_proof = {
     'ok': all(r['ok'] and r['toolOk'] and r['fixtureLogOk'] for r in session_results),
     'sameAgentReuse': next(r for r in session_results if r['id'] == 'agent-alpha-reuse'),
-    'crossAgentIsolation': next(r for r in session_results if r['id'] == 'agent-beta-isolated'),
+    'separateAgentTab': next(r for r in session_results if r['id'] == 'agent-beta-tab'),
 }
 
 summary = {
-    'ok': all(r['ok'] and r['fixtureLogOk'] and r['toolOk'] for r in results) and session_proof['ok'] and bool(pinchtab_api_lines),
+    'ok': all(r['ok'] and r['fixtureLogOk'] and r['toolOk'] for r in results) and session_proof['ok'] and bool(browser_entries),
     'results': results,
     'sessionProof': session_proof,
     'sessionScenarios': session_results,
     'logEntries': len(entries),
-    'pinchtabApiCallCount': len(pinchtab_api_lines),
-    'pinchtabApiSample': pinchtab_api_lines[:10],
+    'browserRequestCount': len(browser_entries),
+    'browserRequestSample': [
+        {'path': e.get('path'), 'userAgent': (e.get('userAgent') or '')[:80]}
+        for e in browser_entries[:5]
+    ],
 }
 (artifacts / 'summary.json').write_text(json.dumps(summary, indent=2) + '\n')
-print(json.dumps(summary, indent=2))
+
+def fmt_row(r):
+    status = 'PASS' if r['ok'] and r['toolOk'] and r['fixtureLogOk'] else 'FAIL'
+    actual = r['actual'].replace('\n', ' ').strip()
+    if len(actual) > 60:
+        actual = actual[:57] + '...'
+    return f"  [{status}] {r['id']:<22} agent={r['agent']:<5} tool={r['requiredTool']:<8} -> {actual!r}"
+
+all_results = results + session_results
+print()
+print('=== smoke summary ===')
+print('Main scenarios:')
+for r in results:
+    print(fmt_row(r))
+print('Session scenarios:')
+for r in session_results:
+    print(fmt_row(r))
+passed = sum(1 for r in all_results if r['ok'] and r['toolOk'] and r['fixtureLogOk'])
+print(f"Browser requests captured: {len(browser_entries)} (Chrome user-agent)")
+print(f"Result: {passed}/{len(all_results)} scenarios passed -> {'OK' if summary['ok'] else 'FAIL'}")
+print(f"(full details: artifacts/summary.json)")
+
 if not summary['ok']:
-    raise SystemExit('mock smoke verification failed')
+    raise SystemExit(1)
 PY

--- a/tests/manual/openclaw-plugin-smoke/openclaw-runner.sh
+++ b/tests/manual/openclaw-plugin-smoke/openclaw-runner.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${PINCHTAB_BASE_URL:?missing PINCHTAB_BASE_URL}"
+: "${PINCHTAB_TOKEN:?missing PINCHTAB_TOKEN}"
+: "${FIXTURES_URL:?missing FIXTURES_URL}"
+
+node /workspace/plugin/scripts/sync-skills.mjs
+
+openclaw plugins install /workspace/plugin --link >/artifacts/plugin-install.log 2>&1
+
+(openclaw gateway >/artifacts/gateway.log 2>&1) &
+GW_PID=$!
+cleanup() {
+  kill "$GW_PID" >/dev/null 2>&1 || true
+  wait "$GW_PID" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+for _ in $(seq 1 45); do
+  if openclaw health >/artifacts/health.json 2>/artifacts/health.err; then
+    break
+  fi
+  sleep 2
+done
+openclaw health >/artifacts/health.json 2>/artifacts/health.err
+
+python3 <<'PY'
+import json
+import subprocess
+from pathlib import Path
+
+artifacts = Path('/artifacts')
+fixtures_url = 'http://fixtures:8080'
+scenarios = [
+    {
+        'id': 'alpha',
+        'prompt': f'Use the pinchtab tool to navigate to {fixtures_url}/alpha and reply with only the verification code on the page.',
+        'expected': 'ALPHA-17',
+        'paths': ['/alpha'],
+        'requiredTool': 'pinchtab',
+    },
+    {
+        'id': 'journey',
+        'prompt': f'Use the pinchtab tool to navigate to {fixtures_url}/journey/start, click the Begin journey button, wait for the next page, and reply with only the final verification code.',
+        'expected': 'ORBIT-42',
+        'paths': ['/journey/start', '/journey/final'],
+        'requiredTool': 'pinchtab',
+    },
+    {
+        'id': 'chain',
+        'prompt': f'Use the pinchtab tool to navigate to {fixtures_url}/chain/one, click through until you reach the last page, and reply with only the full final verification code.',
+        'expected': 'BLUE-SUN-9',
+        'paths': ['/chain/one', '/chain/two', '/chain/final'],
+        'requiredTool': 'pinchtab',
+    },
+    {
+        'id': 'browser-alias',
+        'prompt': f'Use the browser tool to navigate to {fixtures_url}/alpha and reply with only the verification code on the page.',
+        'expected': 'ALPHA-17',
+        'paths': ['/alpha'],
+        'requiredTool': 'browser',
+    },
+]
+
+results = []
+for scenario in scenarios:
+    out_path = artifacts / f"agent-{scenario['id']}.json"
+    cmd = [
+        'openclaw', 'agent',
+        '--agent', 'main',
+        '--message', scenario['prompt'],
+        '--json',
+        '--timeout', '240',
+    ]
+    completed = subprocess.run(cmd, capture_output=True, text=True)
+    if completed.returncode != 0:
+        raise SystemExit(f"agent command failed for {scenario['id']}:\nSTDOUT:\n{completed.stdout}\nSTDERR:\n{completed.stderr}")
+    out_path.write_text(completed.stdout)
+    payload = json.loads(completed.stdout)
+    text = payload['result']['payloads'][0]['text'].strip()
+    tool_summary = payload['result']['meta'].get('toolSummary', {})
+    tools_used = tool_summary.get('tools', []) or []
+    results.append({
+        'id': scenario['id'],
+        'expected': scenario['expected'],
+        'actual': text,
+        'ok': text == scenario['expected'],
+        'paths': scenario['paths'],
+        'requiredTool': scenario['requiredTool'],
+        'toolsUsed': tools_used,
+        'toolOk': scenario['requiredTool'] in tools_used,
+    })
+
+log_path = artifacts / 'fixtures-access.log'
+entries = []
+if log_path.exists():
+    for line in log_path.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        entries.append(json.loads(line))
+
+pinchtab_log = (artifacts / 'pinchtab.log').read_text() if (artifacts / 'pinchtab.log').exists() else ''
+pinchtab_api_lines = [
+    line for line in pinchtab_log.splitlines()
+    if 'path=/health' not in line and ' path=/' in line
+]
+
+for result in results:
+    missing = []
+    for path in result['paths']:
+        hits = [
+            entry for entry in entries
+            if entry.get('path', '').split('?', 1)[0] == path
+        ]
+        if not hits:
+            missing.append(path)
+    result['fixtureLogOk'] = not missing
+    result['missingFixturePaths'] = missing
+
+summary = {
+    'ok': all(r['ok'] and r['fixtureLogOk'] and r['toolOk'] for r in results) and bool(pinchtab_api_lines),
+    'results': results,
+    'logEntries': len(entries),
+    'pinchtabApiCallCount': len(pinchtab_api_lines),
+    'pinchtabApiSample': pinchtab_api_lines[:10],
+}
+(artifacts / 'summary.json').write_text(json.dumps(summary, indent=2) + '\n')
+print(json.dumps(summary, indent=2))
+if not summary['ok']:
+    raise SystemExit('mock smoke verification failed')
+PY

--- a/tests/manual/openclaw-plugin-smoke/openclaw-runner.sh
+++ b/tests/manual/openclaw-plugin-smoke/openclaw-runner.sh
@@ -35,6 +35,7 @@ fixtures_url = 'http://fixtures:8080'
 scenarios = [
     {
         'id': 'alpha',
+        'agent': 'main',
         'prompt': f'Use the pinchtab tool to navigate to {fixtures_url}/alpha and reply with only the verification code on the page.',
         'expected': 'ALPHA-17',
         'paths': ['/alpha'],
@@ -42,6 +43,7 @@ scenarios = [
     },
     {
         'id': 'journey',
+        'agent': 'main',
         'prompt': f'Use the pinchtab tool to navigate to {fixtures_url}/journey/start, click the Begin journey button, wait for the next page, and reply with only the final verification code.',
         'expected': 'ORBIT-42',
         'paths': ['/journey/start', '/journey/final'],
@@ -49,6 +51,7 @@ scenarios = [
     },
     {
         'id': 'chain',
+        'agent': 'main',
         'prompt': f'Use the pinchtab tool to navigate to {fixtures_url}/chain/one, click through until you reach the last page, and reply with only the full final verification code.',
         'expected': 'BLUE-SUN-9',
         'paths': ['/chain/one', '/chain/two', '/chain/final'],
@@ -56,6 +59,7 @@ scenarios = [
     },
     {
         'id': 'browser-alias',
+        'agent': 'main',
         'prompt': f'Use the browser tool to navigate to {fixtures_url}/alpha and reply with only the verification code on the page.',
         'expected': 'ALPHA-17',
         'paths': ['/alpha'],
@@ -63,12 +67,38 @@ scenarios = [
     },
 ]
 
-results = []
-for scenario in scenarios:
+session_scenarios = [
+    {
+        'id': 'agent-alpha-start',
+        'agent': 'alpha',
+        'prompt': f'Use the pinchtab tool to navigate to {fixtures_url}/journey/start, click the Begin journey button, wait for the next page to load, and reply with only READY.',
+        'expected': 'READY',
+        'paths': ['/journey/start', '/journey/final'],
+        'requiredTool': 'pinchtab',
+    },
+    {
+        'id': 'agent-alpha-reuse',
+        'agent': 'alpha',
+        'prompt': f'Use the pinchtab tool to continue the existing browser session for this agent, navigate to {fixtures_url}/journey/final, and reply with only the verification code on the page.',
+        'expected': 'ORBIT-42',
+        'paths': ['/journey/final'],
+        'requiredTool': 'pinchtab',
+    },
+    {
+        'id': 'agent-beta-isolated',
+        'agent': 'beta',
+        'prompt': f'Use the pinchtab tool to continue the existing browser session for this agent, navigate to {fixtures_url}/journey/final, and reply with only the verification code on the page.',
+        'expected': 'MISSING-STATE',
+        'paths': ['/journey/final'],
+        'requiredTool': 'pinchtab',
+    },
+]
+
+def run_agent_scenario(scenario):
     out_path = artifacts / f"agent-{scenario['id']}.json"
     cmd = [
         'openclaw', 'agent',
-        '--agent', 'main',
+        '--agent', scenario['agent'],
         '--message', scenario['prompt'],
         '--json',
         '--timeout', '240',
@@ -81,8 +111,9 @@ for scenario in scenarios:
     text = payload['result']['payloads'][0]['text'].strip()
     tool_summary = payload['result']['meta'].get('toolSummary', {})
     tools_used = tool_summary.get('tools', []) or []
-    results.append({
+    return {
         'id': scenario['id'],
+        'agent': scenario['agent'],
         'expected': scenario['expected'],
         'actual': text,
         'ok': text == scenario['expected'],
@@ -90,7 +121,10 @@ for scenario in scenarios:
         'requiredTool': scenario['requiredTool'],
         'toolsUsed': tools_used,
         'toolOk': scenario['requiredTool'] in tools_used,
-    })
+    }
+
+results = [run_agent_scenario(scenario) for scenario in scenarios]
+session_results = [run_agent_scenario(scenario) for scenario in session_scenarios]
 
 log_path = artifacts / 'fixtures-access.log'
 entries = []
@@ -107,7 +141,7 @@ pinchtab_api_lines = [
     if 'path=/health' not in line and ' path=/' in line
 ]
 
-for result in results:
+for result in results + session_results:
     missing = []
     for path in result['paths']:
         hits = [
@@ -119,9 +153,17 @@ for result in results:
     result['fixtureLogOk'] = not missing
     result['missingFixturePaths'] = missing
 
+session_proof = {
+    'ok': all(r['ok'] and r['toolOk'] and r['fixtureLogOk'] for r in session_results),
+    'sameAgentReuse': next(r for r in session_results if r['id'] == 'agent-alpha-reuse'),
+    'crossAgentIsolation': next(r for r in session_results if r['id'] == 'agent-beta-isolated'),
+}
+
 summary = {
-    'ok': all(r['ok'] and r['fixtureLogOk'] and r['toolOk'] for r in results) and bool(pinchtab_api_lines),
+    'ok': all(r['ok'] and r['fixtureLogOk'] and r['toolOk'] for r in results) and session_proof['ok'] and bool(pinchtab_api_lines),
     'results': results,
+    'sessionProof': session_proof,
+    'sessionScenarios': session_results,
     'logEntries': len(entries),
     'pinchtabApiCallCount': len(pinchtab_api_lines),
     'pinchtabApiSample': pinchtab_api_lines[:10],

--- a/tests/manual/openclaw-plugin-smoke/pinchtab.config.json
+++ b/tests/manual/openclaw-plugin-smoke/pinchtab.config.json
@@ -1,0 +1,14 @@
+{
+  "server": {
+    "bind": "0.0.0.0",
+    "port": "9999",
+    "token": "smoke-token"
+  },
+  "security": {
+    "allowEvaluate": false,
+    "allowDownload": false,
+    "allowUpload": false,
+    "allowStateExport": true,
+    "allowedDomains": ["fixtures"]
+  }
+}

--- a/tests/manual/openclaw-plugin-smoke/run.sh
+++ b/tests/manual/openclaw-plugin-smoke/run.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "$0")/../../.." && pwd)
+SMOKE_DIR="$ROOT_DIR/tests/manual/openclaw-plugin-smoke"
+STATE_SOURCE=${OPENCLAW_STATE_SOURCE:-$HOME/.openclaw}
+OPENCLAW_VERSION=${OPENCLAW_VERSION:-$(openclaw --version | awk '{print $2}')}
+PROJECT_NAME=${PROJECT_NAME:-pinchtab-openclaw-mock-$(date +%s)}
+TEMP_STATE=$(mktemp -d /tmp/pinchtab-openclaw-state.XXXXXX)
+TEMP_ARTIFACTS=$(mktemp -d /tmp/pinchtab-openclaw-artifacts.XXXXXX)
+FINAL_ARTIFACTS_DIR=${FINAL_ARTIFACTS_DIR:-$SMOKE_DIR/artifacts/$(date +%Y%m%d-%H%M%S)}
+
+cleanup() {
+  docker compose -p "$PROJECT_NAME" -f "$SMOKE_DIR/docker-compose.yml" down -v --remove-orphans >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+require_file() {
+  local path=$1
+  if [[ ! -f "$path" ]]; then
+    echo "missing required file: $path" >&2
+    exit 1
+  fi
+}
+
+require_file "$STATE_SOURCE/openclaw.json"
+require_file "$STATE_SOURCE/agents/main/agent/auth-profiles.json"
+
+mkdir -p "$TEMP_STATE/agents/main/agent"
+cp "$STATE_SOURCE/openclaw.json" "$TEMP_STATE/openclaw.json"
+cp "$STATE_SOURCE/agents/main/agent/auth-profiles.json" "$TEMP_STATE/agents/main/agent/auth-profiles.json"
+for dir in credentials identity gateway service-env; do
+  if [[ -d "$STATE_SOURCE/$dir" ]]; then
+    cp -R "$STATE_SOURCE/$dir" "$TEMP_STATE/$dir"
+  fi
+done
+
+python3 - "$TEMP_STATE/openclaw.json" <<'PY'
+import json, sys
+from pathlib import Path
+path = Path(sys.argv[1])
+obj = json.loads(path.read_text())
+plugins = obj.setdefault('plugins', {}).setdefault('entries', {})
+plugins.setdefault('pinchtab', {})['enabled'] = True
+pinchtab_cfg = plugins.setdefault('pinchtab', {}).setdefault('config', {})
+pinchtab_cfg['baseUrl'] = 'http://pinchtab:9999'
+pinchtab_cfg['token'] = 'smoke-token'
+pinchtab_cfg['registerBrowserTool'] = True
+plugins.setdefault('browser', {})['enabled'] = False
+allow = plugins.get('allow')
+if isinstance(allow, list) and 'pinchtab' not in allow:
+    allow.append('pinchtab')
+obj['browser'] = {'enabled': False}
+tools = obj.setdefault('tools', {})
+existing = list(tools.get('allow', [])) if isinstance(tools.get('allow'), list) else []
+if 'pinchtab' not in existing:
+    existing.append('pinchtab')
+tools['allow'] = existing
+path.write_text(json.dumps(obj, indent=2) + '\n')
+PY
+
+mkdir -p "$FINAL_ARTIFACTS_DIR"
+export OPENCLAW_STATE_DIR="$TEMP_STATE"
+export ARTIFACTS_DIR="$TEMP_ARTIFACTS"
+export OPENCLAW_VERSION
+
+echo "running docker mock smoke..."
+if ! docker compose -p "$PROJECT_NAME" -f "$SMOKE_DIR/docker-compose.yml" up --build --abort-on-container-exit --exit-code-from openclaw 2>&1 | tee "$TEMP_ARTIFACTS/docker-compose.log"; then
+  cp -R "$TEMP_ARTIFACTS/." "$FINAL_ARTIFACTS_DIR/"
+  echo
+  echo "failed — artifacts copied to $FINAL_ARTIFACTS_DIR" >&2
+  exit 1
+fi
+
+cp -R "$TEMP_ARTIFACTS/." "$FINAL_ARTIFACTS_DIR/"
+echo
+echo "ok: artifacts copied to $FINAL_ARTIFACTS_DIR"
+cat "$FINAL_ARTIFACTS_DIR/summary.json"

--- a/tests/manual/openclaw-plugin-smoke/run.sh
+++ b/tests/manual/openclaw-plugin-smoke/run.sh
@@ -1,10 +1,31 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+ANTHROPIC_KEY=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --anthropic-key)
+      ANTHROPIC_KEY=${2:-}
+      shift 2
+      ;;
+    --anthropic-key=*)
+      ANTHROPIC_KEY=${1#--anthropic-key=}
+      shift
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      echo "usage: run.sh [--anthropic-key <key>]" >&2
+      exit 2
+      ;;
+  esac
+done
+if [[ -z "$ANTHROPIC_KEY" && -n "${ANTHROPIC_API_KEY:-}" ]]; then
+  ANTHROPIC_KEY=$ANTHROPIC_API_KEY
+fi
+
 ROOT_DIR=$(cd "$(dirname "$0")/../../.." && pwd)
 SMOKE_DIR="$ROOT_DIR/tests/manual/openclaw-plugin-smoke"
 STATE_SOURCE=${OPENCLAW_STATE_SOURCE:-$HOME/.openclaw}
-OPENCLAW_VERSION=${OPENCLAW_VERSION:-$(openclaw --version | awk '{print $2}')}
 PROJECT_NAME=${PROJECT_NAME:-pinchtab-openclaw-mock-$(date +%s)}
 TEMP_STATE=$(mktemp -d /tmp/pinchtab-openclaw-state.XXXXXX)
 TEMP_ARTIFACTS=$(mktemp -d /tmp/pinchtab-openclaw-artifacts.XXXXXX)
@@ -15,61 +36,70 @@ cleanup() {
 }
 trap cleanup EXIT
 
-require_file() {
-  local path=$1
-  if [[ ! -f "$path" ]]; then
-    echo "missing required file: $path" >&2
+if [[ -z "${OPENCLAW_VERSION:-}" ]]; then
+  if command -v openclaw >/dev/null 2>&1; then
+    OPENCLAW_VERSION=$(openclaw --version | awk '{print $2}')
+  elif [[ -n "$ANTHROPIC_KEY" ]]; then
+    OPENCLAW_VERSION=2026.4.27
+  else
+    echo "openclaw CLI not found on PATH" >&2
+    echo "this smoke test reuses the host OpenClaw install for version detection and auth state." >&2
+    echo "install openclaw locally, pin a version with OPENCLAW_VERSION=<version>," >&2
+    echo "or pass --anthropic-key <key> to bootstrap a fresh in-container state." >&2
     exit 1
   fi
-}
+fi
 
-require_file "$STATE_SOURCE/openclaw.json"
-require_file "$STATE_SOURCE/agents/main/agent/auth-profiles.json"
+if [[ -n "$ANTHROPIC_KEY" ]]; then
+  echo "using --anthropic-key: bootstrapping fresh state in container (host openclaw state ignored)"
+  for agent in main alpha beta; do
+    mkdir -p "$TEMP_STATE/agents/$agent/agent"
+  done
+else
+  require_file() {
+    local path=$1
+    if [[ ! -f "$path" ]]; then
+      echo "missing required file: $path" >&2
+      echo "this smoke test reuses the host OpenClaw state at $STATE_SOURCE." >&2
+      echo "run 'openclaw login' (or set OPENCLAW_STATE_SOURCE) before retrying," >&2
+      echo "or pass --anthropic-key <key> to bootstrap a fresh in-container state." >&2
+      exit 1
+    fi
+  }
 
-for agent in main alpha beta; do
-  mkdir -p "$TEMP_STATE/agents/$agent/agent"
-done
-cp "$STATE_SOURCE/openclaw.json" "$TEMP_STATE/openclaw.json"
-for agent in main alpha beta; do
-  cp "$STATE_SOURCE/agents/main/agent/auth-profiles.json" "$TEMP_STATE/agents/$agent/agent/auth-profiles.json"
-done
-for dir in credentials identity gateway service-env; do
-  if [[ -d "$STATE_SOURCE/$dir" ]]; then
-    cp -R "$STATE_SOURCE/$dir" "$TEMP_STATE/$dir"
-  fi
-done
+  require_file "$STATE_SOURCE/openclaw.json"
+  require_file "$STATE_SOURCE/agents/main/agent/auth-profiles.json"
 
-python3 - "$TEMP_STATE/openclaw.json" <<'PY'
-import json, sys
-from pathlib import Path
-path = Path(sys.argv[1])
-obj = json.loads(path.read_text())
-plugins = obj.setdefault('plugins', {}).setdefault('entries', {})
-plugins.setdefault('pinchtab', {})['enabled'] = True
-pinchtab_cfg = plugins.setdefault('pinchtab', {}).setdefault('config', {})
-pinchtab_cfg['baseUrl'] = 'http://pinchtab:9999'
-pinchtab_cfg['token'] = 'smoke-token'
-pinchtab_cfg['registerBrowserTool'] = True
-plugins.setdefault('browser', {})['enabled'] = False
-allow = plugins.get('allow')
-if isinstance(allow, list) and 'pinchtab' not in allow:
-    allow.append('pinchtab')
-obj['browser'] = {'enabled': False}
-tools = obj.setdefault('tools', {})
-existing = list(tools.get('allow', [])) if isinstance(tools.get('allow'), list) else []
-if 'pinchtab' not in existing:
-    existing.append('pinchtab')
-tools['allow'] = existing
-path.write_text(json.dumps(obj, indent=2) + '\n')
-PY
+  for agent in main alpha beta; do
+    mkdir -p "$TEMP_STATE/agents/$agent/agent"
+  done
+  cp "$STATE_SOURCE/openclaw.json" "$TEMP_STATE/openclaw.json"
+  for agent in main alpha beta; do
+    cp "$STATE_SOURCE/agents/main/agent/auth-profiles.json" "$TEMP_STATE/agents/$agent/agent/auth-profiles.json"
+  done
+  for dir in credentials identity gateway service-env; do
+    if [[ -d "$STATE_SOURCE/$dir" ]]; then
+      cp -R "$STATE_SOURCE/$dir" "$TEMP_STATE/$dir"
+    fi
+  done
+fi
 
 mkdir -p "$FINAL_ARTIFACTS_DIR"
 export OPENCLAW_STATE_DIR="$TEMP_STATE"
 export ARTIFACTS_DIR="$TEMP_ARTIFACTS"
 export OPENCLAW_VERSION
+export ANTHROPIC_API_KEY="$ANTHROPIC_KEY"
 
-echo "running docker mock smoke..."
-if ! docker compose -p "$PROJECT_NAME" -f "$SMOKE_DIR/docker-compose.yml" up --build --abort-on-container-exit --exit-code-from openclaw 2>&1 | tee "$TEMP_ARTIFACTS/docker-compose.log"; then
+echo "building docker images..."
+if ! docker compose -p "$PROJECT_NAME" -f "$SMOKE_DIR/docker-compose.yml" build --quiet >"$TEMP_ARTIFACTS/docker-build.log" 2>&1; then
+  cat "$TEMP_ARTIFACTS/docker-build.log" >&2
+  cp -R "$TEMP_ARTIFACTS/." "$FINAL_ARTIFACTS_DIR/"
+  echo "build failed — artifacts: $FINAL_ARTIFACTS_DIR" >&2
+  exit 1
+fi
+
+echo "running smoke..."
+if ! docker compose -p "$PROJECT_NAME" -f "$SMOKE_DIR/docker-compose.yml" up --abort-on-container-exit --exit-code-from openclaw 2>&1 | tee "$TEMP_ARTIFACTS/docker-compose.log"; then
   cp -R "$TEMP_ARTIFACTS/." "$FINAL_ARTIFACTS_DIR/"
   echo
   echo "failed — artifacts copied to $FINAL_ARTIFACTS_DIR" >&2
@@ -78,5 +108,4 @@ fi
 
 cp -R "$TEMP_ARTIFACTS/." "$FINAL_ARTIFACTS_DIR/"
 echo
-echo "ok: artifacts copied to $FINAL_ARTIFACTS_DIR"
-cat "$FINAL_ARTIFACTS_DIR/summary.json"
+echo "artifacts: $FINAL_ARTIFACTS_DIR"

--- a/tests/manual/openclaw-plugin-smoke/run.sh
+++ b/tests/manual/openclaw-plugin-smoke/run.sh
@@ -26,9 +26,13 @@ require_file() {
 require_file "$STATE_SOURCE/openclaw.json"
 require_file "$STATE_SOURCE/agents/main/agent/auth-profiles.json"
 
-mkdir -p "$TEMP_STATE/agents/main/agent"
+for agent in main alpha beta; do
+  mkdir -p "$TEMP_STATE/agents/$agent/agent"
+done
 cp "$STATE_SOURCE/openclaw.json" "$TEMP_STATE/openclaw.json"
-cp "$STATE_SOURCE/agents/main/agent/auth-profiles.json" "$TEMP_STATE/agents/main/agent/auth-profiles.json"
+for agent in main alpha beta; do
+  cp "$STATE_SOURCE/agents/main/agent/auth-profiles.json" "$TEMP_STATE/agents/$agent/agent/auth-profiles.json"
+done
 for dir in credentials identity gateway service-env; do
   if [[ -d "$STATE_SOURCE/$dir" ]]; then
     cp -R "$STATE_SOURCE/$dir" "$TEMP_STATE/$dir"


### PR DESCRIPTION
## Summary
- add a deterministic OpenClaw + Pinchtab smoke harness with Docker fixtures and artifact capture
- improve OpenClaw plugin compatibility and packaged-skill sync flow
- add per-agent Pinchtab session handling so OpenClaw agents do not share one browser context by default
- add smoke coverage proving same-agent session reuse and different-agent tab independence
- improve plugin-side config discovery, health output, and browser alias behavior
- include click / pointer runtime fixes that improve responsiveness and coordinate/current-pointer behavior used by the plugin flows

## Why
The plugin is still evolving, but it needs two things now:
1. a real smoke harness that proves Pinchtab is actually driving browser work through OpenClaw
2. isolation between OpenClaw agents so browser state does not leak across them

This branch provides both, while also folding in a small set of runtime input fixes that improve the reliability of the exercised flows.

## Notes
- this branch is broader than smoke coverage alone: it includes plugin session isolation and some related pointer/runtime fixes
- per-agent session creation fails closed rather than silently falling back to the shared server token, so agent isolation is preserved intentionally
- the smoke harness remains manual/host-driven rather than a default CI lane, but it captures strong artifacts and explicit session-isolation proof
- the plugin should still be treated as evolving rather than “finished”; this PR is a meaningful hardening step, not the final architecture

## Validation
- plugin API / navigation / session / client tests
- bridge action tests for pointer/current-position behavior
- manual OpenClaw plugin smoke harness with fixture log verification
- explicit smoke scenarios for same-agent session reuse and separate-agent tab independence
