### PR TITLE
fix: validate packed plugin artifact in release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,6 +154,76 @@ jobs:
           npm run build
           npm publish --dry-run
 
+  plugin-publish-dry-run:
+    name: Plugin Publish Dry Run
+    needs: validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.validate.outputs.sha }}
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Sync plugin version with release
+        working-directory: plugin
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          CURRENT=$(node -pe "require('./package.json').version")
+          if [ "$CURRENT" != "$VERSION" ]; then
+            npm version "$VERSION" --no-git-tag-version
+            node -e "
+              const fs = require('fs');
+              const p = JSON.parse(fs.readFileSync('openclaw.plugin.json', 'utf8'));
+              p.version = '$VERSION';
+              fs.writeFileSync('openclaw.plugin.json', JSON.stringify(p, null, 2) + '\n');
+            "
+          else
+            echo "Version already correct: $CURRENT"
+          fi
+
+      - name: Install plugin deps
+        working-directory: plugin
+        run: npm ci
+
+      - name: Dry-run npm pack (validates prepack chain + files allowlist)
+        working-directory: plugin
+        run: |
+          npm pack --dry-run
+          # Real pack so we know prepack actually emits dist/ before clawhub validates
+          npm pack
+
+      - name: Install ClawHub CLI
+        run: npm i -g clawhub
+
+      - name: Authenticate with ClawHub
+        env:
+          CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
+        run: clawhub login --token "$CLAWHUB_TOKEN" --no-browser
+
+      - name: Dry-run ClawHub publish
+        working-directory: plugin
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+          TAG: ${{ needs.validate.outputs.tag }}
+        run: |
+          clawhub package publish . \
+            --family code-plugin \
+            --version "$VERSION" \
+            --changelog "Release v$VERSION" \
+            --tags latest \
+            --source-repo pinchtab/pinchtab \
+            --source-commit "$(git rev-parse HEAD)" \
+            --source-ref "$TAG" \
+            --source-path plugin \
+            --dry-run
+
   approval:
     name: Manual Approval
     needs:
@@ -169,6 +239,7 @@ jobs:
       - e2e-infra-extended
       - smoke
       - publish-dry-run
+      - plugin-publish-dry-run
     if: >-
       always() && !cancelled()
       && needs.validate.result == 'success'
@@ -179,6 +250,7 @@ jobs:
       && needs.npm-checks.result == 'success'
       && needs.plugin-checks.result == 'success'
       && needs.publish-dry-run.result == 'success'
+      && needs.plugin-publish-dry-run.result == 'success'
     runs-on: ubuntu-latest
     environment:
       name: release-approval
