### PR TITLE
bridge: --cdp-attach flag to drive an externally-managed Chrome

### DIFF
--- a/cmd/pinchtab/cmd_bridge.go
+++ b/cmd/pinchtab/cmd_bridge.go
@@ -8,7 +8,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var bridgeEngine string
+var (
+	bridgeEngine    string
+	bridgeCDPAttach string
+	bridgeBind      string
+	bridgePort      string
+)
 
 var bridgeCmd = &cobra.Command{
 	Use:   "bridge",
@@ -20,6 +25,15 @@ var bridgeCmd = &cobra.Command{
 			return err
 		}
 		cfg.Engine = engineMode
+		if v := strings.TrimSpace(bridgeCDPAttach); v != "" {
+			cfg.CDPAttachURL = v
+		}
+		if v := strings.TrimSpace(bridgeBind); v != "" {
+			cfg.Bind = v
+		}
+		if v := strings.TrimSpace(bridgePort); v != "" {
+			cfg.Port = v
+		}
 		server.RunBridgeServer(cfg, version)
 		return nil
 	},
@@ -42,5 +56,8 @@ func resolveBridgeEngine(flagValue, configValue string) (string, error) {
 func init() {
 	bridgeCmd.GroupID = "primary"
 	bridgeCmd.Flags().StringVar(&bridgeEngine, "engine", "", "Bridge engine: chrome, lite, or auto (overrides config)")
+	bridgeCmd.Flags().StringVar(&bridgeCDPAttach, "cdp-attach", "", "Attach to an existing Chrome via its browser-level CDP URL (e.g. ws://127.0.0.1:9222/devtools/browser/abc). Skips launching Chrome; the external Chrome is left alive on shutdown.")
+	bridgeCmd.Flags().StringVar(&bridgeBind, "bind", "", "Bind address for the bridge HTTP server (overrides config server.bind)")
+	bridgeCmd.Flags().StringVar(&bridgePort, "port", "", "Port for the bridge HTTP server (overrides config server.port)")
 	rootCmd.AddCommand(bridgeCmd)
 }

--- a/internal/bridge/runtime/init.go
+++ b/internal/bridge/runtime/init.go
@@ -72,8 +72,6 @@ func initChromeFromExistingCDP(cfg *config.RuntimeConfig, bundle *stealth.Bundle
 	wsURL := strings.TrimSpace(cfg.CDPAttachURL)
 	slog.Info("attaching to existing Chrome via CDP", "cdpUrl", wsURL)
 
-	bundle = ensureStealthBundle(cfg, bundle)
-
 	remoteAllocCtx, remoteAllocCancel := chromedp.NewRemoteAllocator(context.Background(), wsURL)
 	browserCtx, browserCancel := chromedp.NewContext(remoteAllocCtx)
 

--- a/internal/bridge/runtime/init.go
+++ b/internal/bridge/runtime/init.go
@@ -38,7 +38,16 @@ type Hooks struct {
 }
 
 // InitChrome initializes a Chrome browser for a Bridge instance.
+//
+// When cfg.CDPAttachURL is set, this skips launching a Chrome process and
+// connects to the externally-managed Chrome at that browser-level CDP
+// WebSocket URL. The returned cancel funcs only release the chromedp
+// allocator + browser context; the external Chrome process is left alive.
 func InitChrome(cfg *config.RuntimeConfig, bundle *stealth.Bundle, hooks Hooks) (context.Context, context.CancelFunc, context.Context, context.CancelFunc, stealth.LaunchMode, error) {
+	if cfg != nil && strings.TrimSpace(cfg.CDPAttachURL) != "" {
+		return initChromeFromExistingCDP(cfg, bundle)
+	}
+
 	slog.Info("starting chrome initialization", "headless", cfg.Headless, "profile", cfg.ProfileDir, "binary", cfg.ChromeBinary)
 
 	bundle = ensureStealthBundle(cfg, bundle)
@@ -52,6 +61,37 @@ func InitChrome(cfg *config.RuntimeConfig, bundle *stealth.Bundle, hooks Hooks) 
 
 	slog.Info("chrome initialized successfully", "headless", cfg.Headless, "profile", cfg.ProfileDir)
 	return allocCtx, allocCancel, browserCtx, browserCancel, launchMode, nil
+}
+
+// initChromeFromExistingCDP attaches the bridge to a Chrome that is already
+// running outside pinchtab (e.g. the user's everyday browser launched with
+// --remote-debugging-port=NNNN). No process is spawned and no profile lock
+// is taken. The allocator is a chromedp remote allocator; the returned
+// cancel funcs release only the chromedp side, never the external Chrome.
+func initChromeFromExistingCDP(cfg *config.RuntimeConfig, bundle *stealth.Bundle) (context.Context, context.CancelFunc, context.Context, context.CancelFunc, stealth.LaunchMode, error) {
+	wsURL := strings.TrimSpace(cfg.CDPAttachURL)
+	slog.Info("attaching to existing Chrome via CDP", "cdpUrl", wsURL)
+
+	bundle = ensureStealthBundle(cfg, bundle)
+
+	remoteAllocCtx, remoteAllocCancel := chromedp.NewRemoteAllocator(context.Background(), wsURL)
+	browserCtx, browserCancel := chromedp.NewContext(remoteAllocCtx)
+
+	// Touch the browser so we fail fast if the CDP URL is unreachable. We
+	// intentionally do NOT inject the stealth/UA script here — the user's
+	// Chrome is theirs, and rewriting its launch contract would be both
+	// surprising and likely break extensions, profile features, and
+	// already-open tabs.
+	if err := chromedp.Run(browserCtx, chromedp.ActionFunc(func(ctx context.Context) error {
+		return nil
+	})); err != nil {
+		browserCancel()
+		remoteAllocCancel()
+		return nil, nil, nil, nil, stealth.LaunchModeUninitialized, fmt.Errorf("failed to attach to CDP at %s: %w", wsURL, err)
+	}
+
+	slog.Info("attached to existing Chrome via CDP", "cdpUrl", wsURL)
+	return remoteAllocCtx, remoteAllocCancel, browserCtx, browserCancel, stealth.LaunchModeAttached, nil
 }
 
 func findChromeBinary() string {

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -62,6 +62,14 @@ type RuntimeConfig struct {
 	ChromeBinary       string
 	ChromeDebugPort    int
 	ChromeExtraFlags   string
+	// CDPAttachURL: when set, the bridge skips launching its own Chrome and
+	// connects to an already-running Chrome whose browser-level CDP
+	// WebSocket URL is provided here (e.g.
+	// "ws://127.0.0.1:9222/devtools/browser/abc"). Useful when you want the
+	// agent to drive the user's actual Chrome (extensions, profile, signed-in
+	// state) rather than a fresh isolated profile. Cleanup never kills the
+	// external Chrome — pinchtab only owns the CDP connection.
+	CDPAttachURL       string
 	ExtensionPaths     []string
 	UserAgent          string
 	NoAnimations       bool

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -46,22 +46,22 @@ type RuntimeConfig struct {
 	TrustLoopbackProxy     bool     // when true, navigation responses with a loopback RemoteIPAddress (e.g. system HTTP/SOCKS proxy on 127.0.0.1) are not blocked; default false
 
 	// Browser/instance settings
-	Headless           bool
-	HeadlessSet        bool // true when explicitly set via config or flag
-	NoRestore          bool
-	ProfileDir         string
-	ProfilesBaseDir    string
-	DefaultProfile     string
-	ChromeVersion      string
-	Timezone           string
-	BlockImages        bool
-	BlockMedia         bool
-	BlockAds           bool
-	MaxTabs            int
-	MaxParallelTabs    int // 0 = auto-detect from runtime.NumCPU
-	ChromeBinary       string
-	ChromeDebugPort    int
-	ChromeExtraFlags   string
+	Headless         bool
+	HeadlessSet      bool // true when explicitly set via config or flag
+	NoRestore        bool
+	ProfileDir       string
+	ProfilesBaseDir  string
+	DefaultProfile   string
+	ChromeVersion    string
+	Timezone         string
+	BlockImages      bool
+	BlockMedia       bool
+	BlockAds         bool
+	MaxTabs          int
+	MaxParallelTabs  int // 0 = auto-detect from runtime.NumCPU
+	ChromeBinary     string
+	ChromeDebugPort  int
+	ChromeExtraFlags string
 	// CDPAttachURL: when set, the bridge skips launching its own Chrome and
 	// connects to an already-running Chrome whose browser-level CDP
 	// WebSocket URL is provided here (e.g.


### PR DESCRIPTION
## Summary
- Add `pinchtab bridge --cdp-attach <ws>` so the bridge can adopt an already-running Chrome instead of launching its own. Useful when an agent should drive the user's everyday browser (extensions, profile, signed-in state) rather than a fresh isolated session.
- Add `--bind` and `--port` flags so the bridge can run on a non-default port alongside the daemon.
- New `RuntimeConfig.CDPAttachURL` carries the WS URL through to a new `initChromeFromExistingCDP()` path that uses `chromedp.NewRemoteAllocator` instead of spawning Chrome. The external Chrome is **never killed** on shutdown — pinchtab only owns the chromedp side of the connection.
- Reuses the existing `stealth.LaunchModeAttached` marker.

## Why
Today the supported paths are:
- `/instances/attach` (CDP) — registers a browser as metadata, but the shorthand routes (`/action`, `/navigate`, `/tabs`) refuse to proxy through. They expect a bridge (HTTP), so a CDP-only attach gives `invalid proxy target` from the moment the agent does anything.
- `/instances/attach-bridge` — works, but requires a bridge server already pointing at that Chrome. There was no first-class way to spawn one against an external CDP URL.

With this flag the existing `bridge` does the job:
```bash
pinchtab bridge --cdp-attach ws://127.0.0.1:9222/devtools/browser/abc --port 9870
# then POST /instances/attach-bridge with that bridge's HTTP URL
```

Then any pinchtab API request (`/action`, `/navigate`, `/tabs`) lands on the user's actual Chrome.

## Design choices
- Stealth script is **not** injected when attaching. Rewriting an external Chrome's launch contract would be surprising and likely break extensions, profile features, and already-open tabs. The user is opting in to drive their own browser; pinchtab shouldn't reshape it.
- The `--bind` / `--port` additions are scoped to the `bridge` sub-command; default behaviour is unchanged when neither flag is set.
- The cleanup func returned from `initChromeFromExistingCDP` cancels the chromedp browser/allocator contexts but does not touch the external Chrome process. There is no `cmd.Wait()` to reap; pinchtab never owned the process.

## Test plan
Smoke (single-host, manual):
- [ ] Launch Chrome with `--remote-debugging-port=9222`.
- [ ] `WS=$(curl -s http://127.0.0.1:9222/json/version | jq -r .webSocketDebuggerUrl)`
- [ ] `PINCHTAB_TOKEN=t pinchtab bridge --cdp-attach "$WS" --port 9870` exits 0 on Ctrl-C and never launches a Chrome.
- [ ] `curl -H "Authorization: Bearer t" http://127.0.0.1:9870/health` returns the attached Chrome's tab count.
- [ ] `curl -X POST -d '{"url":"http://127.0.0.1/"}' -H "content-type: application/json" -H "Authorization: Bearer t" http://127.0.0.1:9870/navigate` navigates a tab inside that running Chrome.
- [ ] After Ctrl-C the external Chrome stays alive.

End-to-end (with daemon):
- [ ] Daemon on `strategy: no-instance` + `security.attach.enabled: true` + `allowSchemes: ["ws","wss","http","https"]`.
- [ ] Spawn the bridge with `--cdp-attach` as above.
- [ ] `POST /instances/attach-bridge` to the daemon with `{baseUrl: http://127.0.0.1:9870, token: t}`.
- [ ] An agent's `goto` / `click` / `read_text` then lands on the externally-managed Chrome (verified in our extension's e2e by asserting the navigated URL appears in the same Playwright `BrowserContext.pages()`).

## Notes
- `--cdp-attach` is mutually exclusive with profile-lock-bearing launches by design — when set, the launch path is bypassed entirely. Existing flags (`--engine`, etc.) keep working when the flag is **not** set.
- This is the **bridge** addition. The follow-up to make the bridge runnable as a daemon-managed instance (e.g. a `pinchtab daemon attach <cdpUrl>` CLI command) can build on this — happy to do that in a separate PR if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)