### PR TITLE
fix: preserve default config semantics on first-run init flows

### DIFF
--- a/cmd/pinchtab/cmd_cli_management.go
+++ b/cmd/pinchtab/cmd_cli_management.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	browseractions "github.com/pinchtab/pinchtab/internal/cli/actions"
+	"github.com/pinchtab/pinchtab/internal/config"
 	"github.com/pinchtab/pinchtab/internal/urls"
 	"github.com/spf13/cobra"
 )
@@ -20,6 +21,7 @@ var healthCmd = &cobra.Command{
 	Use:   "health",
 	Short: "Check server health",
 	Run: func(cmd *cobra.Command, args []string) {
+		config.EmitDefaultConfigHint()
 		runCLI(func(rt cliRuntime) {
 			browseractions.Health(rt.client, rt.base, rt.token, cmd)
 		})

--- a/cmd/pinchtab/cmd_config.go
+++ b/cmd/pinchtab/cmd_config.go
@@ -20,6 +20,9 @@ var clipboardExecCommand = exec.Command
 var configCmd = &cobra.Command{
 	Use:   "config",
 	Short: "Manage configuration",
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		config.EmitDefaultConfigHint()
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		printConfigOverview(loadLocalConfig())
 	},

--- a/internal/config/config_load.go
+++ b/internal/config/config_load.go
@@ -7,8 +7,32 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 )
+
+var configHintOnce sync.Once
+
+// EmitDefaultConfigHint prints a one-time hint to stderr when PINCHTAB_CONFIG
+// points somewhere other than the default config path AND a default config
+// already exists at that path. The hint is best-effort UX nudge for users
+// who may not realize they're running against a custom config.
+//
+// Scoped to specific commands (health, config) and once-per-process via
+// sync.Once so scripted callers and unrelated CLI commands stay quiet.
+func EmitDefaultConfigHint() {
+	configHintOnce.Do(func() {
+		defaultConfigPath := filepath.Join(userConfigDir(), "config.json")
+		configPath := envOr("PINCHTAB_CONFIG", defaultConfigPath)
+		if configPath == defaultConfigPath {
+			return
+		}
+		if _, err := os.Stat(defaultConfigPath); err != nil {
+			return
+		}
+		fmt.Fprintf(os.Stderr, "HINT: default config exists at %s — you can edit it directly instead of using PINCHTAB_CONFIG\n", defaultConfigPath)
+	})
+}
 
 // Load returns the RuntimeConfig with precedence: env vars > config file > defaults.
 func Load() *RuntimeConfig {
@@ -145,12 +169,6 @@ func Load() *RuntimeConfig {
 	// Load config file (supports both legacy flat and new nested format)
 	defaultConfigPath := filepath.Join(userConfigDir(), "config.json")
 	configPath := envOr("PINCHTAB_CONFIG", defaultConfigPath)
-
-	if configPath != defaultConfigPath {
-		if _, statErr := os.Stat(defaultConfigPath); statErr == nil {
-			fmt.Fprintf(os.Stderr, "HINT: default config exists at %s — you can edit it directly instead of using PINCHTAB_CONFIG\n", defaultConfigPath)
-		}
-	}
 
 	data, err := os.ReadFile(configPath)
 	if err != nil {

--- a/internal/config/fileio.go
+++ b/internal/config/fileio.go
@@ -8,24 +8,32 @@ import (
 	"runtime"
 )
 
-// tightenConfigPerms best-effort enforces 0700 on the config directory and
-// 0600 on the config file. It is invoked from both the save path (to handle
-// pre-existing loose perms left by older versions) and the load path (to
-// proactively recover regardless of whether the user mutates anything).
-// Failures are intentionally swallowed: chmod can fail on read-only FS,
-// foreign-owned files, or filesystems that don't honor unix perms, none of
-// which should block reading config.
-func tightenConfigPerms(path string) {
+// applyConfigPerms enforces 0600 on the config file and 0700 on its parent
+// directory. It only chmods when current perms differ from the target, so
+// repeat calls on already-tight perms are no-ops and safe on directories
+// the process doesn't own (e.g. /tmp).
+//
+// Strictness is the caller's choice. SaveFileConfig bubbles errors because
+// it just wrote secrets and a dir we can't tighten is a real problem. The
+// load path swallows the return: chmod can fail on read-only FS, foreign-
+// owned files, or filesystems that don't honor unix perms, none of which
+// should block reading config.
+func applyConfigPerms(path string) error {
 	if runtime.GOOS == "windows" {
-		return
+		return nil
 	}
 	if fi, err := os.Stat(path); err == nil && fi.Mode().Perm() != 0600 {
-		_ = os.Chmod(path, 0600)
+		if err := os.Chmod(path, 0600); err != nil {
+			return fmt.Errorf("failed to set config file permissions: %w", err)
+		}
 	}
 	dir := filepath.Dir(path)
 	if fi, err := os.Stat(dir); err == nil && fi.Mode().Perm() != 0700 {
-		_ = os.Chmod(dir, 0700)
+		if err := os.Chmod(dir, 0700); err != nil {
+			return fmt.Errorf("failed to set config directory permissions: %w", err)
+		}
 	}
+	return nil
 }
 
 // LoadFileConfig loads a FileConfig from the default or specified path.
@@ -36,12 +44,21 @@ func LoadFileConfig() (*FileConfig, string, error) {
 	data, err := os.ReadFile(configPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return &FileConfig{}, configPath, nil
+			// No file on disk — the effective config is the defaults. Returning
+			// a populated DefaultFileConfig() (rather than a zero FileConfig{})
+			// means callers that subsequently SaveFileConfig don't write a
+			// half-empty file with all-zero security/instance fields, which
+			// previously caused IDPI and other defaults to be silently disabled
+			// on first-run auto-config. ConfigVersion is reset so NeedsWizard()
+			// still treats this as a first-install state.
+			defaults := DefaultFileConfig()
+			defaults.ConfigVersion = ""
+			return &defaults, configPath, nil
 		}
 		return nil, configPath, fmt.Errorf("failed to read config file: %w", err)
 	}
 
-	tightenConfigPerms(configPath)
+	_ = applyConfigPerms(configPath)
 
 	if isLegacyConfig(data) {
 		fc, err := loadLegacyFileConfig(data)
@@ -65,9 +82,6 @@ func SaveFileConfig(fc *FileConfig, path string) error {
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		return fmt.Errorf("failed to create config directory: %w", err)
 	}
-	if err := os.Chmod(dir, 0700); err != nil {
-		return fmt.Errorf("failed to set config directory permissions: %w", err)
-	}
 
 	data, err := json.MarshalIndent(fc, "", "  ")
 	if err != nil {
@@ -78,11 +92,8 @@ func SaveFileConfig(fc *FileConfig, path string) error {
 	if err := os.WriteFile(path, data, 0600); err != nil {
 		return fmt.Errorf("failed to write config file: %w", err)
 	}
-	if err := os.Chmod(path, 0600); err != nil {
-		return fmt.Errorf("failed to set config file permissions: %w", err)
-	}
 
-	return nil
+	return applyConfigPerms(path)
 }
 
 func loadLegacyFileConfig(data []byte) (*FileConfig, error) {

--- a/skills/pinchtab-coldstart/SKILL.md
+++ b/skills/pinchtab-coldstart/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pinchtab-coldstart
-description: "Run the PinchTab cold-start test. Spawns a subagent that builds PinchTab from source, starts the server natively (no Docker), and executes groups 0-1 (14 steps) using only the skill docs. Use when asked to 'run cold start', 'cold-start test', or 'test the agent onboarding flow'."
+description: "Run the PinchTab cold-start test. Spawns a subagent that follows tests/coldstart/subagent-context.md to validate the documented first-install user journey. Use when asked to 'run cold start', 'cold-start test', or 'test the agent onboarding flow'."
 ---
 
 # PinchTab Cold-Start Test
@@ -18,14 +18,19 @@ pkill -f 'Google Chrome.*pinchtab' 2>/dev/null
 sleep 2
 rm -f ~/.local/state/pinchtab/current-tab 2>/dev/null
 rm -f "$PROJECT_ROOT/pinchtab" 2>/dev/null
+rm -f ~/.pinchtab/coldstart-config-*.json 2>/dev/null
 lsof -ti:9867 2>/dev/null | xargs kill 2>/dev/null
 ```
+
+The cold-start uses `PINCHTAB_CONFIG=~/.pinchtab/coldstart-config-<timestamp>.json` so it never touches the user's real `~/.pinchtab/config.json`. Stale coldstart-config files from previous runs are removed above so `./pinchtab config init` writes a truly fresh OOTB config every time.
 
 Wait 2 seconds after cleanup before spawning the agent.
 
 ## Execution
 
-Spawn a single subagent with the prompt below. Replace `{PROJECT_ROOT}` and `{TIMESTAMP}` with actual values.
+Spawn a single subagent **on Haiku 4.5** (`model: "haiku"` in the Agent tool call). Cold-start is a doc-quality test: if Haiku can complete 11/11 from the SKILL docs alone, the onboarding flow is genuinely cold-start-ready. Opus passing is unsurprising and not the signal we want. Do not let the subagent inherit Opus from the parent.
+
+Use the prompt below. Replace `{PROJECT_ROOT}` and `{TIMESTAMP}` with actual values.
 
 ```
 You are running a PinchTab cold-start validation. Your working directory is {PROJECT_ROOT}.
@@ -42,24 +47,30 @@ Report pass/fail for every step. Write your full results to `/tmp/pinchtab-colds
 
 ## Interpreting results
 
-- **14/14 PASS**: The skill docs are sufficient for a cold start.
+- **11/11 PASS**: The skill docs are sufficient for a cold start.
 - **Any failure**: Check what the agent got stuck on — that's a gap in the skill docs or the CLI ergonomics.
 
 Key things to look for in the report:
 - Did the agent use the default port (9867) or pick a custom one?
 - Did the agent read the server's READY output or poll health in a loop?
 - Did the agent use `./pinchtab` CLI or fall back to curl/HTTP API?
-- Did the agent modify `~/.pinchtab/config.json` or use a temp config with `PINCHTAB_CONFIG`?
+- Did the agent leave `~/.pinchtab/config.json` untouched and run from a `PINCHTAB_CONFIG=~/.pinchtab/coldstart-config-*.json` throwaway path?
+- Did the agent **avoid** running `./pinchtab config init`, `./pinchtab server`, and `./pinchtab session create`? The auto-flow on the first `nav` should handle all three. If the agent ran any of them, the cold-start docs failed to communicate that the auto-flow is the test.
+- Did step 0.1 (cold nav) auto-create the config AND auto-start the server in a single command?
+- Did step 0.5 (IDPI rejection) get a clean `idpi_domain_blocked`-style error against `https://example.com`?
 - Did step 1.2 (click follows link) pass without an eval workaround?
+- Did step 1.5 (fill+press login) reach `VERIFY_LOGIN_SUCCESS_DASHBOARD`?
 
 ## Comparing runs
 
-Track token usage and tool call counts across runs to measure improvements:
+Track token usage and tool call counts across runs to measure improvements. Thresholds are calibrated for Haiku 4.5 — recalibrate if you switch models.
 
 | Metric | Good | Needs work |
 |--------|------|------------|
-| Total tokens | < 40k | > 50k |
-| Tool calls | < 40 | > 50 |
+| Total tokens | < 60k | > 80k |
+| Tool calls | < 50 | > 60 |
 | Port | 9867 (default) | Custom port |
 | Server wait | Read READY | Polled health |
 | API usage | CLI only | curl/HTTP fallback |
+
+(Earlier runs on Opus 4.7 came in around 45-53k tokens / 29-38 tool calls. Haiku tends to use more tool calls for the same task; expect higher numbers and adjust thresholds after the first few Haiku runs.)

--- a/tests/coldstart/group-00.md
+++ b/tests/coldstart/group-00.md
@@ -1,0 +1,78 @@
+# Group 0: Auto-Start & First-Use Validation
+
+A fresh user is told to "install PinchTab and run `pinchtab nav <url>`" — the CLI auto-creates a config and auto-starts the server. These steps prove that documented flow works end to end on a clean machine.
+
+**Do not** run `./pinchtab config init` or `./pinchtab server` manually. The whole point of group 0 is to verify the auto-flow handles them. Likewise do not create a session — the CLI uses the token from the auto-created config.
+
+The setup section in `subagent-context.md` already exported `PINCHTAB_CONFIG=~/.pinchtab/coldstart-config-<timestamp>.json` to a non-existent path. Step 0.1 is the very first command you run against the binary.
+
+### 0.1 Cold nav auto-creates config and starts server
+Run a single navigation against the fixture server with no preceding `pinchtab` calls:
+
+```bash
+./pinchtab nav http://localhost:$FIXTURE_PORT/ --print-tab-id
+```
+
+**Verify**:
+- The command exits 0 and prints a tab ID. Capture it (`TAB_ID=...`) and reuse for every step in group 1.
+- `$PINCHTAB_CONFIG` now exists on disk — auto-created by the CLI.
+- A `pinchtab server` process is running on default port `9867` (`lsof -i :9867` or check `ps`).
+- A managed Chrome instance has come up (`./pinchtab instances` shows at least one row, `status=running`).
+
+### 0.2 Auto-created config matches OOTB defaults
+Without ever running `config init` manually, inspect what the auto-flow wrote:
+
+```bash
+./pinchtab config validate
+./pinchtab config get server.port
+./pinchtab config get instanceDefaults.mode
+./pinchtab config get security.allowEvaluate
+./pinchtab config get security.allowedDomains
+```
+
+**Verify**:
+- `config validate` reports the file at `$PINCHTAB_CONFIG` is valid.
+- `server.port` → `9867`
+- `instanceDefaults.mode` → `headless`
+- `security.allowEvaluate` → `false`
+- `security.allowedDomains` → contains `localhost` (or `127.0.0.1`)
+
+If any of these are different, the auto-flow didn't produce true OOTB defaults — flag it.
+
+### 0.3 Server is reachable on default port
+The auto-started server should respond to a plain health check.
+
+```bash
+./pinchtab health
+```
+
+**Verify**: `status: ok`. The configured token from the auto-created config was used implicitly — no env override, no session.
+
+### 0.4 Auth is enforced
+Override the token to a deliberately wrong value:
+
+```bash
+PINCHTAB_TOKEN=wrong-token ./pinchtab health
+```
+
+**Verify**: Exits non-zero with HTTP 401 / `unauthorized`.
+
+### 0.5 IDPI rejects non-local URLs OOTB
+The README explicitly warns that the OOTB security posture restricts browsing to local domains. Test it.
+
+```bash
+./pinchtab nav https://example.com
+```
+
+**Verify**: The command fails with `idpi_domain_blocked` (or similar) referring to `example.com` not being in the allowed-domains list. This is correct OOTB behavior — a fresh agent should know it has to add domains explicitly before navigating to the public web. **Do not** run `./pinchtab config set` to add `example.com` here; the rejection itself is the test.
+
+### 0.6 Tab list shows the navigated tab
+The tab from 0.1 should still be listed.
+
+```bash
+./pinchtab tab
+```
+
+**Verify**: `$TAB_ID` from 0.1 is in the list, with title `PinchTab Benchmark - Home` and URL `http://localhost:$FIXTURE_PORT/`. Reuse this tab ID for every step in group 1.
+
+---

--- a/tests/coldstart/group-01.md
+++ b/tests/coldstart/group-01.md
@@ -1,0 +1,42 @@
+# Group 1: First-Use Reading & Interaction
+
+A minimal but real walkthrough of the agent commands the README features in "AI Agent Automation": navigate, snap, click, text, fill, press. Reuse the tab ID captured in 0.1 for every step.
+
+### 1.1 Read the wiki index
+Navigate to `http://localhost:$FIXTURE_PORT/wiki.html` and list the categories with their article counts.
+
+**Verify**: Output names at least two categories with their counts (e.g. `Programming Languages: 12 articles`, `Network Protocols: 8 articles`). The marker `VERIFY_WIKI_INDEX_55555` appears somewhere in the page text.
+
+### 1.2 Click a link by accessibility ref
+From the wiki index, take a snapshot, find the `Go (programming language)` link, and click it via its ref (e.g. `e8`). Use `--wait-nav` so the click resolves the new page before returning.
+
+**Verify**: The current tab is now on `wiki-go.html` with title `Go Language — Encyclopedia`. No `evaluate` workaround was needed — `snap` + `click <ref>` is the expected pattern.
+
+### 1.3 Extract structured data from a table
+On the Go article page, read the infobox and answer: who designed Go, and in what year did it first appear?
+
+**Verify**: Answer contains at least one of `Robert Griesemer`, `Rob Pike`, `Ken Thompson`, AND the year `2009`.
+
+### 1.4 List content with `--full`
+Navigate to `http://localhost:$FIXTURE_PORT/articles.html` and list every article headline. The default `text` command applies a Readability filter and will drop most of the list — use `text --full` for list/grid pages.
+
+**Verify**: Found all three headlines:
+- `The Future of Artificial Intelligence`
+- `Climate Action in 2026: Progress and Challenges`
+- `Mars Colony: First Steps`
+
+The marker `VERIFY_ARTICLES_PAGE_67890` appears somewhere in the page text.
+
+### 1.5 Fill a form and submit with `press`
+Navigate to `http://localhost:$FIXTURE_PORT/login.html`, fill the username and password fields, and submit by pressing Enter on the password input. This exercises `fill` and `press` — the two interaction commands featured in the README's "AI Agent Automation" example that aren't covered by 1.2.
+
+Steps:
+1. Nav to `login.html` and verify the marker `VERIFY_LOGIN_PAGE_77777` is present.
+2. `snap` to get refs for the username and password inputs.
+3. `fill <userRef> admin` and `fill <passRef> password123` (these are valid credentials baked into the fixture).
+4. `press <passRef> Enter` (submit by keystroke, not by clicking the button — covers a different code path).
+5. Read the page after submit.
+
+**Verify**: After submit, the page text contains `VERIFY_LOGIN_SUCCESS_DASHBOARD`. If it instead shows the login form again, the fill/press flow regressed — flag the failure.
+
+---

--- a/tests/coldstart/subagent-context.md
+++ b/tests/coldstart/subagent-context.md
@@ -1,17 +1,18 @@
 # Cold-Start Subagent Context
 
-You are running PinchTab cold-start validation. Your job is to build PinchTab from source, start the server natively (no Docker), and execute groups 0-1 against local fixture HTML files.
+You are running PinchTab cold-start validation. Your job is to build PinchTab from source, then verify that the documented "fresh install" user journey works: `pinchtab nav <url>` should auto-create a config, auto-start the server, and navigate — all in one command, no manual `config init`, no manual `pinchtab server`, no `session create`. Execute groups 0-1 against local fixture HTML files.
 
 ## What to read
 
 1. **PinchTab dev skill**: `skills/pinchtab-dev/SKILL.md` — how to build the project.
 2. **PinchTab skill**: `skills/pinchtab/SKILL.md` — full command reference, configuration, and patterns.
-3. **Group files**: `tests/optimization/group-00.md` and `tests/optimization/group-01.md` — step definitions and verification markers.
+3. **Group files**: `tests/coldstart/group-00.md` and `tests/coldstart/group-01.md` — step definitions and verification markers, written specifically for the cold-start lane (native binary, no Docker).
 
 ## What NOT to read
 
 - `tests/tools/scripts/baseline.sh` — deterministic baseline; reading it defeats the purpose.
 - `tests/benchmark/` — separate benchmark lane, not your concern.
+- `tests/optimization/` — Docker-based lane; uses `./scripts/pt`, which does not apply here.
 
 ## Environment
 
@@ -35,21 +36,31 @@ FIXTURE_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("",0)); pri
 python3 -m http.server $FIXTURE_PORT --directory tests/tools/fixtures --bind 127.0.0.1 &
 ```
 
-### 3. Configure and start PinchTab
+### 3. Point at a throwaway config — DO NOT init it or start the server
 
-Read the PinchTab skill to learn how to configure and start the server. You need:
-- A server with auth enabled
-- Chrome running in headed mode (not headless)
-- `localhost` in allowed domains so you can reach the fixture server
-- `allowEvaluate` enabled (some steps use eval)
+Cold-start matches the documented first-use journey from the README: a user installs PinchTab and just runs `pinchtab nav <url>`. The CLI auto-creates a config (with a generated token) and auto-starts the server. The cold-start verifies that pathway works, so **do not run any of these manually**:
 
-Start the server and **read its stdout** — it prints `READY` when the instance is up and a hint showing how to create a session and start navigating.
+- `./pinchtab config init` — the auto-flow creates the config on first command. Step 0.1 is the test of that.
+- `./pinchtab server` — the auto-flow starts it on first command. Step 0.1 is the test of that.
+- `./pinchtab session create` — local single-user CLI calls authenticate from the config token directly; sessions are an advanced feature.
 
-Use `./pinchtab` CLI commands for everything — never use `./scripts/pt` (that is the Docker wrapper) and never use curl against the HTTP API.
+What you DO need to do:
+
+```bash
+# Isolate from the user's real ~/.pinchtab/config.json by pointing at a throwaway path.
+# The path must NOT exist yet — step 0.1 verifies the CLI creates it.
+export PINCHTAB_CONFIG=~/.pinchtab/coldstart-config-$(date +%s).json
+```
+
+`~/.pinchtab/` is preferred over `/tmp` because PinchTab tightens parent-directory perms to 0700 on save; on macOS that fails on `/tmp` (root-owned `/private/tmp`). The user's home dir always works.
+
+If a step in groups 0-1 actually requires a different config value, the agent should discover that from a failure and modify the config with `./pinchtab config set <path> <value>`. The cold-start groups have been written so this should not be necessary — they verify the OOTB auto-flow.
+
+Use `./pinchtab` CLI commands for everything — never use `./scripts/pt` (that is the Docker wrapper) and never use curl against the HTTP API. The native CLI honors `PINCHTAB_TOKEN`, `PINCHTAB_SERVER`, and `PINCHTAB_CONFIG` env vars, so you can override any of them inline (e.g. `PINCHTAB_TOKEN=wrong-token ./pinchtab health` for the auth-rejection check in step 0.4).
 
 ## Running steps
 
-Fixture URLs are `http://localhost:$FIXTURE_PORT/` — the group files reference `http://fixtures/` which is the Docker hostname. Replace `http://fixtures/` with `http://localhost:$FIXTURE_PORT/` in every command.
+Fixture URLs in the cold-start group files use `http://localhost:$FIXTURE_PORT/` directly — no substitution needed. Export `FIXTURE_PORT` in your shell before running the steps so the literal `$FIXTURE_PORT` in commands resolves correctly.
 
 Execute every step in groups 0 and 1. For each step:
 
@@ -59,4 +70,9 @@ Execute every step in groups 0 and 1. For each step:
 
 ## Cleanup
 
-When finished, kill the fixture server and PinchTab server, remove any temp config, and delete the built binary.
+When finished:
+- Kill the fixture server and PinchTab server.
+- Delete the temp config: `rm -f "$PINCHTAB_CONFIG"`.
+- Delete the built binary: `rm -f ./pinchtab`.
+
+You should not need to restore anything — the cold-start only wrote to `~/.pinchtab/coldstart-config-<timestamp>.json`, never to the user's real `~/.pinchtab/config.json`.


### PR DESCRIPTION
## Summary
- return populated default file config state when no config file exists, instead of a zero-value `FileConfig{}`
- keep `ConfigVersion` empty in that first-run path so wizard/init flows still recognize a fresh install
- refactor config permission tightening into `applyConfigPerms()` with explicit strict-vs-best-effort call sites
- scope the `PINCHTAB_CONFIG` default-config hint to relevant commands instead of emitting it from every config load
- refine the PinchTab cold-start skill and split the cold-start lane into explicit group files

## Why
The important correctness fix here is first-run config behavior: callers that loaded a missing config file and later saved it could previously write a half-empty config, silently dropping expected defaults like security and instance settings. Returning a populated default config state fixes that while still preserving fresh-install detection.

This branch also improves the cold-start validation harness so the documented first-use flow is tested more explicitly and with less room for accidental cheating.

## Notes
- despite the branch name, this is really a first-run config correctness + cold-start validation branch
- `LoadFileConfig()` now returns `DefaultFileConfig()` when the file does not exist, but with `ConfigVersion=""` so first-install flows still behave correctly
- config permission tightening remains best-effort on load and strict on save
- the `PINCHTAB_CONFIG` hint is now scoped to `config` / `health` command entry points rather than emitted on every config load

## Validation
- config load/save behavior updated in `internal/config/`
- cold-start documentation split into `group-00.md` and `group-01.md`
- cold-start skill and subagent context updated to reflect the true auto-init / auto-start flow