@@ -196,6 +268,7 @@ jobs:
           echo "| npm | ✅ success | - | - | - | - |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Plugin | ✅ success | - | - | - | - |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Publish dry run | ✅ success | - | - | - | - |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Plugin publish dry run | ✅ success | - | - | - | - |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Smoke | ${{ needs.smoke.result == 'success' && '✅' || '⚠️ ' }}${{ needs.smoke.result }} | ${{ needs.smoke.outputs.passed || '-' }}/${{ needs.smoke.outputs.tests || '-' }} | ${{ needs.smoke.outputs.failed || '-' }} | ${{ needs.smoke.outputs.test_time || '-' }} | ${{ needs.smoke.outputs.overall_wall_time || '-' }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| E2E API | ${{ needs.e2e-api-extended.result == 'success' && '✅' || '⚠️ ' }}${{ needs.e2e-api-extended.result }} | ${{ needs.e2e-api-extended.outputs.passed || '-' }}/${{ needs.e2e-api-extended.outputs.tests || '-' }} | ${{ needs.e2e-api-extended.outputs.failed || '-' }} | ${{ needs.e2e-api-extended.outputs.test_time || '-' }} | ${{ needs.e2e-api-extended.outputs.overall_wall_time || '-' }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| E2E CLI | ${{ needs.e2e-cli-extended.result == 'success' && '✅' || '⚠️ ' }}${{ needs.e2e-cli-extended.result }} | ${{ needs.e2e-cli-extended.outputs.passed || '-' }}/${{ needs.e2e-cli-extended.outputs.tests || '-' }} | ${{ needs.e2e-cli-extended.outputs.failed || '-' }} | ${{ needs.e2e-cli-extended.outputs.test_time || '-' }} | ${{ needs.e2e-cli-extended.outputs.overall_wall_time || '-' }} |" >> "$GITHUB_STEP_SUMMARY"

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -5,14 +5,16 @@
   "type": "module",
   "scripts": {
     "sync:skills": "node ./scripts/sync-skills.mjs",
+    "build": "tsc -p tsconfig.build.json",
+    "clean": "rm -rf dist",
     "pretest": "npm run sync:skills",
-    "prepack": "npm run sync:skills",
+    "prepack": "npm run clean && npm run sync:skills && npm run build",
     "test": "tsx --test *.test.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "check": "npm run typecheck && npm test"
   },
   "openclaw": {
-    "extensions": ["./index.ts"],
+    "extensions": ["./dist/index.js"],
     "compat": {
       "pluginApi": ">=2026.3.24-beta.2"
     },
@@ -21,14 +23,9 @@
     }
   },
   "files": [
-    "index.ts",
-    "types.ts",
-    "client.ts",
-    "policy.ts",
-    "session.ts",
-    "tools/",
+    "dist/",
     "skills/",
-    "scripts/",
+    "scripts/sync-skills.mjs",
     "openclaw.plugin.json"
   ],
   "license": "MIT",

--- a/plugin/tsconfig.build.json
+++ b/plugin/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "allowImportingTsExtensions": false,
+    "outDir": "./dist",
+    "rootDir": ".",
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["index.ts", "client.ts", "session.ts", "policy.ts", "types.ts", "tools/*.ts"],
+  "exclude": ["*.test.ts", "node_modules", "dist", "skills", "scripts"]
+}

--- a/tests/manual/openclaw-plugin-smoke/README.md
+++ b/tests/manual/openclaw-plugin-smoke/README.md
@@ -5,12 +5,14 @@ Deterministic end-to-end harness for the Pinchtab OpenClaw plugin.
 What it does:
 - builds a local Pinchtab image from this repo
 - starts a local fixture server inside Docker
-- installs the repo plugin into a fresh OpenClaw container
+- **simulates the plugin release flow**: runs `npm pack` against `plugin/` (which triggers the same `prepack` chain — clean → sync skills → `tsc` build → emit `dist/` — that runs during a real `npm publish`), then installs the resulting tarball into the OpenClaw container exactly as a downstream consumer would
 - disables the bundled OpenClaw browser plugin so `browser` resolves to Pinchtab's compatibility alias
 - runs several `openclaw agent` prompts against the fixture site
 - verifies the returned answers
 - verifies fixture access logs show real browser traffic from Pinchtab
 - proves same-agent session reuse (alpha) and per-agent tab independence (beta) via dedicated smoke turns
+
+Because the plugin is consumed from a packed tarball (not via `--link`), this harness catches release-blocking issues — missing compiled output, wrong `openclaw.extensions` path, files-allowlist gaps — before they reach `clawhub package publish` in CI.
 
 ## Requirements
 

