### PR TITLE
docs: warn macOS users about legacy App Support config path

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -54,6 +54,8 @@ go build -o pinchtab ./cmd/pinchtab
 
 **[Full build & contribution guide ->](guides/contributing.md)**
 
+> **macOS upgrade note:** current PinchTab uses `~/.pinchtab/config.json` as the default config path. If you still have an older config at `~/Library/Application Support/pinchtab/config.json`, move or merge it into `~/.pinchtab/config.json`.
+
 ## Platform Support
 
 PinchTab's primary tested workflow is local macOS and Linux.

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -151,6 +151,8 @@ Default location by OS:
 
 On macOS and Linux, PinchTab defaults to `~/.pinchtab` so the CLI, npm-managed binary, and config file all use the same base directory.
 
+If you are upgrading from an older macOS setup and still have a config at `~/Library/Application Support/pinchtab/config.json`, treat that as a legacy location and move or merge it into `~/.pinchtab/config.json`.
+
 Override the config path with:
 
 ```bash


### PR DESCRIPTION
## Summary
- add a short macOS upgrade note to `docs/get-started.md`
- document in `docs/reference/config.md` that `~/Library/Application Support/pinchtab/config.json` is a legacy location
- point users to `~/.pinchtab/config.json` as the current default config path on macOS

## Why
Issue #531 showed that some macOS users may still have an older config in App Support while current PinchTab expects the home-directory config path by default. A short docs warning should make the migration path obvious and reduce token/config confusion.

## Notes
- current default on macOS is `~/.pinchtab/config.json`
- App Support path is documented here only as a legacy location to migrate away from