--- a/tests/manual/openclaw-plugin-smoke/openclaw-runner.sh
+++ b/tests/manual/openclaw-plugin-smoke/openclaw-runner.sh
@@ -132,9 +132,15 @@ if [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
   " 2>&1 | tee /artifacts/anthropic-probe.log
 fi
 
-node /workspace/plugin/scripts/sync-skills.mjs
+if [ ! -f /artifacts/plugin.tgz ]; then
+  echo "missing /artifacts/plugin.tgz — run.sh must run 'npm pack' before docker compose up" >&2
+  exit 1
+fi
 
-openclaw plugins install /workspace/plugin --link >/artifacts/plugin-install.log 2>&1
+# Install from the same tarball npm publish would upload — closest mirror of
+# the release flow. No --link, no source bind: the plugin is consumed exactly
+# as a downstream user would consume the published package.
+openclaw plugins install /artifacts/plugin.tgz >/artifacts/plugin-install.log 2>&1
 
 (openclaw gateway >/artifacts/gateway.log 2>&1) &
 GW_PID=$!

--- a/tests/manual/openclaw-plugin-smoke/run.sh
+++ b/tests/manual/openclaw-plugin-smoke/run.sh
@@ -90,6 +90,29 @@ export ARTIFACTS_DIR="$TEMP_ARTIFACTS"
 export OPENCLAW_VERSION
 export ANTHROPIC_API_KEY="$ANTHROPIC_KEY"
 
+echo "packing plugin (release-flow simulation: prepack → build → npm pack)..."
+# `npm pack` triggers the same `prepack` chain that `npm publish` would run
+# during release: clean → sync skills → tsc build → emit dist/. The resulting
+# tarball is the exact artifact that would be uploaded to npm + ClawHub.
+# Smoke installs from this tarball below to validate the published shape
+# (compiled runtime, files allowlist, manifest paths) end-to-end.
+PACK_DIR="$TEMP_ARTIFACTS/plugin-pack"
+mkdir -p "$PACK_DIR"
+if ! (cd "$ROOT_DIR/plugin" && npm pack --pack-destination "$PACK_DIR" >"$TEMP_ARTIFACTS/plugin-pack.log" 2>&1); then
+  cat "$TEMP_ARTIFACTS/plugin-pack.log" >&2
+  cp -R "$TEMP_ARTIFACTS/." "$FINAL_ARTIFACTS_DIR/"
+  echo "plugin pack failed — artifacts: $FINAL_ARTIFACTS_DIR" >&2
+  exit 1
+fi
+PLUGIN_TARBALL=$(ls "$PACK_DIR"/*.tgz 2>/dev/null | head -1 || true)
+if [[ -z "$PLUGIN_TARBALL" ]]; then
+  echo "plugin pack produced no tarball — see $TEMP_ARTIFACTS/plugin-pack.log" >&2
+  cp -R "$TEMP_ARTIFACTS/." "$FINAL_ARTIFACTS_DIR/"
+  exit 1
+fi
+cp "$PLUGIN_TARBALL" "$TEMP_ARTIFACTS/plugin.tgz"
+echo "  packed: $(basename "$PLUGIN_TARBALL") ($(wc -c <"$PLUGIN_TARBALL" | tr -d ' ') bytes)"
+
 echo "building docker images..."
 if ! docker compose -p "$PROJECT_NAME" -f "$SMOKE_DIR/docker-compose.yml" build --quiet >"$TEMP_ARTIFACTS/docker-build.log" 2>&1; then
   cat "$TEMP_ARTIFACTS/docker-build.log" >&2


### PR DESCRIPTION
## Summary
- add a dedicated plugin publish dry-run stage to the release workflow
- split plugin build emit into `tsconfig.build.json` so release packaging writes `dist/`
- keep `typecheck` as a separate no-emit path
- update the OpenClaw plugin smoke harness to pack the plugin tarball with `npm pack` and install that artifact instead of linking the source tree
- document the smoke harness as a release-flow simulation for the plugin package

## Why
The important failure mode here is not "does the plugin work from source?" but "does the packaged artifact that release/publish ships actually work?" This branch makes both CI and the manual OpenClaw smoke harness validate the packed plugin tarball, which catches missing `dist/`, broken manifest paths, and files-allowlist mistakes before they reach npm or ClawHub.

## Notes
- this is a release correctness fix, not a product behavior change
- the smoke harness now mirrors the publish path much more closely: `prepack` runs, `dist/` is emitted, `npm pack` creates the tarball, and OpenClaw installs that tarball as a downstream consumer would
- the release workflow now performs both a dry-run pack and a real pack before the ClawHub dry-run publish step

## Validation
- release workflow adds `plugin-publish-dry-run`
- plugin package build now emits via `tsconfig.build.json`
- manual smoke harness installs `/artifacts/plugin.tgz` produced by `npm pack`
- smoke README updated to explain the release-flow simulation
