### PR TITLE
feat: add browser activity recording with start/stop/status APIs

### DIFF
--- a/cmd/pinchtab/cmd_cli_browser_record.go
+++ b/cmd/pinchtab/cmd_cli_browser_record.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	browseractions "github.com/pinchtab/pinchtab/internal/cli/actions"
+	"github.com/spf13/cobra"
+)
+
+var recordCmd = &cobra.Command{
+	Use:   "record",
+	Short: "Record browser activity to video",
+}
+
+var recordStartCmd = &cobra.Command{
+	Use:   "start <file>",
+	Short: "Start recording (.webm, .mp4, .gif)",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		runCLI(func(rt cliRuntime) {
+			browseractions.RecordStart(rt.client, rt.base, rt.token, cmd, args)
+		})
+	},
+}
+
+var recordStopCmd = &cobra.Command{
+	Use:   "stop",
+	Short: "Stop recording and save",
+	Run: func(cmd *cobra.Command, args []string) {
+		runCLI(func(rt cliRuntime) {
+			browseractions.RecordStop(rt.client, rt.base, rt.token)
+		})
+	},
+}
+
+var recordStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Check recording status",
+	Run: func(cmd *cobra.Command, args []string) {
+		runCLI(func(rt cliRuntime) {
+			browseractions.RecordStatus(rt.client, rt.base, rt.token)
+		})
+	},
+}

--- a/cmd/pinchtab/cmd_cli_browser_record.go
+++ b/cmd/pinchtab/cmd_cli_browser_record.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"net/http"
+	"time"
+
 	browseractions "github.com/pinchtab/pinchtab/internal/cli/actions"
 	"github.com/spf13/cobra"
 )
@@ -26,7 +29,12 @@ var recordStopCmd = &cobra.Command{
 	Short: "Stop recording and save",
 	Run: func(cmd *cobra.Command, args []string) {
 		runCLI(func(rt cliRuntime) {
-			browseractions.RecordStop(rt.client, rt.base, rt.token)
+			// Encoding can take minutes; use a dedicated long-timeout client.
+			longClient := &http.Client{
+				Timeout:   3 * time.Minute,
+				Transport: rt.client.Transport,
+			}
+			browseractions.RecordStop(longClient, rt.base, rt.token)
 		})
 	},
 }

--- a/cmd/pinchtab/cmd_cli_browser_record.go
+++ b/cmd/pinchtab/cmd_cli_browser_record.go
@@ -1,9 +1,6 @@
 package main
 
 import (
-	"net/http"
-	"time"
-
 	browseractions "github.com/pinchtab/pinchtab/internal/cli/actions"
 	"github.com/spf13/cobra"
 )
@@ -29,12 +26,7 @@ var recordStopCmd = &cobra.Command{
 	Short: "Stop recording and save",
 	Run: func(cmd *cobra.Command, args []string) {
 		runCLI(func(rt cliRuntime) {
-			// Encoding can take minutes; use a dedicated long-timeout client.
-			longClient := &http.Client{
-				Timeout:   3 * time.Minute,
-				Transport: rt.client.Transport,
-			}
-			browseractions.RecordStop(longClient, rt.base, rt.token)
+			browseractions.RecordStop(rt.client, rt.base, rt.token)
 		})
 	},
 }

--- a/cmd/pinchtab/cmd_cli_register.go
+++ b/cmd/pinchtab/cmd_cli_register.go
@@ -82,6 +82,7 @@ func registerBrowserCommands() {
 		tabResumeCmd,
 		handoffStatusCmd,
 		tabHandoffStatusCmd,
+		recordCmd,
 	)
 
 	// These commands carry GroupID="browser" (set by setCommandGroup above).
@@ -93,6 +94,7 @@ func registerBrowserCommands() {
 	dialogCmd.AddCommand(dialogAcceptCmd, dialogDismissCmd)
 	mouseCmd.AddCommand(mouseMoveCmd, mouseDownCmd, mouseUpCmd, mouseWheelCmd)
 	networkCmd.AddCommand(networkRouteCmd, networkUnrouteCmd)
+	recordCmd.AddCommand(recordStartCmd, recordStopCmd, recordStatusCmd)
 
 	configureBrowserFlags()
 
@@ -155,6 +157,7 @@ func registerBrowserCommands() {
 		handoffCmd,
 		resumeCmd,
 		handoffStatusCmd,
+		recordCmd,
 	)
 }
 
@@ -257,6 +260,11 @@ func configureBrowserFlags() {
 	pdfCmd.Flags().Bool("generate-document-outline", false, "Generate document outline")
 	pdfCmd.Flags().Bool("file-output", false, "Use server-side file output")
 	pdfCmd.Flags().String("path", "", "Server-side output path")
+
+	recordStartCmd.Flags().Int("fps", 5, "Frames per second (1-30)")
+	recordStartCmd.Flags().Int("quality", 80, "JPEG capture quality (1-100)")
+	recordStartCmd.Flags().Float64("scale", 1.0, "Resolution scale multiplier")
+	addTabFlag(recordStartCmd)
 
 	findCmd.Flags().String("threshold", "", "Minimum similarity score (0-1)")
 	findCmd.Flags().Bool("explain", false, "Show score breakdown")

--- a/cmd/pinchtab/cmd_config.go
+++ b/cmd/pinchtab/cmd_config.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/pinchtab/pinchtab/internal/cli"
+	"github.com/pinchtab/pinchtab/internal/cli/output"
 	"github.com/pinchtab/pinchtab/internal/config"
 	"github.com/pinchtab/pinchtab/internal/config/workflow"
 	configschema "github.com/pinchtab/pinchtab/internal/schema"
@@ -286,6 +287,7 @@ func handleConfigSet(path, value string) error {
 	}
 
 	fmt.Printf("Set %s = %s\n", path, displayConfigValue(path, value))
+	hintRestartIfRunning()
 	return nil
 }
 
@@ -329,6 +331,7 @@ func handleConfigPatch(jsonPatch string) error {
 	}
 
 	fmt.Println("Config patched successfully")
+	hintRestartIfRunning()
 	return nil
 }
 
@@ -348,6 +351,13 @@ func handleConfigValidate() {
 	}
 
 	fmt.Printf("Config file is valid: %s\n", configPath)
+}
+
+func hintRestartIfRunning() {
+	cfg := loadLocalConfig()
+	if server.CheckPinchTabRunning(cfg.Port, cfg.Token) {
+		output.Hint("Server is running — restart it to apply changes: pinchtab server restart")
+	}
 }
 
 func handleConfigSchema(printSchema bool) {

--- a/cmd/pinchtab/cmd_config_test.go
+++ b/cmd/pinchtab/cmd_config_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -293,6 +295,47 @@ func resetConfigSchemaPrintFlag(t *testing.T) {
 	}
 	if err := cmd.Flags().Set("print", "false"); err != nil {
 		t.Fatalf("reset schema print flag: %v", err)
+	}
+}
+
+func TestConfigSetHintsRestartWhenServerRunning(t *testing.T) {
+	// Spin up a fake health endpoint so hintRestartIfRunning detects a running server.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	}))
+	defer srv.Close()
+
+	port := srv.URL[strings.LastIndex(srv.URL, ":")+1:]
+
+	configPath := filepath.Join(t.TempDir(), "pinchtab", "config.json")
+	t.Setenv("PINCHTAB_CONFIG", configPath)
+
+	// Write a minimal valid config pointing at the fake server port.
+	configJSON := []byte(`{"configVersion":"0.8.0","server":{"port":"` + port + `","token":"test-token-for-restart-hint-00000"}}`)
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(configPath, configJSON, 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+
+	stderr := captureStderr(t, func() {
+		_ = captureStdout(t, func() {
+			rootCmd.SetArgs([]string{"config", "set", "security.allowScreencast", "true"})
+			if err := rootCmd.Execute(); err != nil {
+				t.Fatalf("Execute() error = %v", err)
+			}
+		})
+	})
+
+	if !strings.Contains(stderr, "restart") {
+		t.Fatalf("expected restart hint on stderr, got %q", stderr)
+	}
+	if !strings.Contains(stderr, "pinchtab server restart") {
+		t.Fatalf("expected 'pinchtab server restart' in hint, got %q", stderr)
 	}
 }
 

--- a/cmd/pinchtab/cmd_server.go
+++ b/cmd/pinchtab/cmd_server.go
@@ -74,5 +74,6 @@ func init() {
 	serverCmd.Flags().String("background-child", "", "Internal marker for background server ownership")
 	_ = serverCmd.Flags().MarkHidden("background-child")
 	serverCmd.AddCommand(serverStopCmd)
+	serverCmd.AddCommand(serverRestartCmd)
 	rootCmd.AddCommand(serverCmd)
 }

--- a/cmd/pinchtab/cmd_server_background.go
+++ b/cmd/pinchtab/cmd_server_background.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/pinchtab/pinchtab/internal/cli"
 	"github.com/pinchtab/pinchtab/internal/config"
+	"github.com/pinchtab/pinchtab/internal/server"
 	"github.com/spf13/cobra"
 )
 
@@ -42,9 +43,30 @@ var readProcessCommand = defaultReadProcessCommand
 
 var serverStopCmd = &cobra.Command{
 	Use:   "stop",
-	Short: "Stop a background server started with `pinchtab server --background`",
+	Short: "Stop the running server",
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := runServerStop(); err != nil {
+			fmt.Fprintln(os.Stderr, cli.StyleStderr(cli.ErrorStyle, err.Error()))
+			os.Exit(1)
+		}
+	},
+}
+
+var serverRestartCmd = &cobra.Command{
+	Use:   "restart",
+	Short: "Restart the running server (stop + start in background)",
+	Run: func(cmd *cobra.Command, args []string) {
+		cfg := loadConfig()
+
+		if server.CheckPinchTabRunning(cfg.Port, cfg.Token) {
+			fmt.Println("Stopping server...")
+			if err := runServerStop(); err != nil {
+				fmt.Fprintln(os.Stderr, cli.StyleStderr(cli.WarningStyle, fmt.Sprintf("stop: %v", err)))
+			}
+		}
+
+		fmt.Println("Starting server...")
+		if err := runServerBackground(cfg, serverBackgroundOptions{}); err != nil {
 			fmt.Fprintln(os.Stderr, cli.StyleStderr(cli.ErrorStyle, err.Error()))
 			os.Exit(1)
 		}
@@ -210,15 +232,27 @@ func isPinchTabHealthReady(url, marker string) bool {
 	return marker == "" || health.Marker == marker
 }
 
+func stopViaAPI() error {
+	cfg := loadConfig()
+	if !server.CheckPinchTabRunning(cfg.Port, cfg.Token) {
+		return fmt.Errorf("no server running on port %s", cfg.Port)
+	}
+	if err := server.ShutdownServer(cfg.Port, cfg.Token); err != nil {
+		return fmt.Errorf("shutdown: %w", err)
+	}
+	fmt.Printf("Stopped server on port %s\n", cfg.Port)
+	return nil
+}
+
 func runServerStop() error {
 	info, ok := readServerPID()
 	if !ok {
-		return fmt.Errorf("no background server PID file at %s", serverPIDFilePath())
+		return stopViaAPI()
 	}
 	pid := info.PID
 	if !processAlive(pid) {
 		_ = os.Remove(serverPIDFilePath())
-		return fmt.Errorf("background server (pid %d) is not running; cleaned up stale pid file", pid)
+		return stopViaAPI()
 	}
 	if err := verifyServerPIDInfo(info); err != nil {
 		return err

--- a/cmd/pinchtab/cmd_server_background_test.go
+++ b/cmd/pinchtab/cmd_server_background_test.go
@@ -7,6 +7,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/pinchtab/pinchtab/internal/server"
 )
 
 func TestIsBackgroundServerReadyRequiresValidPinchTabHealth(t *testing.T) {
@@ -137,6 +139,45 @@ func TestVerifyServerPIDInfoRefusesLegacyPID(t *testing.T) {
 	err := verifyServerPIDInfo(serverPIDInfo{PID: os.Getpid()})
 	if err == nil || !strings.Contains(err.Error(), "lacks verifiable background metadata") {
 		t.Fatalf("verifyServerPIDInfo() error = %v, want missing metadata error", err)
+	}
+}
+
+func TestStopViaAPIShutdownEndpoint(t *testing.T) {
+	shutdownCalled := false
+	healthAlive := true
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/health":
+			if healthAlive {
+				w.WriteHeader(200)
+				_, _ = w.Write([]byte(`{"status":"ok","mode":"dashboard","version":"dev"}`))
+			} else {
+				w.WriteHeader(503)
+			}
+		case "/shutdown":
+			if r.Method != http.MethodPost {
+				w.WriteHeader(405)
+				return
+			}
+			shutdownCalled = true
+			healthAlive = false
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"status":"shutting down"}`))
+		default:
+			w.WriteHeader(404)
+		}
+	}))
+	defer srv.Close()
+
+	// Extract port from test server URL.
+	port := strings.TrimPrefix(srv.URL, "http://127.0.0.1:")
+
+	err := server.ShutdownServer(port, "")
+	if err != nil {
+		t.Fatalf("ShutdownServer() error = %v", err)
+	}
+	if !shutdownCalled {
+		t.Fatal("POST /shutdown was not called")
 	}
 }
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -4,6 +4,8 @@
 
 ```bash
 pinchtab server                         # Start the full server (dashboard + API)
+pinchtab server stop                    # Stop the running server (foreground or background)
+pinchtab server restart                 # Stop + restart in background (applies config changes)
 pinchtab bridge                         # Start the bridge-only runtime
 pinchtab mcp                            # Start the MCP stdio server
 pinchtab daemon                         # Show daemon status

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -223,6 +223,12 @@ pinchtab download <url>                 # Download through the browser session
 pinchtab download <url> -o <path>       # Save downloaded file to a path
 pinchtab upload <file>                  # Upload to the default file input
 pinchtab upload <file> -s <css>         # Upload to a specific file input
+pinchtab record start <file>            # Start recording (.webm, .mp4, .gif)
+pinchtab record start <file> --fps 10   # Custom frame rate (default 5)
+pinchtab record start <file> --quality 90 # JPEG capture quality (default 80)
+pinchtab record start <file> --scale 0.5  # Half resolution
+pinchtab record stop                    # Stop recording and save
+pinchtab record status                  # Check recording status
 ```
 
 ## Instances, Profiles, And Activity

--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -249,6 +249,9 @@ GET  /screencast
 GET  /screencast/tabs
 GET  /instances/{id}/screencast
 GET  /instances/{id}/proxy/screencast
+POST /record/start
+POST /record/stop
+GET  /record/status
 ```
 
 Screenshot query parameters:
@@ -281,6 +284,21 @@ PDF query parameters:
 - `footerTemplate`
 - `generateTaggedPDF`
 - `generateDocumentOutline`
+
+Record start body fields (JSON POST `/record/start`):
+
+- `format`: `gif`, `webm`, or `mp4`.
+- `fps`: Frames per second, 1-30 (default 5).
+- `quality`: JPEG capture quality 1-100 (default 80).
+- `scale`: Resolution multiplier (default 1.0).
+- `tabId`: Target a specific tab.
+
+Notes:
+
+- Recording endpoints are gated by `security.allowScreencast`.
+- `.webm` and `.mp4` formats require `ffmpeg` on the server PATH.
+- `.gif` format uses pure Go encoding (always available).
+- Only one recording per bridge instance.
 
 ## Downloads, Uploads, Cookies, And Clipboard
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -92,6 +92,8 @@ pinchtab network              # GET  200  https://...
 | Command | Purpose |
 | --- | --- |
 | `pinchtab server` | Start the full server and dashboard |
+| `pinchtab server stop` | Stop the running server (foreground or background) |
+| `pinchtab server restart` | Stop + restart in background (applies config changes) |
 | `pinchtab bridge` | Start the single-instance bridge runtime |
 | `pinchtab mcp` | Start the stdio MCP server |
 | `pinchtab daemon` | Show daemon status and manage the background service |

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -22,6 +22,7 @@ Note: this index is generated and should be checked against the code when comman
 - [Navigate](./navigate.md)
 - [PDF](./pdf.md)
 - [Press](./press.md)
+- [Record](./record.md)
 - [Profiles](./profiles.md)
 - [Scheduler And Tasks](./scheduler.md)
 - [Screenshot](./screenshot.md)

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -1,6 +1,6 @@
 # MCP Tool Reference
 
-PinchTab currently exposes 38 MCP tools. All tool names are prefixed with `pinchtab_` and are served over stdio JSON-RPC.
+PinchTab currently exposes 41 MCP tools. All tool names are prefixed with `pinchtab_` and are served over stdio JSON-RPC.
 
 For selector-based interaction tools, prefer `selector`. `ref` and `query` are still accepted as deprecated/alias fallbacks on the element-action tools (`query` is shorthand for `find:<text>`).
 
@@ -92,6 +92,14 @@ All element-action tools accept the unified `selector` and the legacy aliases `r
 | `pinchtab_network_clear` | `tabId` | Clears one tab or all tabs when omitted |
 | `pinchtab_network_route` | `tabId` required, `pattern` required, `action`, `body`, `contentType`, `status`, `resourceType`, `method` | Install a request-interception rule on a tab. `action` is `continue` (default), `abort`, or `fulfill`. `fulfill` is blocked on hosts in `security.allowedDomains` and falls through to a real fetch on those hosts |
 | `pinchtab_network_unroute` | `tabId` required, `pattern` | Remove a tab's interception rule by pattern, or all rules when `pattern` is omitted |
+
+## Recording
+
+| Tool | Key Parameters | Notes |
+| --- | --- | --- |
+| `pinchtab_record_start` | `file` required, `fps`, `quality`, `scale`, `tabId` | Start recording; format inferred from extension (`.gif`, `.webm`, `.mp4`). Requires `security.allowScreencast`. GIF works without ffmpeg |
+| `pinchtab_record_stop` | `file` required | Stop recording, encode, and save to `file`. Encoding may take a while for long recordings |
+| `pinchtab_record_status` | — | Returns active recording status (format, fps, duration, frame count) |
 
 ## Dialog
 

--- a/docs/reference/record.md
+++ b/docs/reference/record.md
@@ -58,11 +58,21 @@ curl -X POST http://localhost:9867/record/stop > recording.gif
 - `--scale <f>`: Resolution scale (default 1.0).
 - `--tab <id>`: Target a specific tab.
 
+## Format Dependencies
+
+| Format | Dependency | Encoding | Notes |
+| --- | --- | --- | --- |
+| `.gif` | None | Pure Go (Floyd-Steinberg dithering) | Always available; CPU-intensive for long recordings |
+| `.webm` | `ffmpeg` | VP8 via ffmpeg pipe | Requires ffmpeg on `$PATH` |
+| `.mp4` | `ffmpeg` | H.264 via ffmpeg pipe | Requires ffmpeg on `$PATH` |
+
+GIF encoding runs entirely in-process — no external binary needed. Dithering is CPU-bound; recordings over ~2 minutes at 10 fps can take 30-60 seconds to encode. Frames are capped at 600 (max ~2 minutes at 5 fps) and downscaled if they exceed 1280x720 pixels to limit memory usage.
+
+WebM and MP4 stream frames to ffmpeg during `record stop`. If ffmpeg is not installed, `record start` returns a 400 error with a message indicating the dependency. Install ffmpeg via your package manager (`brew install ffmpeg`, `apt install ffmpeg`, etc.) or use `.gif` as a zero-dependency alternative.
+
 ## Notes
 
-- Gated by `security.allowScreencast`.
-- `.webm` and `.mp4` require `ffmpeg` installed on the server.
-- `.gif` always available (pure Go encoding).
+- Gated by `security.allowScreencast` (disabled by default). Enable with `pinchtab config set security.allowScreencast true` and restart the server.
 - One active recording per bridge instance.
 
 ## Related Pages

--- a/docs/reference/record.md
+++ b/docs/reference/record.md
@@ -1,0 +1,71 @@
+# Record
+
+Record browser activity as a video file. Supports GIF (pure Go), WebM, and MP4 (require ffmpeg).
+
+```bash
+# Start recording (format from file extension)
+curl -X POST http://localhost:9867/record/start \
+  -H "Content-Type: application/json" \
+  -d '{"format":"gif","fps":5,"quality":80}'
+
+# Check status
+curl http://localhost:9867/record/status
+
+# Stop and save
+curl -X POST http://localhost:9867/record/stop > recording.gif
+```
+
+## Start Response
+
+```json
+{
+  "status": "recording",
+  "format": "gif",
+  "fps": 5,
+  "quality": 80,
+  "tabId": "tab1"
+}
+```
+
+## Status Response
+
+```json
+{
+  "active": true,
+  "format": "gif",
+  "durationSeconds": 12.5,
+  "frames": 62,
+  "tabId": "tab1",
+  "fps": 5
+}
+```
+
+## API Body Fields (POST /record/start)
+
+- `format`: `gif`, `webm`, or `mp4`. Determined by file extension in CLI.
+- `fps`: Frames per second, 1-30 (default 5).
+- `quality`: JPEG capture quality 1-100 (default 80).
+- `scale`: Resolution multiplier (default 1.0). Values < 1 reduce output size.
+- `tabId`: Target a specific tab.
+
+## CLI
+
+- `record start <file>`: Start recording. Format from extension (.gif, .webm, .mp4).
+- `record stop`: Stop and save to the path given at start.
+- `record status`: Show active recording info.
+- `--fps <n>`: Frames per second (default 5).
+- `--quality <n>`: JPEG capture quality (default 80).
+- `--scale <f>`: Resolution scale (default 1.0).
+- `--tab <id>`: Target a specific tab.
+
+## Notes
+
+- Gated by `security.allowScreencast`.
+- `.webm` and `.mp4` require `ffmpeg` installed on the server.
+- `.gif` always available (pure Go encoding).
+- One active recording per bridge instance.
+
+## Related Pages
+
+- [Screenshot](./screenshot.md)
+- [PDF](./pdf.md)

--- a/internal/bridge/bridge_lifecycle.go
+++ b/internal/bridge/bridge_lifecycle.go
@@ -103,14 +103,14 @@ func (b *Bridge) EnsureChrome(cfg *config.RuntimeConfig) error {
 		if b.BrowserCtx.Err() == nil {
 			return nil
 		}
-		// Chrome died — reset state for re-initialization
-		slog.Warn("chrome context cancelled, re-initializing")
+		slog.Warn("chrome context cancelled, re-initializing without in-process-gpu")
 		b.initialized = false
 		b.BrowserCtx = nil
 		b.BrowserCancel = nil
 		b.AllocCtx = nil
 		b.AllocCancel = nil
 		b.TabManager = nil
+		cfg.DisableInProcessGPU = true
 	}
 
 	if b.BrowserCtx != nil {

--- a/internal/bridge/crash.go
+++ b/internal/bridge/crash.go
@@ -125,22 +125,26 @@ func (b *Bridge) MonitorCrashes(handler CrashHandler) {
 		}
 	})
 
-	// Monitor browser context cancellation
+	// Monitor browser context cancellation. A canceled context during
+	// draining is expected (deliberate shutdown); otherwise it indicates
+	// an unexpected failure such as an in-process GPU crash.
 	go func() {
 		<-b.BrowserCtx.Done()
 		err := b.BrowserCtx.Err()
-		if err == nil || err == context.Canceled {
-			slog.Info("browser context ended", "reason", "context canceled")
+		if b.draining {
+			slog.Info("browser context ended during drain", "reason", err)
 			return
+		}
+		reason := "unexpected context cancellation"
+		if err != nil && err != context.Canceled {
+			reason = err.Error()
 		}
 		event := CrashEvent{
 			Time:   time.Now(),
-			Reason: err.Error(),
+			Reason: reason,
 		}
 		recordCrashEvent(event)
-		slog.Warn("🔥 BROWSER CONTEXT ENDED",
-			"error", err,
-		)
+		slog.Warn("🔥 BROWSER CONTEXT ENDED UNEXPECTEDLY", "error", err)
 		if handler != nil {
 			handler(event)
 		}

--- a/internal/bridge/runtime/init.go
+++ b/internal/bridge/runtime/init.go
@@ -181,9 +181,11 @@ func setupAllocator(cfg *config.RuntimeConfig, bundle *stealth.Bundle, hooks Hoo
 		// Collapse the GPU process into the browser process. Saves one
 		// OS process and ~50-150MB per Chrome instance, and avoids the
 		// GPU-process sandbox negotiation in our --no-sandbox containers.
-		// Trade-off: a GPU code crash takes the browser with it, but the
-		// always-on strategy restarts instances anyway.
-		opts = append(opts, chromedp.Flag("in-process-gpu", true))
+		// Trade-off: a GPU code crash takes the browser with it. Disabled
+		// automatically after a crash so the failure doesn't repeat.
+		if !cfg.DisableInProcessGPU {
+			opts = append(opts, chromedp.Flag("in-process-gpu", true))
+		}
 	} else {
 		opts = append(opts, chromedp.Flag("headless", false))
 	}

--- a/internal/cli/actions/actions_record.go
+++ b/internal/cli/actions/actions_record.go
@@ -100,16 +100,29 @@ func recordingStateFile() string {
 	if dir := os.Getenv("XDG_STATE_HOME"); dir != "" {
 		return dir + "/pinchtab/current-recording"
 	}
-	if home, err := os.UserHomeDir(); err == nil {
-		return home + "/.local/state/pinchtab/current-recording"
+	home, err := os.UserHomeDir()
+	if err != nil {
+		home = os.TempDir()
 	}
-	return "/tmp/pinchtab-current-recording"
+	return home + "/.local/state/pinchtab/current-recording"
 }
 
 func writeRecordingState(outFile string) {
 	path := recordingStateFile()
-	_ = os.MkdirAll(filepath.Dir(path), 0755)
-	_ = os.WriteFile(path, []byte(outFile+"\n"), 0644)
+	dir := filepath.Dir(path)
+	_ = os.MkdirAll(dir, 0700)
+	tmp, err := os.CreateTemp(dir, ".current-recording-*")
+	if err != nil {
+		_ = os.WriteFile(path, []byte(outFile+"\n"), 0600)
+		return
+	}
+	_, _ = tmp.WriteString(outFile + "\n")
+	_ = tmp.Chmod(0600)
+	tmpName := tmp.Name()
+	_ = tmp.Close()
+	if err := os.Rename(tmpName, path); err != nil {
+		_ = os.Remove(tmpName)
+	}
 }
 
 func readRecordingState() string {

--- a/internal/cli/actions/actions_record.go
+++ b/internal/cli/actions/actions_record.go
@@ -62,9 +62,9 @@ func RecordStop(client *http.Client, base, token string) {
 		outFile = abs
 	}
 
-	raw := apiclient.DoPostRaw(client, base, token, "/record/stop", map[string]any{
-		"outputPath": outFile,
-	})
+	// Server encodes to its own recordings directory; we move the file
+	// to the user's desired location after encoding completes.
+	raw := apiclient.DoPostRaw(client, base, token, "/record/stop", map[string]any{})
 	clearRecordingState()
 
 	if raw == nil {
@@ -75,15 +75,48 @@ func RecordStop(client *http.Client, base, token string) {
 		Status string `json:"status"`
 		Path   string `json:"path"`
 		Frames int    `json:"frames"`
-		Hint   string `json:"hint"`
 	}
 	if err := json.Unmarshal(raw, &result); err != nil {
-		fmt.Println(cli.StyleStdout(cli.SuccessStyle, fmt.Sprintf("Encoding → %s", outFile)))
+		fmt.Println(cli.StyleStdout(cli.SuccessStyle, "Recording stopped"))
 		return
 	}
 
-	fmt.Println(cli.StyleStdout(cli.SuccessStyle,
-		fmt.Sprintf("Encoding %d frames → %s (use `record status` to check progress)", result.Frames, result.Path)))
+	if result.Path == "" {
+		fmt.Println(cli.StyleStdout(cli.SuccessStyle,
+			fmt.Sprintf("Recording stopped (%d frames)", result.Frames)))
+		return
+	}
+
+	fmt.Println(cli.StyleStdout(cli.MutedStyle,
+		fmt.Sprintf("Encoding %d frames...", result.Frames)))
+
+	serverPath := result.Path
+	for i := 0; i < 300; i++ {
+		time.Sleep(time.Second)
+		statusRaw := apiclient.DoGetRaw(client, base, token, "/record/status", nil)
+		if statusRaw == nil {
+			continue
+		}
+		var s struct {
+			State string `json:"state"`
+			Error string `json:"error"`
+		}
+		if json.Unmarshal(statusRaw, &s) != nil {
+			continue
+		}
+		if s.State == "finished" || s.State == "idle" {
+			if s.Error != "" {
+				cli.Fatal("Encoding failed: %s", s.Error)
+			}
+			if err := os.Rename(serverPath, outFile); err != nil {
+				cli.Fatal("Failed to move %s → %s: %v", serverPath, outFile, err)
+			}
+			fmt.Println(cli.StyleStdout(cli.SuccessStyle,
+				fmt.Sprintf("Saved → %s", outFile)))
+			return
+		}
+	}
+	cli.Fatal("Encoding timed out — file may be at %s", serverPath)
 }
 
 func RecordStatus(client *http.Client, base, token string) {

--- a/internal/cli/actions/actions_record.go
+++ b/internal/cli/actions/actions_record.go
@@ -57,16 +57,33 @@ func RecordStop(client *http.Client, base, token string) {
 		outFile = fmt.Sprintf("recording-%s.gif", time.Now().Format("20060102-150405"))
 	}
 
-	data := apiclient.DoPostRaw(client, base, token, "/record/stop", map[string]any{})
-	if data == nil {
+	abs, err := filepath.Abs(outFile)
+	if err == nil {
+		outFile = abs
+	}
+
+	raw := apiclient.DoPostRaw(client, base, token, "/record/stop", map[string]any{
+		"outputPath": outFile,
+	})
+	clearRecordingState()
+
+	if raw == nil {
 		return
 	}
 
-	if err := os.WriteFile(outFile, data, 0600); err != nil {
-		cli.Fatal("Write failed: %v", err)
+	var result struct {
+		Status string `json:"status"`
+		Path   string `json:"path"`
+		Frames int    `json:"frames"`
+		Hint   string `json:"hint"`
 	}
-	clearRecordingState()
-	fmt.Println(cli.StyleStdout(cli.SuccessStyle, fmt.Sprintf("Saved %s (%d bytes)", outFile, len(data))))
+	if err := json.Unmarshal(raw, &result); err != nil {
+		fmt.Println(cli.StyleStdout(cli.SuccessStyle, fmt.Sprintf("Encoding → %s", outFile)))
+		return
+	}
+
+	fmt.Println(cli.StyleStdout(cli.SuccessStyle,
+		fmt.Sprintf("Encoding %d frames → %s (use `record status` to check progress)", result.Frames, result.Path)))
 }
 
 func RecordStatus(client *http.Client, base, token string) {

--- a/internal/cli/actions/actions_record.go
+++ b/internal/cli/actions/actions_record.go
@@ -1,0 +1,125 @@
+package actions
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/pinchtab/pinchtab/internal/cli"
+	"github.com/pinchtab/pinchtab/internal/cli/apiclient"
+	"github.com/spf13/cobra"
+)
+
+func RecordStart(client *http.Client, base, token string, cmd *cobra.Command, args []string) {
+	outFile := args[0]
+
+	ext := strings.ToLower(filepath.Ext(outFile))
+	var format string
+	switch ext {
+	case ".gif":
+		format = "gif"
+	case ".webm":
+		format = "webm"
+	case ".mp4":
+		format = "mp4"
+	default:
+		cli.Fatal("Unsupported format %q — use .gif, .webm, or .mp4", ext)
+	}
+
+	fps, _ := cmd.Flags().GetInt("fps")
+	quality, _ := cmd.Flags().GetInt("quality")
+	scale, _ := cmd.Flags().GetFloat64("scale")
+	tab, _ := cmd.Flags().GetString("tab")
+
+	body := map[string]any{
+		"format":  format,
+		"fps":     fps,
+		"quality": quality,
+		"scale":   scale,
+	}
+	if tab != "" {
+		body["tabId"] = tab
+	}
+
+	apiclient.DoPost(client, base, token, "/record/start", body)
+
+	writeRecordingState(outFile)
+	fmt.Println(cli.StyleStdout(cli.SuccessStyle, fmt.Sprintf("Recording started → %s (%s, %d fps)", outFile, format, fps)))
+}
+
+func RecordStop(client *http.Client, base, token string) {
+	outFile := readRecordingState()
+	if outFile == "" {
+		outFile = fmt.Sprintf("recording-%s.gif", time.Now().Format("20060102-150405"))
+	}
+
+	data := apiclient.DoPostRaw(client, base, token, "/record/stop", map[string]any{})
+	if data == nil {
+		return
+	}
+
+	if err := os.WriteFile(outFile, data, 0600); err != nil {
+		cli.Fatal("Write failed: %v", err)
+	}
+	clearRecordingState()
+	fmt.Println(cli.StyleStdout(cli.SuccessStyle, fmt.Sprintf("Saved %s (%d bytes)", outFile, len(data))))
+}
+
+func RecordStatus(client *http.Client, base, token string) {
+	raw := apiclient.DoGetRaw(client, base, token, "/record/status", nil)
+	if raw == nil {
+		return
+	}
+
+	var status struct {
+		Active   bool    `json:"active"`
+		Format   string  `json:"format"`
+		Duration float64 `json:"durationSeconds"`
+		Frames   int     `json:"frames"`
+		TabID    string  `json:"tabId"`
+		FPS      int     `json:"fps"`
+	}
+	if err := json.Unmarshal(raw, &status); err != nil {
+		cli.Fatal("Decode failed: %v", err)
+	}
+
+	if !status.Active {
+		fmt.Println(cli.StyleStdout(cli.MutedStyle, "No active recording"))
+		return
+	}
+
+	fmt.Printf("Recording: %s @ %d fps  |  %.1fs  |  %d frames  |  tab %s\n",
+		status.Format, status.FPS, status.Duration, status.Frames, status.TabID)
+}
+
+func recordingStateFile() string {
+	if dir := os.Getenv("XDG_STATE_HOME"); dir != "" {
+		return dir + "/pinchtab/current-recording"
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		return home + "/.local/state/pinchtab/current-recording"
+	}
+	return "/tmp/pinchtab-current-recording"
+}
+
+func writeRecordingState(outFile string) {
+	path := recordingStateFile()
+	_ = os.MkdirAll(filepath.Dir(path), 0755)
+	_ = os.WriteFile(path, []byte(outFile+"\n"), 0644)
+}
+
+func readRecordingState() string {
+	data, err := os.ReadFile(recordingStateFile())
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
+func clearRecordingState() {
+	_ = os.Remove(recordingStateFile())
+}

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -46,22 +46,23 @@ type RuntimeConfig struct {
 	TrustLoopbackProxy     bool     // when true, navigation responses with a loopback RemoteIPAddress (e.g. system HTTP/SOCKS proxy on 127.0.0.1) are not blocked; default false
 
 	// Browser/instance settings
-	Headless         bool
-	HeadlessSet      bool // true when explicitly set via config or flag
-	NoRestore        bool
-	ProfileDir       string
-	ProfilesBaseDir  string
-	DefaultProfile   string
-	ChromeVersion    string
-	Timezone         string
-	BlockImages      bool
-	BlockMedia       bool
-	BlockAds         bool
-	MaxTabs          int
-	MaxParallelTabs  int // 0 = auto-detect from runtime.NumCPU
-	ChromeBinary     string
-	ChromeDebugPort  int
-	ChromeExtraFlags string
+	Headless            bool
+	HeadlessSet         bool // true when explicitly set via config or flag
+	DisableInProcessGPU bool // runtime-only: set after a GPU crash to avoid repeating the failure
+	NoRestore           bool
+	ProfileDir          string
+	ProfilesBaseDir     string
+	DefaultProfile      string
+	ChromeVersion       string
+	Timezone            string
+	BlockImages         bool
+	BlockMedia          bool
+	BlockAds            bool
+	MaxTabs             int
+	MaxParallelTabs     int // 0 = auto-detect from runtime.NumCPU
+	ChromeBinary        string
+	ChromeDebugPort     int
+	ChromeExtraFlags    string
 	// CDPAttachURL: when set, the bridge skips launching its own Chrome and
 	// connects to an already-running Chrome whose browser-level CDP
 	// WebSocket URL is provided here (e.g.

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -42,6 +42,8 @@ type Handlers struct {
 	// tabId and has no stored scoped current tab. See EmptyPointerPolicy.
 	emptyPointerPolicy EmptyPointerPolicy
 
+	recorder *recorder
+
 	// Optional dependency injection (for unit testing)
 	evalJS           func(ctx context.Context, expression string, out *string) error
 	autoSolverRunner func(ctx context.Context, tabID string) error
@@ -64,6 +66,7 @@ func New(b bridge.BridgeAPI, cfg *config.RuntimeConfig, p bridge.ProfileService,
 		IDPIGuard:       idpi.NewGuard(cfg.IDPI, cfg.AllowedDomains),
 		CurrentTabs:     NewCurrentTabStore(),
 		credentialStore: newCredentialStore(),
+		recorder:        &recorder{},
 	}
 
 	// Wire up the recovery engine with callbacks that delegate back to
@@ -297,6 +300,9 @@ func (h *Handlers) RegisterRoutes(mux *http.ServeMux, doShutdown func()) {
 	mux.HandleFunc("POST /find", h.HandleFind)
 	mux.HandleFunc("GET /screencast", h.HandleScreencast)
 	mux.HandleFunc("GET /screencast/tabs", h.HandleScreencastAll)
+	mux.HandleFunc("POST /record/start", h.HandleRecordStart)
+	mux.HandleFunc("POST /record/stop", h.HandleRecordStop)
+	mux.HandleFunc("GET /record/status", h.HandleRecordStatus)
 	mux.HandleFunc("POST /tabs/{id}/evaluate", h.HandleTabEvaluate)
 	mux.HandleFunc("POST /evaluate", h.HandleEvaluate)
 	mux.HandleFunc("GET /clipboard/read", h.HandleClipboardRead)

--- a/internal/handlers/middleware_session_grants.go
+++ b/internal/handlers/middleware_session_grants.go
@@ -203,7 +203,8 @@ func sessionMediaGrantAllows(method, path string) bool {
 		case path == "/pdf",
 			path == "/download",
 			path == "/screencast",
-			path == "/screencast/tabs":
+			path == "/screencast/tabs",
+			path == "/record/status":
 			return true
 		case tabRouteHasSuffix(path, "/pdf"),
 			tabRouteHasSuffix(path, "/download"):
@@ -212,7 +213,9 @@ func sessionMediaGrantAllows(method, path string) bool {
 	case http.MethodPost:
 		switch {
 		case path == "/pdf",
-			path == "/upload":
+			path == "/upload",
+			path == "/record/start",
+			path == "/record/stop":
 			return true
 		case tabRouteHasSuffix(path, "/pdf"),
 			tabRouteHasSuffix(path, "/upload"):

--- a/internal/handlers/openapi.go
+++ b/internal/handlers/openapi.go
@@ -103,6 +103,21 @@ func (h *Handlers) HandleOpenAPI(w http.ResponseWriter, _ *http.Request) {
 				"description":        security["screencast"].Message,
 				"x-pinchtab-enabled": security["screencast"].Enabled,
 			}},
+			"/record/start": map[string]any{"post": map[string]any{
+				"summary":            "Start recording browser activity to video",
+				"description":        security["screencast"].Message,
+				"x-pinchtab-enabled": security["screencast"].Enabled,
+			}},
+			"/record/stop": map[string]any{"post": map[string]any{
+				"summary":            "Stop recording and return encoded file",
+				"description":        security["screencast"].Message,
+				"x-pinchtab-enabled": security["screencast"].Enabled,
+			}},
+			"/record/status": map[string]any{"get": map[string]any{
+				"summary":            "Check recording status",
+				"description":        security["screencast"].Message,
+				"x-pinchtab-enabled": security["screencast"].Enabled,
+			}},
 			"/storage": map[string]any{
 				"get": map[string]any{
 					"summary":            "Get localStorage/sessionStorage items (current origin only)",

--- a/internal/handlers/record.go
+++ b/internal/handlers/record.go
@@ -17,9 +17,21 @@ import (
 	"sort"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/pinchtab/pinchtab/internal/httpx"
+)
+
+const (
+	maxRecordDuration = 5 * time.Minute
+	maxRecordFrames   = 9000      // 5min × 30fps
+	maxTempBytes      = 1 << 30   // 1 GB disk
+	maxOutputBytes    = 256 << 20 // 256 MB encoded
+	encodeTimeout     = 2 * time.Minute
+	maxFPS            = 30
+	maxQuality        = 100
+	maxScale          = 1.0
 )
 
 type RecordingStatus struct {
@@ -29,25 +41,30 @@ type RecordingStatus struct {
 	Frames   int     `json:"frames"`
 	TabID    string  `json:"tabId,omitempty"`
 	FPS      int     `json:"fps,omitempty"`
+	Owner    string  `json:"owner,omitempty"`
 }
 
 type recorder struct {
 	mu        sync.Mutex
 	active    bool
+	stopping  bool
 	tabCtx    context.Context
+	tabCancel context.CancelFunc
 	tabID     string
+	owner     string
 	format    string
 	fps       int
 	quality   int
 	scale     float64
 	tmpDir    string
 	frameNum  int
+	tempBytes int64
 	startTime time.Time
 	stopCh    chan struct{}
 	doneCh    chan struct{}
 }
 
-func (rec *recorder) start(tabCtx context.Context, tabID, format string, fps, quality int, scale float64) error {
+func (rec *recorder) start(tabCtx context.Context, tabID, owner, format string, fps, quality int, scale float64) error {
 	rec.mu.Lock()
 	defer rec.mu.Unlock()
 
@@ -60,15 +77,21 @@ func (rec *recorder) start(tabCtx context.Context, tabID, format string, fps, qu
 		return fmt.Errorf("create temp dir: %w", err)
 	}
 
+	ctx, cancel := context.WithCancel(tabCtx)
+
 	rec.active = true
-	rec.tabCtx = tabCtx
+	rec.stopping = false
+	rec.tabCtx = ctx
+	rec.tabCancel = cancel
 	rec.tabID = tabID
+	rec.owner = owner
 	rec.format = format
 	rec.fps = fps
 	rec.quality = quality
 	rec.scale = scale
 	rec.tmpDir = tmpDir
 	rec.frameNum = 0
+	rec.tempBytes = 0
 	rec.startTime = time.Now()
 	rec.stopCh = make(chan struct{})
 	rec.doneCh = make(chan struct{})
@@ -77,36 +100,66 @@ func (rec *recorder) start(tabCtx context.Context, tabID, format string, fps, qu
 	return nil
 }
 
-func (rec *recorder) stop() ([]byte, string, error) {
+func (rec *recorder) stop(callerOwner string) ([]byte, string, error) {
 	rec.mu.Lock()
 	if !rec.active {
 		rec.mu.Unlock()
 		return nil, "", fmt.Errorf("no active recording")
 	}
+	if rec.stopping {
+		doneCh := rec.doneCh
+		rec.mu.Unlock()
+		<-doneCh
+		return nil, "", fmt.Errorf("no active recording")
+	}
+	if callerOwner != "" && rec.owner != "" && callerOwner != rec.owner {
+		rec.mu.Unlock()
+		return nil, "", fmt.Errorf("recording owned by another session")
+	}
+	rec.stopping = true
 	close(rec.stopCh)
+	doneCh := rec.doneCh
+	format := rec.format
+	tmpDir := rec.tmpDir
+	frameNum := rec.frameNum
+	fps := rec.fps
+	scale := rec.scale
 	rec.mu.Unlock()
 
-	<-rec.doneCh
+	<-doneCh
 
 	rec.mu.Lock()
 	defer rec.mu.Unlock()
+	defer rec.cleanup()
 
-	defer func() {
-		_ = os.RemoveAll(rec.tmpDir)
-		rec.active = false
-		rec.tmpDir = ""
-	}()
-
-	if rec.frameNum == 0 {
+	if frameNum == 0 {
 		return nil, "", fmt.Errorf("no frames captured")
 	}
 
-	data, err := rec.encode()
+	data, err := encode(tmpDir, format, fps, scale)
 	if err != nil {
 		return nil, "", err
 	}
 
-	return data, rec.format, nil
+	if len(data) > maxOutputBytes {
+		return nil, "", fmt.Errorf("encoded output too large (%d bytes, max %d)", len(data), maxOutputBytes)
+	}
+
+	return data, format, nil
+}
+
+func (rec *recorder) cleanup() {
+	if rec.tabCancel != nil {
+		rec.tabCancel()
+		rec.tabCancel = nil
+	}
+	if rec.tmpDir != "" {
+		_ = os.RemoveAll(rec.tmpDir)
+	}
+	rec.active = false
+	rec.stopping = false
+	rec.tmpDir = ""
+	rec.owner = ""
 }
 
 func (rec *recorder) status() RecordingStatus {
@@ -123,60 +176,93 @@ func (rec *recorder) status() RecordingStatus {
 		Frames:   rec.frameNum,
 		TabID:    rec.tabID,
 		FPS:      rec.fps,
+		Owner:    rec.owner,
 	}
 }
 
 func (rec *recorder) captureLoop() {
 	defer close(rec.doneCh)
 
+	deadline := time.NewTimer(maxRecordDuration)
+	defer deadline.Stop()
+
 	interval := time.Second / time.Duration(rec.fps)
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
+
+	var diskBytes atomic.Int64
 
 	for {
 		select {
 		case <-rec.stopCh:
 			return
 		case <-rec.tabCtx.Done():
+			rec.mu.Lock()
+			rec.cleanup()
+			rec.mu.Unlock()
+			slog.Info("recording aborted: tab context canceled", "tab", rec.tabID)
+			return
+		case <-deadline.C:
+			slog.Info("recording stopped: max duration reached", "tab", rec.tabID)
 			return
 		case <-ticker.C:
+			rec.mu.Lock()
+			if rec.frameNum >= maxRecordFrames {
+				rec.mu.Unlock()
+				slog.Info("recording stopped: max frames reached", "tab", rec.tabID)
+				return
+			}
+			rec.mu.Unlock()
+
+			if diskBytes.Load() >= int64(maxTempBytes) {
+				slog.Info("recording stopped: temp disk limit reached", "tab", rec.tabID)
+				return
+			}
+
 			frame, err := captureScreencastJPEG(rec.tabCtx, rec.quality)
 			if err != nil {
 				slog.Debug("recording frame capture failed", "err", err)
 				continue
 			}
+
 			rec.mu.Lock()
 			rec.frameNum++
 			path := filepath.Join(rec.tmpDir, fmt.Sprintf("frame_%06d.jpg", rec.frameNum))
 			rec.mu.Unlock()
+
 			if err := os.WriteFile(path, frame, 0600); err != nil {
 				slog.Debug("recording frame write failed", "err", err)
+			} else {
+				diskBytes.Add(int64(len(frame)))
 			}
 		}
 	}
 }
 
-func (rec *recorder) encode() ([]byte, error) {
-	switch rec.format {
+func encode(tmpDir, format string, fps int, scale float64) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), encodeTimeout)
+	defer cancel()
+
+	switch format {
 	case "gif":
-		return rec.encodeGIF()
+		return encodeGIF(tmpDir, fps, scale)
 	case "webm":
-		return rec.encodeFFmpeg("libvpx", "-crf", "10", "-b:v", "1M")
+		return encodeFFmpeg(ctx, tmpDir, format, fps, scale, "libvpx", "-crf", "10", "-b:v", "1M")
 	case "mp4":
-		return rec.encodeFFmpeg("libx264", "-pix_fmt", "yuv420p", "-crf", "23")
+		return encodeFFmpeg(ctx, tmpDir, format, fps, scale, "libx264", "-pix_fmt", "yuv420p", "-crf", "23")
 	default:
-		return nil, fmt.Errorf("unsupported format: %s", rec.format)
+		return nil, fmt.Errorf("unsupported format: %s", format)
 	}
 }
 
-func (rec *recorder) encodeGIF() ([]byte, error) {
-	files, err := filepath.Glob(filepath.Join(rec.tmpDir, "frame_*.jpg"))
+func encodeGIF(tmpDir string, fps int, scale float64) ([]byte, error) {
+	files, err := filepath.Glob(filepath.Join(tmpDir, "frame_*.jpg"))
 	if err != nil {
 		return nil, err
 	}
 	sort.Strings(files)
 
-	delay := 100 / rec.fps
+	delay := 100 / fps
 	if delay < 1 {
 		delay = 1
 	}
@@ -193,8 +279,8 @@ func (rec *recorder) encodeGIF() ([]byte, error) {
 			continue
 		}
 
-		if rec.scale != 1.0 && rec.scale > 0 {
-			img = scaleImage(img, rec.scale)
+		if scale != 1.0 && scale > 0 {
+			img = scaleImage(img, scale)
 		}
 
 		bounds := img.Bounds()
@@ -215,25 +301,25 @@ func (rec *recorder) encodeGIF() ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func (rec *recorder) encodeFFmpeg(codec string, extraArgs ...string) ([]byte, error) {
-	outFile := filepath.Join(rec.tmpDir, "output."+rec.format)
+func encodeFFmpeg(ctx context.Context, tmpDir, format string, fps int, scale float64, codec string, extraArgs ...string) ([]byte, error) {
+	outFile := filepath.Join(tmpDir, "output."+format)
 
 	args := []string{
 		"-y",
-		"-framerate", strconv.Itoa(rec.fps),
-		"-i", filepath.Join(rec.tmpDir, "frame_%06d.jpg"),
+		"-framerate", strconv.Itoa(fps),
+		"-i", filepath.Join(tmpDir, "frame_%06d.jpg"),
 	}
 
-	if rec.scale != 1.0 && rec.scale > 0 {
+	if scale != 1.0 && scale > 0 {
 		args = append(args, "-vf",
-			fmt.Sprintf("scale=trunc(iw*%g/2)*2:trunc(ih*%g/2)*2", rec.scale, rec.scale))
+			fmt.Sprintf("scale=trunc(iw*%g/2)*2:trunc(ih*%g/2)*2", scale, scale))
 	}
 
 	args = append(args, "-c:v", codec)
 	args = append(args, extraArgs...)
 	args = append(args, outFile)
 
-	cmd := exec.Command("ffmpeg", args...)
+	cmd := exec.CommandContext(ctx, "ffmpeg", args...)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
@@ -305,14 +391,20 @@ func (h *Handlers) HandleRecordStart(w http.ResponseWriter, r *http.Request) {
 	if req.FPS <= 0 {
 		req.FPS = 5
 	}
-	if req.FPS > 30 {
-		req.FPS = 30
+	if req.FPS > maxFPS {
+		req.FPS = maxFPS
 	}
 	if req.Quality <= 0 {
 		req.Quality = 80
 	}
+	if req.Quality > maxQuality {
+		req.Quality = maxQuality
+	}
 	if req.Scale <= 0 {
 		req.Scale = 1.0
+	}
+	if req.Scale > maxScale {
+		req.Scale = maxScale
 	}
 
 	switch req.Format {
@@ -336,12 +428,14 @@ func (h *Handlers) HandleRecordStart(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := h.recorder.start(ctx, resolvedTabID, req.Format, req.FPS, req.Quality, req.Scale); err != nil {
+	owner := requestOwner(r)
+
+	if err := h.recorder.start(ctx, resolvedTabID, owner, req.Format, req.FPS, req.Quality, req.Scale); err != nil {
 		httpx.ErrorCode(w, 409, "recording_error", err.Error(), false, nil)
 		return
 	}
 
-	slog.Info("recording started", "tab", resolvedTabID, "format", req.Format, "fps", req.FPS)
+	slog.Info("recording started", "tab", resolvedTabID, "format", req.Format, "fps", req.FPS, "owner", owner)
 	httpx.JSON(w, 200, map[string]any{
 		"status":  "recording",
 		"format":  req.Format,
@@ -353,7 +447,8 @@ func (h *Handlers) HandleRecordStart(w http.ResponseWriter, r *http.Request) {
 
 // HandleRecordStop stops the active recording and returns the encoded file.
 func (h *Handlers) HandleRecordStop(w http.ResponseWriter, r *http.Request) {
-	data, format, err := h.recorder.stop()
+	owner := requestOwner(r)
+	data, format, err := h.recorder.stop(owner)
 	if err != nil {
 		httpx.ErrorCode(w, 400, "recording_error", err.Error(), false, nil)
 		return
@@ -380,4 +475,14 @@ func (h *Handlers) HandleRecordStop(w http.ResponseWriter, r *http.Request) {
 // HandleRecordStatus returns the current recording status.
 func (h *Handlers) HandleRecordStatus(w http.ResponseWriter, r *http.Request) {
 	httpx.JSON(w, 200, h.recorder.status())
+}
+
+func requestOwner(r *http.Request) string {
+	if sid := r.Header.Get("X-Pinchtab-Session-Id"); sid != "" {
+		return sid
+	}
+	if aid := r.Header.Get("X-Agent-Id"); aid != "" {
+		return aid
+	}
+	return ""
 }

--- a/internal/handlers/record.go
+++ b/internal/handlers/record.go
@@ -21,14 +21,17 @@ import (
 	"time"
 
 	"github.com/pinchtab/pinchtab/internal/httpx"
+	"github.com/pinchtab/pinchtab/internal/session"
 )
 
 const (
 	maxRecordDuration = 5 * time.Minute
 	maxRecordFrames   = 9000      // 5min × 30fps
+	maxGIFFrames      = 600       // ~2min at 5fps; keeps memory bounded during GIF encoding
 	maxTempBytes      = 1 << 30   // 1 GB disk
 	maxOutputBytes    = 256 << 20 // 256 MB encoded
 	encodeTimeout     = 2 * time.Minute
+	limitCleanupGrace = 5 * time.Minute
 	maxFPS            = 30
 	maxQuality        = 100
 	maxScale          = 1.0
@@ -41,7 +44,6 @@ type RecordingStatus struct {
 	Frames   int     `json:"frames"`
 	TabID    string  `json:"tabId,omitempty"`
 	FPS      int     `json:"fps,omitempty"`
-	Owner    string  `json:"owner,omitempty"`
 }
 
 type recorder struct {
@@ -51,7 +53,7 @@ type recorder struct {
 	tabCtx    context.Context
 	tabCancel context.CancelFunc
 	tabID     string
-	owner     string
+	owner     string // opaque key derived from authenticated session, never exposed
 	format    string
 	fps       int
 	quality   int
@@ -112,7 +114,7 @@ func (rec *recorder) stop(callerOwner string) ([]byte, string, error) {
 		<-doneCh
 		return nil, "", fmt.Errorf("no active recording")
 	}
-	if callerOwner != "" && rec.owner != "" && callerOwner != rec.owner {
+	if rec.owner != "" && callerOwner != rec.owner {
 		rec.mu.Unlock()
 		return nil, "", fmt.Errorf("recording owned by another session")
 	}
@@ -128,23 +130,26 @@ func (rec *recorder) stop(callerOwner string) ([]byte, string, error) {
 
 	<-doneCh
 
+	// Encode without holding the mutex so status/start aren't blocked.
+	var data []byte
+	var encErr error
+	if frameNum > 0 {
+		data, encErr = encode(tmpDir, format, fps, scale)
+		if encErr == nil && len(data) > maxOutputBytes {
+			data = nil
+			encErr = fmt.Errorf("encoded output too large (max %d bytes)", maxOutputBytes)
+		}
+	} else {
+		encErr = fmt.Errorf("no frames captured")
+	}
+
 	rec.mu.Lock()
 	defer rec.mu.Unlock()
 	defer rec.cleanup()
 
-	if frameNum == 0 {
-		return nil, "", fmt.Errorf("no frames captured")
+	if encErr != nil {
+		return nil, "", encErr
 	}
-
-	data, err := encode(tmpDir, format, fps, scale)
-	if err != nil {
-		return nil, "", err
-	}
-
-	if len(data) > maxOutputBytes {
-		return nil, "", fmt.Errorf("encoded output too large (%d bytes, max %d)", len(data), maxOutputBytes)
-	}
-
 	return data, format, nil
 }
 
@@ -176,7 +181,6 @@ func (rec *recorder) status() RecordingStatus {
 		Frames:   rec.frameNum,
 		TabID:    rec.tabID,
 		FPS:      rec.fps,
-		Owner:    rec.owner,
 	}
 }
 
@@ -191,6 +195,7 @@ func (rec *recorder) captureLoop() {
 	defer ticker.Stop()
 
 	var diskBytes atomic.Int64
+	limitHit := false
 
 	for {
 		select {
@@ -204,39 +209,67 @@ func (rec *recorder) captureLoop() {
 			return
 		case <-deadline.C:
 			slog.Info("recording stopped: max duration reached", "tab", rec.tabID)
-			return
+			limitHit = true
 		case <-ticker.C:
 			rec.mu.Lock()
 			if rec.frameNum >= maxRecordFrames {
 				rec.mu.Unlock()
 				slog.Info("recording stopped: max frames reached", "tab", rec.tabID)
-				return
+				limitHit = true
+			} else {
+				rec.mu.Unlock()
 			}
-			rec.mu.Unlock()
 
-			if diskBytes.Load() >= int64(maxTempBytes) {
+			if !limitHit && diskBytes.Load() >= int64(maxTempBytes) {
 				slog.Info("recording stopped: temp disk limit reached", "tab", rec.tabID)
-				return
+				limitHit = true
 			}
 
-			frame, err := captureScreencastJPEG(rec.tabCtx, rec.quality)
-			if err != nil {
-				slog.Debug("recording frame capture failed", "err", err)
+			if limitHit {
+				// noop: break out to the cleanup below
+			} else {
+				frame, err := captureScreencastJPEG(rec.tabCtx, rec.quality)
+				if err != nil {
+					slog.Debug("recording frame capture failed", "err", err)
+					continue
+				}
+
+				rec.mu.Lock()
+				rec.frameNum++
+				path := filepath.Join(rec.tmpDir, fmt.Sprintf("frame_%06d.jpg", rec.frameNum))
+				rec.mu.Unlock()
+
+				if err := os.WriteFile(path, frame, 0600); err != nil {
+					slog.Debug("recording frame write failed", "err", err)
+				} else {
+					diskBytes.Add(int64(len(frame)))
+				}
 				continue
 			}
+		}
 
-			rec.mu.Lock()
-			rec.frameNum++
-			path := filepath.Join(rec.tmpDir, fmt.Sprintf("frame_%06d.jpg", rec.frameNum))
-			rec.mu.Unlock()
-
-			if err := os.WriteFile(path, frame, 0600); err != nil {
-				slog.Debug("recording frame write failed", "err", err)
-			} else {
-				diskBytes.Add(int64(len(frame)))
-			}
+		if limitHit {
+			break
 		}
 	}
+
+	// Limit was reached. Keep frames for stop() to encode, but auto-cleanup
+	// after a grace period if nobody calls stop().
+	go func() {
+		timer := time.NewTimer(limitCleanupGrace)
+		defer timer.Stop()
+		select {
+		case <-rec.stopCh:
+			return
+		case <-timer.C:
+			rec.mu.Lock()
+			defer rec.mu.Unlock()
+			if rec.active && !rec.stopping {
+				slog.Info("recording auto-cleanup after limit grace period", "tab", rec.tabID)
+				rec.cleanup()
+			}
+		}
+	}()
 }
 
 func encode(tmpDir, format string, fps int, scale float64) ([]byte, error) {
@@ -262,10 +295,22 @@ func encodeGIF(tmpDir string, fps int, scale float64) ([]byte, error) {
 	}
 	sort.Strings(files)
 
+	if len(files) > maxGIFFrames {
+		files = files[:maxGIFFrames]
+	}
+
 	delay := 100 / fps
 	if delay < 1 {
 		delay = 1
 	}
+
+	// Encode to a temp file to avoid holding all paletted frames in memory.
+	outPath := filepath.Join(tmpDir, "output.gif")
+	outFile, err := os.Create(outPath)
+	if err != nil {
+		return nil, fmt.Errorf("create gif output: %w", err)
+	}
+	defer func() { _ = outFile.Close() }()
 
 	g := &gif.GIF{LoopCount: 0}
 
@@ -294,11 +339,12 @@ func encodeGIF(tmpDir string, fps int, scale float64) ([]byte, error) {
 		return nil, fmt.Errorf("no frames to encode")
 	}
 
-	var buf bytes.Buffer
-	if err := gif.EncodeAll(&buf, g); err != nil {
+	if err := gif.EncodeAll(outFile, g); err != nil {
 		return nil, fmt.Errorf("gif encode: %w", err)
 	}
-	return buf.Bytes(), nil
+	_ = outFile.Close()
+
+	return readFileCapped(outPath, maxOutputBytes)
 }
 
 func encodeFFmpeg(ctx context.Context, tmpDir, format string, fps int, scale float64, codec string, extraArgs ...string) ([]byte, error) {
@@ -325,7 +371,19 @@ func encodeFFmpeg(ctx context.Context, tmpDir, format string, fps int, scale flo
 	if err := cmd.Run(); err != nil {
 		return nil, fmt.Errorf("ffmpeg encode: %w\n%s", err, stderr.String())
 	}
-	return os.ReadFile(outFile)
+
+	return readFileCapped(outFile, maxOutputBytes)
+}
+
+func readFileCapped(path string, maxBytes int) ([]byte, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	if info.Size() > int64(maxBytes) {
+		return nil, fmt.Errorf("encoded output too large (%d bytes, max %d)", info.Size(), maxBytes)
+	}
+	return os.ReadFile(path)
 }
 
 func scaleImage(src image.Image, scale float64) image.Image {
@@ -428,14 +486,14 @@ func (h *Handlers) HandleRecordStart(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	owner := requestOwner(r)
+	owner := authenticatedOwner(r)
 
 	if err := h.recorder.start(ctx, resolvedTabID, owner, req.Format, req.FPS, req.Quality, req.Scale); err != nil {
 		httpx.ErrorCode(w, 409, "recording_error", err.Error(), false, nil)
 		return
 	}
 
-	slog.Info("recording started", "tab", resolvedTabID, "format", req.Format, "fps", req.FPS, "owner", owner)
+	slog.Info("recording started", "tab", resolvedTabID, "format", req.Format, "fps", req.FPS)
 	httpx.JSON(w, 200, map[string]any{
 		"status":  "recording",
 		"format":  req.Format,
@@ -447,7 +505,7 @@ func (h *Handlers) HandleRecordStart(w http.ResponseWriter, r *http.Request) {
 
 // HandleRecordStop stops the active recording and returns the encoded file.
 func (h *Handlers) HandleRecordStop(w http.ResponseWriter, r *http.Request) {
-	owner := requestOwner(r)
+	owner := authenticatedOwner(r)
 	data, format, err := h.recorder.stop(owner)
 	if err != nil {
 		httpx.ErrorCode(w, 400, "recording_error", err.Error(), false, nil)
@@ -477,12 +535,14 @@ func (h *Handlers) HandleRecordStatus(w http.ResponseWriter, r *http.Request) {
 	httpx.JSON(w, 200, h.recorder.status())
 }
 
-func requestOwner(r *http.Request) string {
-	if sid := r.Header.Get("X-Pinchtab-Session-Id"); sid != "" {
-		return sid
+// authenticatedOwner derives a non-secret owner key from the authenticated
+// session context. Only session-authenticated requests get an owner; token/cookie
+// auth callers get "" (anonymous). X-Agent-Id is not used because it is
+// caller-controllable on non-session auth paths.
+func authenticatedOwner(r *http.Request) string {
+	sess, ok := session.FromRequest(r)
+	if !ok || sess == nil {
+		return ""
 	}
-	if aid := r.Header.Get("X-Agent-Id"); aid != "" {
-		return aid
-	}
-	return ""
+	return "session:" + sess.AgentID
 }

--- a/internal/handlers/record.go
+++ b/internal/handlers/record.go
@@ -440,7 +440,11 @@ func (h *Handlers) HandleRecordStart(w http.ResponseWriter, r *http.Request) {
 	if !h.Config.AllowScreencast {
 		httpx.ErrorCode(w, 403, "recording_disabled",
 			httpx.DisabledEndpointMessage("recording", "security.allowScreencast"), false,
-			map[string]any{"setting": "security.allowScreencast"})
+			map[string]any{
+				"setting": "security.allowScreencast",
+				"hint":    "Recording requires screen capture to be enabled.",
+				"remedy":  "pinchtab config set security.allowScreencast true",
+			})
 		return
 	}
 
@@ -522,6 +526,10 @@ func (h *Handlers) HandleRecordStart(w http.ResponseWriter, r *http.Request) {
 
 // HandleRecordStop stops the active recording and returns the encoded file.
 func (h *Handlers) HandleRecordStop(w http.ResponseWriter, r *http.Request) {
+	// Encoding can exceed the default WriteTimeout; extend the deadline.
+	rc := http.NewResponseController(w)
+	_ = rc.SetWriteDeadline(time.Now().Add(encodeTimeout + 30*time.Second))
+
 	owner := authenticatedOwner(r)
 	data, format, err := h.recorder.stop(owner)
 	if err != nil {

--- a/internal/handlers/record.go
+++ b/internal/handlers/record.go
@@ -42,40 +42,78 @@ const (
 	maxScale          = 1.0
 )
 
+type recorderState int
+
+const (
+	stateIdle         recorderState = iota
+	stateRecording                  // capture loop is running
+	stateLimitReached               // capture stopped due to limit; frames on disk awaiting stop()
+	stateStopping                   // stop() called; waiting for capture loop to finish
+	stateEncoding                   // encoding frames to output format
+	stateFinished                   // encoding complete; cleanup pending
+	stateAborted                    // tab context was cancelled; resources cleaned up
+)
+
+func (s recorderState) String() string {
+	switch s {
+	case stateIdle:
+		return "idle"
+	case stateRecording:
+		return "recording"
+	case stateLimitReached:
+		return "limit_reached"
+	case stateStopping:
+		return "stopping"
+	case stateEncoding:
+		return "encoding"
+	case stateFinished:
+		return "finished"
+	case stateAborted:
+		return "aborted"
+	default:
+		return "unknown"
+	}
+}
+
 type RecordingStatus struct {
-	Active   bool    `json:"active"`
-	Format   string  `json:"format,omitempty"`
-	Duration float64 `json:"durationSeconds,omitempty"`
-	Frames   int     `json:"frames"`
-	TabID    string  `json:"tabId,omitempty"`
-	FPS      int     `json:"fps,omitempty"`
+	Active     bool    `json:"active"`
+	State      string  `json:"state"`
+	StopReason string  `json:"stopReason,omitempty"`
+	Format     string  `json:"format,omitempty"`
+	Duration   float64 `json:"durationSeconds,omitempty"`
+	Frames     int     `json:"frames"`
+	TabID      string  `json:"tabId,omitempty"`
+	FPS        int     `json:"fps,omitempty"`
 }
 
 type recorder struct {
-	mu        sync.Mutex
-	active    bool
-	stopping  bool
-	tabCtx    context.Context
-	tabCancel context.CancelFunc
-	tabID     string
-	owner     string // opaque key derived from authenticated session, never exposed
-	format    string
-	fps       int
-	quality   int
-	scale     float64
-	tmpDir    string
-	frameNum  int
-	tempBytes int64
-	startTime time.Time
-	stopCh    chan struct{}
-	doneCh    chan struct{}
+	mu         sync.Mutex
+	state      recorderState
+	stopReason string
+	tabCtx     context.Context
+	tabCancel  context.CancelFunc
+	tabID      string
+	owner      string // opaque key derived from authenticated session, never exposed
+	format     string
+	fps        int
+	quality    int
+	scale      float64
+	tmpDir     string
+	frameNum   int
+	startTime  time.Time
+	stopCh     chan struct{}
+	doneCh     chan struct{}
 }
 
 func (rec *recorder) start(tabCtx context.Context, tabID, owner, format string, fps, quality int, scale float64) error {
 	rec.mu.Lock()
 	defer rec.mu.Unlock()
 
-	if rec.active {
+	if rec.state == stateAborted {
+		rec.state = stateIdle
+		rec.stopReason = ""
+	}
+	if rec.state != stateIdle {
 		return fmt.Errorf("recording already in progress")
 	}
 
@@ -86,8 +124,8 @@ func (rec *recorder) start(tabCtx context.Context, tabID, owner, format string, 
 
 	ctx, cancel := context.WithCancel(tabCtx)
 
-	rec.active = true
-	rec.stopping = false
+	rec.state = stateRecording
+	rec.stopReason = ""
 	rec.tabCtx = ctx
 	rec.tabCancel = cancel
 	rec.tabID = tabID
@@ -98,7 +136,6 @@ func (rec *recorder) start(tabCtx context.Context, tabID, owner, format string, 
 	rec.scale = scale
 	rec.tmpDir = tmpDir
 	rec.frameNum = 0
-	rec.tempBytes = 0
 	rec.startTime = time.Now()
 	rec.stopCh = make(chan struct{})
 	rec.doneCh = make(chan struct{})
@@ -109,11 +146,11 @@ func (rec *recorder) start(tabCtx context.Context, tabID, owner, format string, 
 
 func (rec *recorder) stop(callerOwner string) ([]byte, string, error) {
 	rec.mu.Lock()
-	if !rec.active {
+	if rec.state == stateIdle || rec.state == stateAborted {
 		rec.mu.Unlock()
 		return nil, "", fmt.Errorf("no active recording")
 	}
-	if rec.stopping {
+	if rec.state == stateStopping || rec.state == stateEncoding || rec.state == stateFinished {
 		doneCh := rec.doneCh
 		rec.mu.Unlock()
 		<-doneCh
@@ -123,7 +160,7 @@ func (rec *recorder) stop(callerOwner string) ([]byte, string, error) {
 		rec.mu.Unlock()
 		return nil, "", fmt.Errorf("recording owned by another session")
 	}
-	rec.stopping = true
+	rec.state = stateStopping
 	close(rec.stopCh)
 	doneCh := rec.doneCh
 	format := rec.format
@@ -135,7 +172,10 @@ func (rec *recorder) stop(callerOwner string) ([]byte, string, error) {
 
 	<-doneCh
 
-	// Encode without holding the mutex so status/start aren't blocked.
+	rec.mu.Lock()
+	rec.state = stateEncoding
+	rec.mu.Unlock()
+
 	var data []byte
 	var encErr error
 	if frameNum > 0 {
@@ -146,7 +186,10 @@ func (rec *recorder) stop(callerOwner string) ([]byte, string, error) {
 
 	rec.mu.Lock()
 	defer rec.mu.Unlock()
-	defer rec.cleanup()
+	rec.state = stateFinished
+	rec.cleanup()
+	rec.state = stateIdle
+	rec.stopReason = ""
 
 	if encErr != nil {
 		return nil, "", encErr
@@ -154,6 +197,8 @@ func (rec *recorder) stop(callerOwner string) ([]byte, string, error) {
 	return data, format, nil
 }
 
+// cleanup releases resources but does not change state — callers set the
+// final state (stateIdle, stateAborted, etc.) before or after calling this.
 func (rec *recorder) cleanup() {
 	if rec.tabCancel != nil {
 		rec.tabCancel()
@@ -162,8 +207,6 @@ func (rec *recorder) cleanup() {
 	if rec.tmpDir != "" {
 		_ = os.RemoveAll(rec.tmpDir)
 	}
-	rec.active = false
-	rec.stopping = false
 	rec.tmpDir = ""
 	rec.owner = ""
 }
@@ -172,16 +215,18 @@ func (rec *recorder) status() RecordingStatus {
 	rec.mu.Lock()
 	defer rec.mu.Unlock()
 
-	if !rec.active {
-		return RecordingStatus{}
+	if rec.state == stateIdle {
+		return RecordingStatus{State: stateIdle.String()}
 	}
 	return RecordingStatus{
-		Active:   true,
-		Format:   rec.format,
-		Duration: time.Since(rec.startTime).Seconds(),
-		Frames:   rec.frameNum,
-		TabID:    rec.tabID,
-		FPS:      rec.fps,
+		Active:     rec.state != stateAborted,
+		State:      rec.state.String(),
+		StopReason: rec.stopReason,
+		Format:     rec.format,
+		Duration:   time.Since(rec.startTime).Seconds(),
+		Frames:     rec.frameNum,
+		TabID:      rec.tabID,
+		FPS:        rec.fps,
 	}
 }
 
@@ -196,7 +241,6 @@ func (rec *recorder) captureLoop() {
 	defer ticker.Stop()
 
 	var diskBytes atomic.Int64
-	limitHit := false
 
 	for {
 		select {
@@ -204,58 +248,72 @@ func (rec *recorder) captureLoop() {
 			return
 		case <-rec.tabCtx.Done():
 			rec.mu.Lock()
+			rec.state = stateAborted
+			rec.stopReason = "tab_closed"
 			rec.cleanup()
 			rec.mu.Unlock()
 			slog.Info("recording aborted: tab context canceled", "tab", rec.tabID)
 			return
 		case <-deadline.C:
+			rec.transitionToLimitReached("max_duration")
 			slog.Info("recording stopped: max duration reached", "tab", rec.tabID)
-			limitHit = true
+			rec.scheduleLimitCleanup()
+			return
 		case <-ticker.C:
-			rec.mu.Lock()
-			if rec.frameNum >= maxRecordFrames {
-				rec.mu.Unlock()
-				slog.Info("recording stopped: max frames reached", "tab", rec.tabID)
-				limitHit = true
-			} else {
-				rec.mu.Unlock()
+			if reason := rec.checkLimits(&diskBytes); reason != "" {
+				rec.transitionToLimitReached(reason)
+				slog.Info("recording stopped: "+reason, "tab", rec.tabID)
+				rec.scheduleLimitCleanup()
+				return
 			}
-
-			if !limitHit && diskBytes.Load() >= int64(maxTempBytes) {
-				slog.Info("recording stopped: temp disk limit reached", "tab", rec.tabID)
-				limitHit = true
-			}
-
-			if limitHit {
-				// noop: break out to the cleanup below
-			} else {
-				frame, err := captureScreencastJPEG(rec.tabCtx, rec.quality)
-				if err != nil {
-					slog.Debug("recording frame capture failed", "err", err)
-					continue
-				}
-
-				rec.mu.Lock()
-				rec.frameNum++
-				path := filepath.Join(rec.tmpDir, fmt.Sprintf("frame_%06d.jpg", rec.frameNum))
-				rec.mu.Unlock()
-
-				if err := os.WriteFile(path, frame, 0600); err != nil {
-					slog.Debug("recording frame write failed", "err", err)
-				} else {
-					diskBytes.Add(int64(len(frame)))
-				}
-				continue
-			}
-		}
-
-		if limitHit {
-			break
+			rec.writeFrame(&diskBytes)
 		}
 	}
+}
 
-	// Limit was reached. Keep frames for stop() to encode, but auto-cleanup
-	// after a grace period if nobody calls stop().
+func (rec *recorder) checkLimits(diskBytes *atomic.Int64) string {
+	rec.mu.Lock()
+	frames := rec.frameNum
+	rec.mu.Unlock()
+
+	if frames >= maxRecordFrames {
+		return "max_frames"
+	}
+	if diskBytes.Load() >= int64(maxTempBytes) {
+		return "disk_limit"
+	}
+	return ""
+}
+
+func (rec *recorder) writeFrame(diskBytes *atomic.Int64) {
+	frame, err := captureScreencastJPEG(rec.tabCtx, rec.quality)
+	if err != nil {
+		slog.Debug("recording frame capture failed", "err", err)
+		return
+	}
+
+	rec.mu.Lock()
+	rec.frameNum++
+	path := filepath.Join(rec.tmpDir, fmt.Sprintf("frame_%06d.jpg", rec.frameNum))
+	rec.mu.Unlock()
+
+	if err := os.WriteFile(path, frame, 0600); err != nil {
+		slog.Debug("recording frame write failed", "err", err)
+	} else {
+		diskBytes.Add(int64(len(frame)))
+	}
+}
+
+func (rec *recorder) transitionToLimitReached(reason string) {
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	rec.state = stateLimitReached
+	rec.stopReason = reason
+}
+
+// scheduleLimitCleanup starts a goroutine that auto-cleans the recording
+// after limitCleanupGrace if nobody calls stop().
+func (rec *recorder) scheduleLimitCleanup() {
 	go func() {
 		timer := time.NewTimer(limitCleanupGrace)
 		defer timer.Stop()
@@ -265,9 +323,11 @@ func (rec *recorder) captureLoop() {
 		case <-timer.C:
 			rec.mu.Lock()
 			defer rec.mu.Unlock()
-			if rec.active && !rec.stopping {
+			if rec.state == stateLimitReached {
 				slog.Info("recording auto-cleanup after limit grace period", "tab", rec.tabID)
 				rec.cleanup()
+				rec.state = stateIdle
+				rec.stopReason = ""
 			}
 		}
 	}()
@@ -524,7 +584,10 @@ func (h *Handlers) HandleRecordStart(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// HandleRecordStop stops the active recording and returns the encoded file.
+// HandleRecordStop stops the active recording and returns the encoded binary
+// file directly (not JSON). The Content-Type is set to the appropriate media
+// type (image/gif, video/webm, video/mp4). This endpoint is fundamentally
+// different from most other API endpoints which return JSON.
 func (h *Handlers) HandleRecordStop(w http.ResponseWriter, r *http.Request) {
 	// Encoding can exceed the default WriteTimeout; extend the deadline.
 	rc := http.NewResponseController(w)
@@ -561,10 +624,9 @@ func (h *Handlers) HandleRecordStatus(w http.ResponseWriter, r *http.Request) {
 }
 
 // authenticatedOwner derives a non-secret owner key from the authenticated
-// session context. On direct requests, session.FromRequest provides the
-// session. On proxy hops (orchestrator → child bridge), the session is not
-// attached but X-PinchTab-Session-Id / X-Agent-Id headers are preserved by
-// trust middleware — we honor those only when IsTrustedInternalProxy is true.
+// session context. Returns "" for anonymous (unauthenticated) requests.
+// Anonymous recordings can be stopped by any caller, including other anonymous
+// callers — this is intentional for the single-user local model.
 func authenticatedOwner(r *http.Request) string {
 	if sess, ok := session.FromRequest(r); ok && sess != nil {
 		if id := strings.TrimSpace(sess.AgentID); id != "" {

--- a/internal/handlers/record.go
+++ b/internal/handlers/record.go
@@ -277,6 +277,15 @@ func (rec *recorder) cleanup() {
 	rec.encodeErr = nil
 }
 
+func (rec *recorder) activeFormat() string {
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	if rec.format == "" {
+		return "gif"
+	}
+	return rec.format
+}
+
 func (rec *recorder) status() RecordingStatus {
 	rec.mu.Lock()
 	defer rec.mu.Unlock()
@@ -653,31 +662,34 @@ func (h *Handlers) HandleRecordStart(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// HandleRecordStop stops the active recording. If outputPath is provided,
-// encoding runs in the background and the endpoint returns immediately.
-// If outputPath is empty, the recording is discarded (capture stops, no
-// encoding). Use /record/status to check encoding progress.
+// HandleRecordStop stops the active recording. If discard is false (default),
+// encoding runs in the background into a server-controlled recordings directory
+// and the endpoint returns the path immediately. If discard is true, frames are
+// dropped without encoding. Use /record/status to check encoding progress.
 func (h *Handlers) HandleRecordStop(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		OutputPath string `json:"outputPath"`
+		Discard bool `json:"discard"`
 	}
 	_ = httpx.DecodeJSONBody(w, r, 0, &req)
 
-	if req.OutputPath != "" {
-		if err := validateOutputPath(req.OutputPath); err != nil {
-			httpx.ErrorCode(w, 400, "invalid_output_path", err.Error(), false, nil)
+	var outputPath string
+	if !req.Discard {
+		var err error
+		outputPath, err = h.recordingsOutputPath()
+		if err != nil {
+			httpx.ErrorCode(w, 500, "recording_error", err.Error(), false, nil)
 			return
 		}
 	}
 
 	owner := authenticatedOwner(r)
-	result, err := h.recorder.stop(owner, req.OutputPath)
+	result, err := h.recorder.stop(owner, outputPath)
 	if err != nil {
 		httpx.ErrorCode(w, 400, "recording_error", err.Error(), false, nil)
 		return
 	}
 
-	if req.OutputPath == "" {
+	if req.Discard {
 		httpx.JSON(w, 200, map[string]any{
 			"status": "discarded",
 			"format": result.Format,
@@ -697,46 +709,17 @@ func (h *Handlers) HandleRecordStop(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// validateOutputPath checks that an output path is safe to write to:
-// absolute, supported extension, parent dir exists and is not a symlink,
-// target and temp file do not already exist.
-func validateOutputPath(path string) error {
-	cleaned := filepath.Clean(path)
-	if !filepath.IsAbs(cleaned) {
-		return fmt.Errorf("outputPath must be an absolute path, got %q", path)
+// recordingsOutputPath returns a unique output path inside the server-controlled
+// recordings directory. The caller never chooses the path — only the server does.
+func (h *Handlers) recordingsOutputPath() (string, error) {
+	dir := filepath.Join(h.Config.StateDir, "recordings")
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return "", fmt.Errorf("create recordings dir: %w", err)
 	}
-	ext := filepath.Ext(cleaned)
-	switch ext {
-	case ".gif", ".webm", ".mp4":
-	default:
-		return fmt.Errorf("unsupported extension %q — use .gif, .webm, or .mp4", ext)
-	}
-
-	dir := filepath.Dir(cleaned)
-	dirInfo, err := os.Lstat(dir)
-	if err != nil {
-		return fmt.Errorf("output directory: %w", err)
-	}
-	if dirInfo.Mode()&os.ModeSymlink != 0 {
-		return fmt.Errorf("output directory %q is a symlink", dir)
-	}
-	if !dirInfo.IsDir() {
-		return fmt.Errorf("output directory %q is not a directory", dir)
-	}
-
-	if info, err := os.Lstat(cleaned); err == nil {
-		if info.Mode()&os.ModeSymlink != 0 {
-			return fmt.Errorf("refusing to follow symlink at %q", cleaned)
-		}
-		return fmt.Errorf("file already exists at %q — remove it first or choose another path", cleaned)
-	}
-
-	tmpPath := cleaned + ".encoding.tmp"
-	if _, err := os.Lstat(tmpPath); err == nil {
-		return fmt.Errorf("temp file already exists at %q — a previous encoding may still be running", tmpPath)
-	}
-
-	return nil
+	format := h.recorder.activeFormat()
+	ext := "." + format
+	name := fmt.Sprintf("rec_%s%s", time.Now().Format("20060102_150405"), ext)
+	return filepath.Join(dir, name), nil
 }
 
 // HandleRecordStatus returns the current recording status.

--- a/internal/handlers/record.go
+++ b/internal/handlers/record.go
@@ -532,6 +532,8 @@ func encodeFFmpegToFile(ctx context.Context, tmpDir, outputPath, format string, 
 	args = append(args, "-fs", strconv.Itoa(maxOutputBytes))
 	args = append(args, outputPath)
 
+	// #nosec G204 -- ffmpeg executable is fixed and args are built from validated,
+	// bounded internal values (format/fps/scale/output path), not shell-expanded input.
 	cmd := exec.CommandContext(ctx, "ffmpeg", args...)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr

--- a/internal/handlers/record.go
+++ b/internal/handlers/record.go
@@ -84,6 +84,8 @@ type RecordingStatus struct {
 	Frames     int     `json:"frames"`
 	TabID      string  `json:"tabId,omitempty"`
 	FPS        int     `json:"fps,omitempty"`
+	OutputPath string  `json:"outputPath,omitempty"`
+	Error      string  `json:"error,omitempty"`
 }
 
 type recorder struct {
@@ -103,13 +105,16 @@ type recorder struct {
 	startTime  time.Time
 	stopCh     chan struct{}
 	doneCh     chan struct{}
+	outputPath string // final destination set by stop(); encoding writes here
+	encodeErr  error  // set by background encode goroutine
 }
 
 func (rec *recorder) start(tabCtx context.Context, tabID, owner, format string, fps, quality int, scale float64) error {
 	rec.mu.Lock()
 	defer rec.mu.Unlock()
 
-	if rec.state == stateAborted {
+	if rec.state == stateAborted || rec.state == stateFinished {
+		rec.cleanup()
 		rec.state = stateIdle
 		rec.stopReason = ""
 	}
@@ -144,23 +149,31 @@ func (rec *recorder) start(tabCtx context.Context, tabID, owner, format string, 
 	return nil
 }
 
-func (rec *recorder) stop(callerOwner string) ([]byte, string, error) {
+func (rec *recorder) stop(callerOwner, outputPath string) (RecordStopResult, error) {
 	rec.mu.Lock()
 	if rec.state == stateIdle || rec.state == stateAborted {
 		rec.mu.Unlock()
-		return nil, "", fmt.Errorf("no active recording")
+		return RecordStopResult{}, fmt.Errorf("no active recording")
 	}
-	if rec.state == stateStopping || rec.state == stateEncoding || rec.state == stateFinished {
-		doneCh := rec.doneCh
+	if rec.state == stateEncoding {
+		r := RecordStopResult{
+			OutputPath: rec.outputPath,
+			Format:     rec.format,
+			Frames:     rec.frameNum,
+		}
 		rec.mu.Unlock()
-		<-doneCh
-		return nil, "", fmt.Errorf("no active recording")
+		return r, fmt.Errorf("already encoding to %s — use record status to check progress", rec.outputPath)
+	}
+	if rec.state == stateStopping || rec.state == stateFinished {
+		rec.mu.Unlock()
+		return RecordStopResult{}, fmt.Errorf("no active recording")
 	}
 	if rec.owner != "" && callerOwner != rec.owner {
 		rec.mu.Unlock()
-		return nil, "", fmt.Errorf("recording owned by another session")
+		return RecordStopResult{}, fmt.Errorf("recording owned by another session")
 	}
 	rec.state = stateStopping
+	rec.outputPath = outputPath
 	close(rec.stopCh)
 	doneCh := rec.doneCh
 	format := rec.format
@@ -172,29 +185,70 @@ func (rec *recorder) stop(callerOwner string) ([]byte, string, error) {
 
 	<-doneCh
 
+	result := RecordStopResult{
+		OutputPath: outputPath,
+		Format:     format,
+		Frames:     frameNum,
+	}
+
+	if frameNum == 0 {
+		rec.mu.Lock()
+		rec.state = stateFinished
+		rec.cleanup()
+		rec.state = stateIdle
+		rec.mu.Unlock()
+		return result, fmt.Errorf("no frames captured")
+	}
+
 	rec.mu.Lock()
 	rec.state = stateEncoding
 	rec.mu.Unlock()
 
-	var data []byte
-	var encErr error
-	if frameNum > 0 {
-		data, encErr = encode(tmpDir, format, fps, scale)
-	} else {
-		encErr = fmt.Errorf("no frames captured")
-	}
+	go func() {
+		tmpOut := outputPath + ".encoding.tmp"
+		encErr := encodeToFile(tmpDir, tmpOut, format, fps, scale)
+		if encErr == nil {
+			encErr = os.Rename(tmpOut, outputPath)
+			if encErr != nil {
+				_ = os.Remove(tmpOut)
+			}
+		} else {
+			_ = os.Remove(tmpOut)
+		}
 
-	rec.mu.Lock()
-	defer rec.mu.Unlock()
-	rec.state = stateFinished
-	rec.cleanup()
-	rec.state = stateIdle
-	rec.stopReason = ""
+		rec.mu.Lock()
+		rec.encodeErr = encErr
+		rec.state = stateFinished
+		if rec.tabCancel != nil {
+			rec.tabCancel()
+			rec.tabCancel = nil
+		}
+		if rec.tmpDir != "" {
+			_ = os.RemoveAll(rec.tmpDir)
+			rec.tmpDir = ""
+		}
+		rec.mu.Unlock()
 
-	if encErr != nil {
-		return nil, "", encErr
-	}
-	return data, format, nil
+		if encErr != nil {
+			slog.Error("recording encode failed", "path", outputPath, "err", encErr)
+		} else {
+			info, _ := os.Stat(outputPath)
+			size := int64(0)
+			if info != nil {
+				size = info.Size()
+			}
+			slog.Info("recording saved", "path", outputPath, "bytes", size)
+		}
+	}()
+
+	return result, nil
+}
+
+// RecordStopResult is returned immediately by stop(); encoding continues in the background.
+type RecordStopResult struct {
+	OutputPath string
+	Format     string
+	Frames     int
 }
 
 // cleanup releases resources but does not change state — callers set the
@@ -209,6 +263,8 @@ func (rec *recorder) cleanup() {
 	}
 	rec.tmpDir = ""
 	rec.owner = ""
+	rec.outputPath = ""
+	rec.encodeErr = nil
 }
 
 func (rec *recorder) status() RecordingStatus {
@@ -217,6 +273,18 @@ func (rec *recorder) status() RecordingStatus {
 
 	if rec.state == stateIdle {
 		return RecordingStatus{State: stateIdle.String()}
+	}
+	if rec.state == stateFinished {
+		s := RecordingStatus{
+			State:      stateFinished.String(),
+			Format:     rec.format,
+			Frames:     rec.frameNum,
+			OutputPath: rec.outputPath,
+		}
+		if rec.encodeErr != nil {
+			s.Error = rec.encodeErr.Error()
+		}
+		return s
 	}
 	return RecordingStatus{
 		Active:     rec.state != stateAborted,
@@ -227,6 +295,7 @@ func (rec *recorder) status() RecordingStatus {
 		Frames:     rec.frameNum,
 		TabID:      rec.tabID,
 		FPS:        rec.fps,
+		OutputPath: rec.outputPath,
 	}
 }
 
@@ -333,26 +402,26 @@ func (rec *recorder) scheduleLimitCleanup() {
 	}()
 }
 
-func encode(tmpDir, format string, fps int, scale float64) ([]byte, error) {
+func encodeToFile(tmpDir, outputPath, format string, fps int, scale float64) error {
 	ctx, cancel := context.WithTimeout(context.Background(), encodeTimeout)
 	defer cancel()
 
 	switch format {
 	case "gif":
-		return encodeGIF(tmpDir, fps, scale)
+		return encodeGIFToFile(tmpDir, outputPath, fps, scale)
 	case "webm":
-		return encodeFFmpeg(ctx, tmpDir, format, fps, scale, "libvpx", "-crf", "10", "-b:v", "1M")
+		return encodeFFmpegToFile(ctx, tmpDir, outputPath, format, fps, scale, "libvpx", "-crf", "10", "-b:v", "1M")
 	case "mp4":
-		return encodeFFmpeg(ctx, tmpDir, format, fps, scale, "libx264", "-pix_fmt", "yuv420p", "-crf", "23")
+		return encodeFFmpegToFile(ctx, tmpDir, outputPath, format, fps, scale, "libx264", "-pix_fmt", "yuv420p", "-crf", "23")
 	default:
-		return nil, fmt.Errorf("unsupported format: %s", format)
+		return fmt.Errorf("unsupported format: %s", format)
 	}
 }
 
-func encodeGIF(tmpDir string, fps int, scale float64) ([]byte, error) {
+func encodeGIFToFile(tmpDir, outputPath string, fps int, scale float64) error {
 	files, err := filepath.Glob(filepath.Join(tmpDir, "frame_*.jpg"))
 	if err != nil {
-		return nil, err
+		return err
 	}
 	sort.Strings(files)
 
@@ -365,10 +434,9 @@ func encodeGIF(tmpDir string, fps int, scale float64) ([]byte, error) {
 		delay = 1
 	}
 
-	outPath := filepath.Join(tmpDir, "output.gif")
-	outFile, err := os.Create(outPath)
+	outFile, err := os.Create(outputPath)
 	if err != nil {
-		return nil, fmt.Errorf("create gif output: %w", err)
+		return fmt.Errorf("create gif output: %w", err)
 	}
 	defer func() { _ = outFile.Close() }()
 
@@ -411,21 +479,17 @@ func encodeGIF(tmpDir string, fps int, scale float64) ([]byte, error) {
 	}
 
 	if len(g.Image) == 0 {
-		return nil, fmt.Errorf("no frames to encode")
+		return fmt.Errorf("no frames to encode")
 	}
 
 	lw := &limitedWriter{w: outFile, max: int64(maxOutputBytes)}
 	if err := gif.EncodeAll(lw, g); err != nil {
-		return nil, fmt.Errorf("gif encode: %w", err)
+		return fmt.Errorf("gif encode: %w", err)
 	}
-	_ = outFile.Close()
-
-	return readFileCapped(outPath, maxOutputBytes)
+	return outFile.Close()
 }
 
-func encodeFFmpeg(ctx context.Context, tmpDir, format string, fps int, scale float64, codec string, extraArgs ...string) ([]byte, error) {
-	outFile := filepath.Join(tmpDir, "output."+format)
-
+func encodeFFmpegToFile(ctx context.Context, tmpDir, outputPath, format string, fps int, scale float64, codec string, extraArgs ...string) error {
 	args := []string{
 		"-y",
 		"-framerate", strconv.Itoa(fps),
@@ -440,27 +504,15 @@ func encodeFFmpeg(ctx context.Context, tmpDir, format string, fps int, scale flo
 	args = append(args, "-c:v", codec)
 	args = append(args, extraArgs...)
 	args = append(args, "-fs", strconv.Itoa(maxOutputBytes))
-	args = append(args, outFile)
+	args = append(args, outputPath)
 
 	cmd := exec.CommandContext(ctx, "ffmpeg", args...)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("ffmpeg encode: %w\n%s", err, stderr.String())
+		return fmt.Errorf("ffmpeg encode: %w\n%s", err, stderr.String())
 	}
-
-	return readFileCapped(outFile, maxOutputBytes)
-}
-
-func readFileCapped(path string, maxBytes int) ([]byte, error) {
-	info, err := os.Stat(path)
-	if err != nil {
-		return nil, err
-	}
-	if info.Size() > int64(maxBytes) {
-		return nil, fmt.Errorf("encoded output too large (%d bytes, max %d)", info.Size(), maxBytes)
-	}
-	return os.ReadFile(path)
+	return nil
 }
 
 func scaleImage(src image.Image, scale float64) image.Image {
@@ -584,38 +636,36 @@ func (h *Handlers) HandleRecordStart(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// HandleRecordStop stops the active recording and returns the encoded binary
-// file directly (not JSON). The Content-Type is set to the appropriate media
-// type (image/gif, video/webm, video/mp4). This endpoint is fundamentally
-// different from most other API endpoints which return JSON.
+// HandleRecordStop stops the active recording. Encoding runs in the background;
+// this endpoint returns immediately with a JSON status so callers are not
+// blocked. Use /record/status to check encoding progress.
 func (h *Handlers) HandleRecordStop(w http.ResponseWriter, r *http.Request) {
-	// Encoding can exceed the default WriteTimeout; extend the deadline.
-	rc := http.NewResponseController(w)
-	_ = rc.SetWriteDeadline(time.Now().Add(encodeTimeout + 30*time.Second))
+	var req struct {
+		OutputPath string `json:"outputPath"`
+	}
+	_ = httpx.DecodeJSONBody(w, r, 0, &req)
+
+	if req.OutputPath == "" {
+		httpx.ErrorCode(w, 400, "missing_output_path", "outputPath is required — the encoded file will be written there", false, nil)
+		return
+	}
 
 	owner := authenticatedOwner(r)
-	data, format, err := h.recorder.stop(owner)
+	result, err := h.recorder.stop(owner, req.OutputPath)
 	if err != nil {
 		httpx.ErrorCode(w, 400, "recording_error", err.Error(), false, nil)
 		return
 	}
 
-	contentType := "application/octet-stream"
-	switch format {
-	case "gif":
-		contentType = "image/gif"
-	case "webm":
-		contentType = "video/webm"
-	case "mp4":
-		contentType = "video/mp4"
-	}
-
-	slog.Info("recording stopped", "format", format, "size", len(data))
-	w.Header().Set("Content-Type", contentType)
-	w.Header().Set("Content-Length", strconv.Itoa(len(data)))
-	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=recording.%s", format))
-	w.WriteHeader(200)
-	_, _ = w.Write(data)
+	slog.Info("recording stopped, encoding in background",
+		"format", result.Format, "frames", result.Frames, "path", result.OutputPath)
+	httpx.JSON(w, 200, map[string]any{
+		"status": "encoding",
+		"path":   result.OutputPath,
+		"format": result.Format,
+		"frames": result.Frames,
+		"hint":   fmt.Sprintf("Encoding %d frames to %s. Use `record status` to check progress — the file will appear at the path once encoding completes.", result.Frames, result.OutputPath),
+	})
 }
 
 // HandleRecordStatus returns the current recording status.

--- a/internal/handlers/record.go
+++ b/internal/handlers/record.go
@@ -9,6 +9,7 @@ import (
 	"image/draw"
 	"image/gif"
 	"image/jpeg"
+	"io"
 	"log/slog"
 	"net/http"
 	"os"
@@ -16,18 +17,22 @@ import (
 	"path/filepath"
 	"sort"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 
+	"github.com/pinchtab/pinchtab/internal/activity"
 	"github.com/pinchtab/pinchtab/internal/httpx"
 	"github.com/pinchtab/pinchtab/internal/session"
 )
 
 const (
 	maxRecordDuration = 5 * time.Minute
-	maxRecordFrames   = 9000      // 5min × 30fps
-	maxGIFFrames      = 600       // ~2min at 5fps; keeps memory bounded during GIF encoding
+	maxRecordFrames   = 9000 // 5min × 30fps
+	maxGIFFrames      = 600  // ~2min at 5fps
+	maxGIFFramePixels = 1280 * 720
+	maxGIFEncodeBytes = 256 << 20 // 256 MB total paletted frame budget
 	maxTempBytes      = 1 << 30   // 1 GB disk
 	maxOutputBytes    = 256 << 20 // 256 MB encoded
 	encodeTimeout     = 2 * time.Minute
@@ -135,10 +140,6 @@ func (rec *recorder) stop(callerOwner string) ([]byte, string, error) {
 	var encErr error
 	if frameNum > 0 {
 		data, encErr = encode(tmpDir, format, fps, scale)
-		if encErr == nil && len(data) > maxOutputBytes {
-			data = nil
-			encErr = fmt.Errorf("encoded output too large (max %d bytes)", maxOutputBytes)
-		}
 	} else {
 		encErr = fmt.Errorf("no frames captured")
 	}
@@ -304,7 +305,6 @@ func encodeGIF(tmpDir string, fps int, scale float64) ([]byte, error) {
 		delay = 1
 	}
 
-	// Encode to a temp file to avoid holding all paletted frames in memory.
 	outPath := filepath.Join(tmpDir, "output.gif")
 	outFile, err := os.Create(outPath)
 	if err != nil {
@@ -313,6 +313,7 @@ func encodeGIF(tmpDir string, fps int, scale float64) ([]byte, error) {
 	defer func() { _ = outFile.Close() }()
 
 	g := &gif.GIF{LoopCount: 0}
+	var palettedBytes int64
 
 	for _, f := range files {
 		data, err := os.ReadFile(f)
@@ -329,17 +330,32 @@ func encodeGIF(tmpDir string, fps int, scale float64) ([]byte, error) {
 		}
 
 		bounds := img.Bounds()
+		pixels := bounds.Dx() * bounds.Dy()
+		if pixels > maxGIFFramePixels {
+			ratio := float64(maxGIFFramePixels) / float64(pixels)
+			img = scaleImage(img, ratio)
+			bounds = img.Bounds()
+			pixels = bounds.Dx() * bounds.Dy()
+		}
+
+		if palettedBytes+int64(pixels) > maxGIFEncodeBytes {
+			slog.Info("GIF encode: memory budget reached, truncating", "frames", len(g.Image))
+			break
+		}
+
 		paletted := image.NewPaletted(bounds, palette.Plan9)
 		draw.FloydSteinberg.Draw(paletted, bounds, img, bounds.Min)
 		g.Image = append(g.Image, paletted)
 		g.Delay = append(g.Delay, delay)
+		palettedBytes += int64(pixels)
 	}
 
 	if len(g.Image) == 0 {
 		return nil, fmt.Errorf("no frames to encode")
 	}
 
-	if err := gif.EncodeAll(outFile, g); err != nil {
+	lw := &limitedWriter{w: outFile, max: int64(maxOutputBytes)}
+	if err := gif.EncodeAll(lw, g); err != nil {
 		return nil, fmt.Errorf("gif encode: %w", err)
 	}
 	_ = outFile.Close()
@@ -363,6 +379,7 @@ func encodeFFmpeg(ctx context.Context, tmpDir, format string, fps int, scale flo
 
 	args = append(args, "-c:v", codec)
 	args = append(args, extraArgs...)
+	args = append(args, "-fs", strconv.Itoa(maxOutputBytes))
 	args = append(args, outFile)
 
 	cmd := exec.CommandContext(ctx, "ffmpeg", args...)
@@ -536,13 +553,41 @@ func (h *Handlers) HandleRecordStatus(w http.ResponseWriter, r *http.Request) {
 }
 
 // authenticatedOwner derives a non-secret owner key from the authenticated
-// session context. Only session-authenticated requests get an owner; token/cookie
-// auth callers get "" (anonymous). X-Agent-Id is not used because it is
-// caller-controllable on non-session auth paths.
+// session context. On direct requests, session.FromRequest provides the
+// session. On proxy hops (orchestrator → child bridge), the session is not
+// attached but X-PinchTab-Session-Id / X-Agent-Id headers are preserved by
+// trust middleware — we honor those only when IsTrustedInternalProxy is true.
 func authenticatedOwner(r *http.Request) string {
-	sess, ok := session.FromRequest(r)
-	if !ok || sess == nil {
-		return ""
+	if sess, ok := session.FromRequest(r); ok && sess != nil {
+		if id := strings.TrimSpace(sess.AgentID); id != "" {
+			return "session:" + id
+		}
+		if id := strings.TrimSpace(sess.ID); id != "" {
+			return "session:" + id
+		}
 	}
-	return "session:" + sess.AgentID
+	if IsTrustedInternalProxy(r) {
+		if id := strings.TrimSpace(r.Header.Get(activity.HeaderPTSessionID)); id != "" {
+			return "proxy-session:" + id
+		}
+		if id := strings.TrimSpace(r.Header.Get(activity.HeaderAgentID)); id != "" {
+			return "proxy-agent:" + id
+		}
+	}
+	return ""
+}
+
+type limitedWriter struct {
+	w   io.Writer
+	n   int64
+	max int64
+}
+
+func (lw *limitedWriter) Write(p []byte) (int, error) {
+	if lw.n+int64(len(p)) > lw.max {
+		return 0, fmt.Errorf("output exceeds maximum size (%d bytes)", lw.max)
+	}
+	n, err := lw.w.Write(p)
+	lw.n += int64(n)
+	return n, err
 }

--- a/internal/handlers/record.go
+++ b/internal/handlers/record.go
@@ -200,6 +200,16 @@ func (rec *recorder) stop(callerOwner, outputPath string) (RecordStopResult, err
 		return result, fmt.Errorf("no frames captured")
 	}
 
+	if outputPath == "" {
+		rec.mu.Lock()
+		rec.state = stateFinished
+		rec.cleanup()
+		rec.state = stateIdle
+		rec.mu.Unlock()
+		slog.Info("recording discarded", "frames", frameNum, "format", format)
+		return result, nil
+	}
+
 	rec.mu.Lock()
 	rec.state = stateEncoding
 	rec.mu.Unlock()
@@ -434,7 +444,7 @@ func encodeGIFToFile(tmpDir, outputPath string, fps int, scale float64) error {
 		delay = 1
 	}
 
-	outFile, err := os.Create(outputPath)
+	outFile, err := os.OpenFile(outputPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
 	if err != nil {
 		return fmt.Errorf("create gif output: %w", err)
 	}
@@ -490,8 +500,15 @@ func encodeGIFToFile(tmpDir, outputPath string, fps int, scale float64) error {
 }
 
 func encodeFFmpegToFile(ctx context.Context, tmpDir, outputPath, format string, fps int, scale float64, codec string, extraArgs ...string) error {
+	// Pre-create exclusively to prevent symlink following by ffmpeg.
+	f, err := os.OpenFile(outputPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+	if err != nil {
+		return fmt.Errorf("create output: %w", err)
+	}
+	_ = f.Close()
+
 	args := []string{
-		"-y",
+		"-y", // safe: we own the file from O_EXCL above
 		"-framerate", strconv.Itoa(fps),
 		"-i", filepath.Join(tmpDir, "frame_%06d.jpg"),
 	}
@@ -636,24 +653,36 @@ func (h *Handlers) HandleRecordStart(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// HandleRecordStop stops the active recording. Encoding runs in the background;
-// this endpoint returns immediately with a JSON status so callers are not
-// blocked. Use /record/status to check encoding progress.
+// HandleRecordStop stops the active recording. If outputPath is provided,
+// encoding runs in the background and the endpoint returns immediately.
+// If outputPath is empty, the recording is discarded (capture stops, no
+// encoding). Use /record/status to check encoding progress.
 func (h *Handlers) HandleRecordStop(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		OutputPath string `json:"outputPath"`
 	}
 	_ = httpx.DecodeJSONBody(w, r, 0, &req)
 
-	if req.OutputPath == "" {
-		httpx.ErrorCode(w, 400, "missing_output_path", "outputPath is required — the encoded file will be written there", false, nil)
-		return
+	if req.OutputPath != "" {
+		if err := validateOutputPath(req.OutputPath); err != nil {
+			httpx.ErrorCode(w, 400, "invalid_output_path", err.Error(), false, nil)
+			return
+		}
 	}
 
 	owner := authenticatedOwner(r)
 	result, err := h.recorder.stop(owner, req.OutputPath)
 	if err != nil {
 		httpx.ErrorCode(w, 400, "recording_error", err.Error(), false, nil)
+		return
+	}
+
+	if req.OutputPath == "" {
+		httpx.JSON(w, 200, map[string]any{
+			"status": "discarded",
+			"format": result.Format,
+			"frames": result.Frames,
+		})
 		return
 	}
 
@@ -666,6 +695,48 @@ func (h *Handlers) HandleRecordStop(w http.ResponseWriter, r *http.Request) {
 		"frames": result.Frames,
 		"hint":   fmt.Sprintf("Encoding %d frames to %s. Use `record status` to check progress — the file will appear at the path once encoding completes.", result.Frames, result.OutputPath),
 	})
+}
+
+// validateOutputPath checks that an output path is safe to write to:
+// absolute, supported extension, parent dir exists and is not a symlink,
+// target and temp file do not already exist.
+func validateOutputPath(path string) error {
+	cleaned := filepath.Clean(path)
+	if !filepath.IsAbs(cleaned) {
+		return fmt.Errorf("outputPath must be an absolute path, got %q", path)
+	}
+	ext := filepath.Ext(cleaned)
+	switch ext {
+	case ".gif", ".webm", ".mp4":
+	default:
+		return fmt.Errorf("unsupported extension %q — use .gif, .webm, or .mp4", ext)
+	}
+
+	dir := filepath.Dir(cleaned)
+	dirInfo, err := os.Lstat(dir)
+	if err != nil {
+		return fmt.Errorf("output directory: %w", err)
+	}
+	if dirInfo.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("output directory %q is a symlink", dir)
+	}
+	if !dirInfo.IsDir() {
+		return fmt.Errorf("output directory %q is not a directory", dir)
+	}
+
+	if info, err := os.Lstat(cleaned); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("refusing to follow symlink at %q", cleaned)
+		}
+		return fmt.Errorf("file already exists at %q — remove it first or choose another path", cleaned)
+	}
+
+	tmpPath := cleaned + ".encoding.tmp"
+	if _, err := os.Lstat(tmpPath); err == nil {
+		return fmt.Errorf("temp file already exists at %q — a previous encoding may still be running", tmpPath)
+	}
+
+	return nil
 }
 
 // HandleRecordStatus returns the current recording status.

--- a/internal/handlers/record.go
+++ b/internal/handlers/record.go
@@ -1,0 +1,383 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"image"
+	"image/color/palette"
+	"image/draw"
+	"image/gif"
+	"image/jpeg"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/pinchtab/pinchtab/internal/httpx"
+)
+
+type RecordingStatus struct {
+	Active   bool    `json:"active"`
+	Format   string  `json:"format,omitempty"`
+	Duration float64 `json:"durationSeconds,omitempty"`
+	Frames   int     `json:"frames"`
+	TabID    string  `json:"tabId,omitempty"`
+	FPS      int     `json:"fps,omitempty"`
+}
+
+type recorder struct {
+	mu        sync.Mutex
+	active    bool
+	tabCtx    context.Context
+	tabID     string
+	format    string
+	fps       int
+	quality   int
+	scale     float64
+	tmpDir    string
+	frameNum  int
+	startTime time.Time
+	stopCh    chan struct{}
+	doneCh    chan struct{}
+}
+
+func (rec *recorder) start(tabCtx context.Context, tabID, format string, fps, quality int, scale float64) error {
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+
+	if rec.active {
+		return fmt.Errorf("recording already in progress")
+	}
+
+	tmpDir, err := os.MkdirTemp("", "pinchtab-recording-*")
+	if err != nil {
+		return fmt.Errorf("create temp dir: %w", err)
+	}
+
+	rec.active = true
+	rec.tabCtx = tabCtx
+	rec.tabID = tabID
+	rec.format = format
+	rec.fps = fps
+	rec.quality = quality
+	rec.scale = scale
+	rec.tmpDir = tmpDir
+	rec.frameNum = 0
+	rec.startTime = time.Now()
+	rec.stopCh = make(chan struct{})
+	rec.doneCh = make(chan struct{})
+
+	go rec.captureLoop()
+	return nil
+}
+
+func (rec *recorder) stop() ([]byte, string, error) {
+	rec.mu.Lock()
+	if !rec.active {
+		rec.mu.Unlock()
+		return nil, "", fmt.Errorf("no active recording")
+	}
+	close(rec.stopCh)
+	rec.mu.Unlock()
+
+	<-rec.doneCh
+
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+
+	defer func() {
+		_ = os.RemoveAll(rec.tmpDir)
+		rec.active = false
+		rec.tmpDir = ""
+	}()
+
+	if rec.frameNum == 0 {
+		return nil, "", fmt.Errorf("no frames captured")
+	}
+
+	data, err := rec.encode()
+	if err != nil {
+		return nil, "", err
+	}
+
+	return data, rec.format, nil
+}
+
+func (rec *recorder) status() RecordingStatus {
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+
+	if !rec.active {
+		return RecordingStatus{}
+	}
+	return RecordingStatus{
+		Active:   true,
+		Format:   rec.format,
+		Duration: time.Since(rec.startTime).Seconds(),
+		Frames:   rec.frameNum,
+		TabID:    rec.tabID,
+		FPS:      rec.fps,
+	}
+}
+
+func (rec *recorder) captureLoop() {
+	defer close(rec.doneCh)
+
+	interval := time.Second / time.Duration(rec.fps)
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-rec.stopCh:
+			return
+		case <-rec.tabCtx.Done():
+			return
+		case <-ticker.C:
+			frame, err := captureScreencastJPEG(rec.tabCtx, rec.quality)
+			if err != nil {
+				slog.Debug("recording frame capture failed", "err", err)
+				continue
+			}
+			rec.mu.Lock()
+			rec.frameNum++
+			path := filepath.Join(rec.tmpDir, fmt.Sprintf("frame_%06d.jpg", rec.frameNum))
+			rec.mu.Unlock()
+			if err := os.WriteFile(path, frame, 0600); err != nil {
+				slog.Debug("recording frame write failed", "err", err)
+			}
+		}
+	}
+}
+
+func (rec *recorder) encode() ([]byte, error) {
+	switch rec.format {
+	case "gif":
+		return rec.encodeGIF()
+	case "webm":
+		return rec.encodeFFmpeg("libvpx", "-crf", "10", "-b:v", "1M")
+	case "mp4":
+		return rec.encodeFFmpeg("libx264", "-pix_fmt", "yuv420p", "-crf", "23")
+	default:
+		return nil, fmt.Errorf("unsupported format: %s", rec.format)
+	}
+}
+
+func (rec *recorder) encodeGIF() ([]byte, error) {
+	files, err := filepath.Glob(filepath.Join(rec.tmpDir, "frame_*.jpg"))
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(files)
+
+	delay := 100 / rec.fps
+	if delay < 1 {
+		delay = 1
+	}
+
+	g := &gif.GIF{LoopCount: 0}
+
+	for _, f := range files {
+		data, err := os.ReadFile(f)
+		if err != nil {
+			continue
+		}
+		img, err := jpeg.Decode(bytes.NewReader(data))
+		if err != nil {
+			continue
+		}
+
+		if rec.scale != 1.0 && rec.scale > 0 {
+			img = scaleImage(img, rec.scale)
+		}
+
+		bounds := img.Bounds()
+		paletted := image.NewPaletted(bounds, palette.Plan9)
+		draw.FloydSteinberg.Draw(paletted, bounds, img, bounds.Min)
+		g.Image = append(g.Image, paletted)
+		g.Delay = append(g.Delay, delay)
+	}
+
+	if len(g.Image) == 0 {
+		return nil, fmt.Errorf("no frames to encode")
+	}
+
+	var buf bytes.Buffer
+	if err := gif.EncodeAll(&buf, g); err != nil {
+		return nil, fmt.Errorf("gif encode: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+func (rec *recorder) encodeFFmpeg(codec string, extraArgs ...string) ([]byte, error) {
+	outFile := filepath.Join(rec.tmpDir, "output."+rec.format)
+
+	args := []string{
+		"-y",
+		"-framerate", strconv.Itoa(rec.fps),
+		"-i", filepath.Join(rec.tmpDir, "frame_%06d.jpg"),
+	}
+
+	if rec.scale != 1.0 && rec.scale > 0 {
+		args = append(args, "-vf",
+			fmt.Sprintf("scale=trunc(iw*%g/2)*2:trunc(ih*%g/2)*2", rec.scale, rec.scale))
+	}
+
+	args = append(args, "-c:v", codec)
+	args = append(args, extraArgs...)
+	args = append(args, outFile)
+
+	cmd := exec.Command("ffmpeg", args...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("ffmpeg encode: %w\n%s", err, stderr.String())
+	}
+	return os.ReadFile(outFile)
+}
+
+func scaleImage(src image.Image, scale float64) image.Image {
+	bounds := src.Bounds()
+	w := int(float64(bounds.Dx()) * scale)
+	h := int(float64(bounds.Dy()) * scale)
+	if w < 1 {
+		w = 1
+	}
+	if h < 1 {
+		h = 1
+	}
+	dst := image.NewRGBA(image.Rect(0, 0, w, h))
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			srcX := bounds.Min.X + int(float64(x)/scale)
+			srcY := bounds.Min.Y + int(float64(y)/scale)
+			if srcX >= bounds.Max.X {
+				srcX = bounds.Max.X - 1
+			}
+			if srcY >= bounds.Max.Y {
+				srcY = bounds.Max.Y - 1
+			}
+			dst.Set(x, y, src.At(srcX, srcY))
+		}
+	}
+	return dst
+}
+
+func ffmpegAvailable() bool {
+	_, err := exec.LookPath("ffmpeg")
+	return err == nil
+}
+
+// HandleRecordStart starts a recording session for a tab.
+func (h *Handlers) HandleRecordStart(w http.ResponseWriter, r *http.Request) {
+	if !h.Config.AllowScreencast {
+		httpx.ErrorCode(w, 403, "recording_disabled",
+			httpx.DisabledEndpointMessage("recording", "security.allowScreencast"), false,
+			map[string]any{"setting": "security.allowScreencast"})
+		return
+	}
+
+	if !h.ensureChromeOrRespond(w) {
+		return
+	}
+
+	var req struct {
+		TabID   string  `json:"tabId"`
+		Format  string  `json:"format"`
+		FPS     int     `json:"fps"`
+		Quality int     `json:"quality"`
+		Scale   float64 `json:"scale"`
+	}
+	if err := httpx.DecodeJSONBody(w, r, 0, &req); err != nil {
+		httpx.Error(w, httpx.StatusForJSONDecodeError(err), err)
+		return
+	}
+
+	if req.Format == "" {
+		req.Format = "gif"
+	}
+	if req.FPS <= 0 {
+		req.FPS = 5
+	}
+	if req.FPS > 30 {
+		req.FPS = 30
+	}
+	if req.Quality <= 0 {
+		req.Quality = 80
+	}
+	if req.Scale <= 0 {
+		req.Scale = 1.0
+	}
+
+	switch req.Format {
+	case "gif":
+	case "webm", "mp4":
+		if !ffmpegAvailable() {
+			httpx.ErrorCode(w, 400, "ffmpeg_required",
+				fmt.Sprintf("recording to .%s requires ffmpeg; install it or use .gif", req.Format),
+				false, nil)
+			return
+		}
+	default:
+		httpx.ErrorCode(w, 400, "invalid_format",
+			"supported formats: gif, webm, mp4", false, nil)
+		return
+	}
+
+	ctx, resolvedTabID, err := h.tabContext(r, req.TabID)
+	if err != nil {
+		httpx.Problem(w, http.StatusNotFound, "tab_not_found", "tab not found", false, nil)
+		return
+	}
+
+	if err := h.recorder.start(ctx, resolvedTabID, req.Format, req.FPS, req.Quality, req.Scale); err != nil {
+		httpx.ErrorCode(w, 409, "recording_error", err.Error(), false, nil)
+		return
+	}
+
+	slog.Info("recording started", "tab", resolvedTabID, "format", req.Format, "fps", req.FPS)
+	httpx.JSON(w, 200, map[string]any{
+		"status":  "recording",
+		"format":  req.Format,
+		"fps":     req.FPS,
+		"quality": req.Quality,
+		"tabId":   resolvedTabID,
+	})
+}
+
+// HandleRecordStop stops the active recording and returns the encoded file.
+func (h *Handlers) HandleRecordStop(w http.ResponseWriter, r *http.Request) {
+	data, format, err := h.recorder.stop()
+	if err != nil {
+		httpx.ErrorCode(w, 400, "recording_error", err.Error(), false, nil)
+		return
+	}
+
+	contentType := "application/octet-stream"
+	switch format {
+	case "gif":
+		contentType = "image/gif"
+	case "webm":
+		contentType = "video/webm"
+	case "mp4":
+		contentType = "video/mp4"
+	}
+
+	slog.Info("recording stopped", "format", format, "size", len(data))
+	w.Header().Set("Content-Type", contentType)
+	w.Header().Set("Content-Length", strconv.Itoa(len(data)))
+	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=recording.%s", format))
+	w.WriteHeader(200)
+	_, _ = w.Write(data)
+}
+
+// HandleRecordStatus returns the current recording status.
+func (h *Handlers) HandleRecordStatus(w http.ResponseWriter, r *http.Request) {
+	httpx.JSON(w, 200, h.recorder.status())
+}

--- a/internal/handlers/record_test.go
+++ b/internal/handlers/record_test.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http/httptest"
 	"testing"
@@ -80,36 +81,26 @@ func TestHandleRecordStart_Success(t *testing.T) {
 	if resp["tabId"] == nil || resp["tabId"] == "" {
 		t.Errorf("expected tabId to be set, got %v", resp["tabId"])
 	}
-
-	// Clean up: stop the recording (ignore error since no frames captured)
-	_, _, _ = h.recorder.stop()
 }
 
-func TestHandleRecordStart_AlreadyRecording(t *testing.T) {
-	cfg := &config.RuntimeConfig{AllowScreencast: true}
-	h := New(&mockBridge{}, cfg, nil, nil, nil)
+func TestRecorderStart_AlreadyRecording(t *testing.T) {
+	rec := &recorder{}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
-	// First start: should succeed
-	body := `{"format":"gif","fps":5}`
-	req := httptest.NewRequest("POST", "/record/start", bytes.NewReader([]byte(body)))
-	w := httptest.NewRecorder()
-	h.HandleRecordStart(w, req)
-
-	if w.Code != 200 {
-		t.Fatalf("first start: expected 200, got %d: %s", w.Code, w.Body.String())
+	if err := rec.start(ctx, "tab1", "", "gif", 5, 80, 1.0); err != nil {
+		t.Fatalf("first start: %v", err)
 	}
 
-	// Second start: should return 409
-	req = httptest.NewRequest("POST", "/record/start", bytes.NewReader([]byte(body)))
-	w = httptest.NewRecorder()
-	h.HandleRecordStart(w, req)
-
-	if w.Code != 409 {
-		t.Errorf("expected 409 for already recording, got %d: %s", w.Code, w.Body.String())
+	err := rec.start(ctx, "tab1", "", "gif", 5, 80, 1.0)
+	if err == nil {
+		t.Fatal("second start should fail")
+	}
+	if err.Error() != "recording already in progress" {
+		t.Errorf("unexpected error: %v", err)
 	}
 
-	// Clean up: stop the recording (ignore error since no frames captured)
-	_, _, _ = h.recorder.stop()
+	_, _, _ = rec.stop("")
 }
 
 func TestHandleRecordStop_NoRecording(t *testing.T) {
@@ -146,48 +137,105 @@ func TestHandleRecordStatus_Inactive(t *testing.T) {
 	}
 }
 
-func TestHandleRecordStatus_Active(t *testing.T) {
+func TestRecorderStatus_Active(t *testing.T) {
+	rec := &recorder{}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := rec.start(ctx, "tab1", "", "gif", 5, 80, 1.0); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	status := rec.status()
+	if !status.Active {
+		t.Errorf("expected active=true, got false")
+	}
+	if status.Format != "gif" {
+		t.Errorf("expected format=gif, got %q", status.Format)
+	}
+	if status.FPS != 5 {
+		t.Errorf("expected fps=5, got %d", status.FPS)
+	}
+	if status.TabID != "tab1" {
+		t.Errorf("expected tabId=tab1, got %q", status.TabID)
+	}
+
+	_, _, _ = rec.stop("")
+}
+
+func TestHandleRecordStart_ClampsInputs(t *testing.T) {
 	cfg := &config.RuntimeConfig{AllowScreencast: true}
 	h := New(&mockBridge{}, cfg, nil, nil, nil)
 
-	// Start a recording first
-	body := `{"format":"gif","fps":5}`
+	body := `{"format":"gif","fps":60,"quality":200,"scale":3.0}`
 	req := httptest.NewRequest("POST", "/record/start", bytes.NewReader([]byte(body)))
 	w := httptest.NewRecorder()
 	h.HandleRecordStart(w, req)
 
 	if w.Code != 200 {
-		t.Fatalf("start: expected 200, got %d: %s", w.Code, w.Body.String())
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}
 
-	// Check status
-	req = httptest.NewRequest("GET", "/record/status", nil)
-	w = httptest.NewRecorder()
-	h.HandleRecordStatus(w, req)
-
-	if w.Code != 200 {
-		t.Fatalf("status: expected 200, got %d", w.Code)
-	}
-
-	var resp RecordingStatus
+	var resp map[string]any
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode response: %v", err)
+		t.Fatalf("decode: %v", err)
 	}
-	if !resp.Active {
-		t.Errorf("expected active=true, got false")
+	if resp["fps"] != float64(maxFPS) {
+		t.Errorf("expected fps clamped to %d, got %v", maxFPS, resp["fps"])
 	}
-	if resp.Format != "gif" {
-		t.Errorf("expected format=gif, got %q", resp.Format)
+	if resp["quality"] != float64(maxQuality) {
+		t.Errorf("expected quality clamped to %d, got %v", maxQuality, resp["quality"])
 	}
-	if resp.FPS != 5 {
-		t.Errorf("expected fps=5, got %d", resp.FPS)
+}
+
+func TestRecorderStop_OwnerMismatch(t *testing.T) {
+	rec := &recorder{}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := rec.start(ctx, "tab1", "agent-1", "gif", 5, 80, 1.0); err != nil {
+		t.Fatal(err)
 	}
 
-	// Clean up: stop the recording (ignore error since no frames captured)
-	_, _, _ = h.recorder.stop()
+	_, _, err := rec.stop("agent-2")
+	if err == nil || err.Error() != "recording owned by another session" {
+		t.Errorf("expected owner mismatch error, got %v", err)
+	}
+
+	_, _, _ = rec.stop("agent-1")
+}
+
+func TestRecorderStop_OwnerMatch(t *testing.T) {
+	rec := &recorder{}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := rec.start(ctx, "tab1", "agent-1", "gif", 5, 80, 1.0); err != nil {
+		t.Fatal(err)
+	}
+
+	// Gets past owner check; fails with "no frames captured" which is expected
+	_, _, err := rec.stop("agent-1")
+	if err == nil || err.Error() != "no frames captured" {
+		t.Errorf("expected 'no frames captured' error, got %v", err)
+	}
+}
+
+func TestRecorderStop_NoOwnerCanStopAnonymous(t *testing.T) {
+	rec := &recorder{}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := rec.start(ctx, "tab1", "", "gif", 5, 80, 1.0); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err := rec.stop("any-agent")
+	if err == nil || err.Error() != "no frames captured" {
+		t.Errorf("expected 'no frames captured', got %v", err)
+	}
 }
 
 func TestFFmpegAvailable(t *testing.T) {
-	// Just verify it doesn't panic; result depends on environment.
 	_ = ffmpegAvailable()
 }

--- a/internal/handlers/record_test.go
+++ b/internal/handlers/record_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/pinchtab/pinchtab/internal/config"
 )
@@ -135,6 +136,9 @@ func TestHandleRecordStatus_Inactive(t *testing.T) {
 	if resp.Active {
 		t.Errorf("expected active=false, got true")
 	}
+	if resp.State != "idle" {
+		t.Errorf("expected state=idle, got %q", resp.State)
+	}
 }
 
 func TestRecorderStatus_Active(t *testing.T) {
@@ -149,6 +153,9 @@ func TestRecorderStatus_Active(t *testing.T) {
 	status := rec.status()
 	if !status.Active {
 		t.Errorf("expected active=true, got false")
+	}
+	if status.State != "recording" {
+		t.Errorf("expected state=recording, got %q", status.State)
 	}
 	if status.Format != "gif" {
 		t.Errorf("expected format=gif, got %q", status.Format)
@@ -238,4 +245,69 @@ func TestRecorderStop_NoOwnerCanStopAnonymous(t *testing.T) {
 
 func TestFFmpegAvailable(t *testing.T) {
 	_ = ffmpegAvailable()
+}
+
+func TestRecorderStateString(t *testing.T) {
+	tests := []struct {
+		state recorderState
+		want  string
+	}{
+		{stateIdle, "idle"},
+		{stateRecording, "recording"},
+		{stateLimitReached, "limit_reached"},
+		{stateStopping, "stopping"},
+		{stateEncoding, "encoding"},
+		{stateFinished, "finished"},
+		{stateAborted, "aborted"},
+		{recorderState(99), "unknown"},
+	}
+	for _, tt := range tests {
+		if got := tt.state.String(); got != tt.want {
+			t.Errorf("recorderState(%d).String() = %q, want %q", tt.state, got, tt.want)
+		}
+	}
+}
+
+func TestRecorderStatus_Aborted(t *testing.T) {
+	rec := &recorder{}
+	ctx, cancel := context.WithCancel(context.Background())
+
+	if err := rec.start(ctx, "tab1", "", "gif", 5, 80, 1.0); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	cancel()
+	// Wait for capture loop to detect cancellation and transition to aborted.
+	time.Sleep(100 * time.Millisecond)
+
+	status := rec.status()
+	if status.Active {
+		t.Errorf("expected active=false after abort")
+	}
+	if status.State != "aborted" {
+		t.Errorf("expected state=aborted, got %q", status.State)
+	}
+	if status.StopReason != "tab_closed" {
+		t.Errorf("expected stopReason=tab_closed, got %q", status.StopReason)
+	}
+}
+
+func TestRecorderStatus_IdleAfterStop(t *testing.T) {
+	rec := &recorder{}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := rec.start(ctx, "tab1", "", "gif", 5, 80, 1.0); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	_, _, _ = rec.stop("")
+
+	status := rec.status()
+	if status.Active {
+		t.Errorf("expected active=false after stop")
+	}
+	if status.State != "idle" {
+		t.Errorf("expected state=idle after stop+cleanup, got %q", status.State)
+	}
 }

--- a/internal/handlers/record_test.go
+++ b/internal/handlers/record_test.go
@@ -101,7 +101,7 @@ func TestRecorderStart_AlreadyRecording(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	_, _, _ = rec.stop("")
+	_, _ = rec.stop("", "")
 }
 
 func TestHandleRecordStop_NoRecording(t *testing.T) {
@@ -167,7 +167,7 @@ func TestRecorderStatus_Active(t *testing.T) {
 		t.Errorf("expected tabId=tab1, got %q", status.TabID)
 	}
 
-	_, _, _ = rec.stop("")
+	_, _ = rec.stop("", "")
 }
 
 func TestHandleRecordStart_ClampsInputs(t *testing.T) {
@@ -204,12 +204,12 @@ func TestRecorderStop_OwnerMismatch(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, _, err := rec.stop("agent-2")
+	_, err := rec.stop("agent-2", "")
 	if err == nil || err.Error() != "recording owned by another session" {
 		t.Errorf("expected owner mismatch error, got %v", err)
 	}
 
-	_, _, _ = rec.stop("agent-1")
+	_, _ = rec.stop("agent-1", "")
 }
 
 func TestRecorderStop_OwnerMatch(t *testing.T) {
@@ -222,7 +222,7 @@ func TestRecorderStop_OwnerMatch(t *testing.T) {
 	}
 
 	// Gets past owner check; fails with "no frames captured" which is expected
-	_, _, err := rec.stop("agent-1")
+	_, err := rec.stop("agent-1", "")
 	if err == nil || err.Error() != "no frames captured" {
 		t.Errorf("expected 'no frames captured' error, got %v", err)
 	}
@@ -237,7 +237,7 @@ func TestRecorderStop_NoOwnerCanStopAnonymous(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, _, err := rec.stop("any-agent")
+	_, err := rec.stop("any-agent", "")
 	if err == nil || err.Error() != "no frames captured" {
 		t.Errorf("expected 'no frames captured', got %v", err)
 	}
@@ -301,7 +301,7 @@ func TestRecorderStatus_IdleAfterStop(t *testing.T) {
 		t.Fatalf("start: %v", err)
 	}
 
-	_, _, _ = rec.stop("")
+	_, _ = rec.stop("", "")
 
 	status := rec.status()
 	if status.Active {

--- a/internal/handlers/record_test.go
+++ b/internal/handlers/record_test.go
@@ -1,0 +1,193 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/pinchtab/pinchtab/internal/config"
+)
+
+func TestHandleRecordStart_Disabled(t *testing.T) {
+	cfg := &config.RuntimeConfig{AllowScreencast: false}
+	h := New(&mockBridge{}, cfg, nil, nil, nil)
+
+	body := `{"format":"gif","fps":5}`
+	req := httptest.NewRequest("POST", "/record/start", bytes.NewReader([]byte(body)))
+	w := httptest.NewRecorder()
+	h.HandleRecordStart(w, req)
+
+	if w.Code != 403 {
+		t.Errorf("expected 403 when recording disabled, got %d", w.Code)
+	}
+}
+
+func TestHandleRecordStart_InvalidFormat(t *testing.T) {
+	cfg := &config.RuntimeConfig{AllowScreencast: true}
+	h := New(&mockBridge{}, cfg, nil, nil, nil)
+
+	body := `{"format":"avi","fps":5}`
+	req := httptest.NewRequest("POST", "/record/start", bytes.NewReader([]byte(body)))
+	w := httptest.NewRecorder()
+	h.HandleRecordStart(w, req)
+
+	if w.Code != 400 {
+		t.Errorf("expected 400 for invalid format, got %d", w.Code)
+	}
+}
+
+func TestHandleRecordStart_TabNotFound(t *testing.T) {
+	cfg := &config.RuntimeConfig{AllowScreencast: true}
+	h := New(&mockBridge{failTab: true}, cfg, nil, nil, nil)
+
+	body := `{"format":"gif","fps":5,"tabId":"missing"}`
+	req := httptest.NewRequest("POST", "/record/start", bytes.NewReader([]byte(body)))
+	w := httptest.NewRecorder()
+	h.HandleRecordStart(w, req)
+
+	if w.Code != 404 {
+		t.Errorf("expected 404 for missing tab, got %d", w.Code)
+	}
+}
+
+func TestHandleRecordStart_Success(t *testing.T) {
+	cfg := &config.RuntimeConfig{AllowScreencast: true}
+	h := New(&mockBridge{}, cfg, nil, nil, nil)
+
+	body := `{"format":"gif","fps":5}`
+	req := httptest.NewRequest("POST", "/record/start", bytes.NewReader([]byte(body)))
+	w := httptest.NewRecorder()
+	h.HandleRecordStart(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp["status"] != "recording" {
+		t.Errorf("expected status=recording, got %v", resp["status"])
+	}
+	if resp["format"] != "gif" {
+		t.Errorf("expected format=gif, got %v", resp["format"])
+	}
+	if resp["fps"] != float64(5) {
+		t.Errorf("expected fps=5, got %v", resp["fps"])
+	}
+	if resp["tabId"] == nil || resp["tabId"] == "" {
+		t.Errorf("expected tabId to be set, got %v", resp["tabId"])
+	}
+
+	// Clean up: stop the recording (ignore error since no frames captured)
+	_, _, _ = h.recorder.stop()
+}
+
+func TestHandleRecordStart_AlreadyRecording(t *testing.T) {
+	cfg := &config.RuntimeConfig{AllowScreencast: true}
+	h := New(&mockBridge{}, cfg, nil, nil, nil)
+
+	// First start: should succeed
+	body := `{"format":"gif","fps":5}`
+	req := httptest.NewRequest("POST", "/record/start", bytes.NewReader([]byte(body)))
+	w := httptest.NewRecorder()
+	h.HandleRecordStart(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("first start: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Second start: should return 409
+	req = httptest.NewRequest("POST", "/record/start", bytes.NewReader([]byte(body)))
+	w = httptest.NewRecorder()
+	h.HandleRecordStart(w, req)
+
+	if w.Code != 409 {
+		t.Errorf("expected 409 for already recording, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Clean up: stop the recording (ignore error since no frames captured)
+	_, _, _ = h.recorder.stop()
+}
+
+func TestHandleRecordStop_NoRecording(t *testing.T) {
+	cfg := &config.RuntimeConfig{}
+	h := New(&mockBridge{}, cfg, nil, nil, nil)
+
+	req := httptest.NewRequest("POST", "/record/stop", nil)
+	w := httptest.NewRecorder()
+	h.HandleRecordStop(w, req)
+
+	if w.Code != 400 {
+		t.Errorf("expected 400 when no recording active, got %d", w.Code)
+	}
+}
+
+func TestHandleRecordStatus_Inactive(t *testing.T) {
+	cfg := &config.RuntimeConfig{}
+	h := New(&mockBridge{}, cfg, nil, nil, nil)
+
+	req := httptest.NewRequest("GET", "/record/status", nil)
+	w := httptest.NewRecorder()
+	h.HandleRecordStatus(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp RecordingStatus
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Active {
+		t.Errorf("expected active=false, got true")
+	}
+}
+
+func TestHandleRecordStatus_Active(t *testing.T) {
+	cfg := &config.RuntimeConfig{AllowScreencast: true}
+	h := New(&mockBridge{}, cfg, nil, nil, nil)
+
+	// Start a recording first
+	body := `{"format":"gif","fps":5}`
+	req := httptest.NewRequest("POST", "/record/start", bytes.NewReader([]byte(body)))
+	w := httptest.NewRecorder()
+	h.HandleRecordStart(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("start: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Check status
+	req = httptest.NewRequest("GET", "/record/status", nil)
+	w = httptest.NewRecorder()
+	h.HandleRecordStatus(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("status: expected 200, got %d", w.Code)
+	}
+
+	var resp RecordingStatus
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !resp.Active {
+		t.Errorf("expected active=true, got false")
+	}
+	if resp.Format != "gif" {
+		t.Errorf("expected format=gif, got %q", resp.Format)
+	}
+	if resp.FPS != 5 {
+		t.Errorf("expected fps=5, got %d", resp.FPS)
+	}
+
+	// Clean up: stop the recording (ignore error since no frames captured)
+	_, _, _ = h.recorder.stop()
+}
+
+func TestFFmpegAvailable(t *testing.T) {
+	// Just verify it doesn't panic; result depends on environment.
+	_ = ffmpegAvailable()
+}

--- a/internal/handlers/security.go
+++ b/internal/handlers/security.go
@@ -51,7 +51,7 @@ func (h *Handlers) endpointSecurityStates() map[string]endpointSecurityState {
 			Enabled: h.screencastEnabled(),
 			Setting: "security.allowScreencast",
 			Message: httpx.DisabledEndpointMessage("screencast", "security.allowScreencast"),
-			Paths:   []string{"GET /screencast", "GET /screencast/tabs", "GET /instances/{id}/screencast", "GET /instances/{id}/proxy/screencast"},
+			Paths:   []string{"GET /screencast", "GET /screencast/tabs", "POST /record/start", "POST /record/stop", "GET /record/status", "GET /instances/{id}/screencast", "GET /instances/{id}/proxy/screencast"},
 		},
 		"download": {
 			Enabled: h.downloadEnabled(),

--- a/internal/httpx/endpointlock.go
+++ b/internal/httpx/endpointlock.go
@@ -15,6 +15,8 @@ func DisabledEndpointHandler(feature, setting, code string) http.HandlerFunc {
 	return func(w http.ResponseWriter, _ *http.Request) {
 		ErrorCode(w, http.StatusForbidden, code, DisabledEndpointMessage(feature, setting), false, map[string]any{
 			"setting": setting,
+			"hint":    fmt.Sprintf("Enable %s to use this feature.", setting),
+			"remedy":  fmt.Sprintf("pinchtab config set %s true", setting),
 		})
 	}
 }

--- a/internal/httpx/endpointlock_test.go
+++ b/internal/httpx/endpointlock_test.go
@@ -1,0 +1,46 @@
+package httpx
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestDisabledEndpointHandlerIncludesHintAndRemedy(t *testing.T) {
+	handler := DisabledEndpointHandler("recording", "security.allowScreencast", "recording_disabled")
+
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest("POST", "/record/start", nil)
+	handler(w, r)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusForbidden)
+	}
+
+	var resp struct {
+		Error   string         `json:"error"`
+		Code    string         `json:"code"`
+		Details map[string]any `json:"details"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+
+	if resp.Code != "recording_disabled" {
+		t.Fatalf("code = %q, want recording_disabled", resp.Code)
+	}
+
+	hint, _ := resp.Details["hint"].(string)
+	remedy, _ := resp.Details["remedy"].(string)
+
+	if hint == "" {
+		t.Fatal("expected non-empty hint in details")
+	}
+	if remedy == "" {
+		t.Fatal("expected non-empty remedy in details")
+	}
+	if remedy != "pinchtab config set security.allowScreencast true" {
+		t.Fatalf("remedy = %q, want config set command", remedy)
+	}
+}

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -90,6 +90,37 @@ func (c *Client) Delete(ctx context.Context, path string, query url.Values) ([]b
 	return c.do(req)
 }
 
+// PostStream performs a POST request and returns the response body as a
+// ReadCloser so the caller can stream large responses directly to disk.
+// The caller must close the returned body.
+func (c *Client) PostStream(ctx context.Context, path string, payload any) (io.ReadCloser, int, error) {
+	var body io.Reader
+	if payload != nil {
+		b, err := json.Marshal(payload)
+		if err != nil {
+			return nil, 0, fmt.Errorf("marshal payload: %w", err)
+		}
+		body = bytes.NewReader(b)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.url(path), body)
+	if err != nil {
+		return nil, 0, err
+	}
+	if payload != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if c.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.Token)
+	}
+	req.Header.Set(activity.HeaderAgentID, "mcp")
+	req.Header.Set(activity.HeaderPTSource, "mcp")
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, 0, fmt.Errorf("request %s %s: %w", req.Method, req.URL.Path, err)
+	}
+	return resp.Body, resp.StatusCode, nil
+}
+
 // Post performs a POST request with a JSON body.
 func (c *Client) Post(ctx context.Context, path string, payload any) ([]byte, int, error) {
 	var body io.Reader

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -33,6 +33,17 @@ func NewClient(baseURL, token string) *Client {
 	}
 }
 
+// withTimeout returns a shallow copy of the Client whose HTTPClient uses the
+// given timeout. The original Transport is preserved.
+func (c *Client) withTimeout(d time.Duration) *Client {
+	clone := *c
+	clone.HTTPClient = &http.Client{
+		Timeout:   d,
+		Transport: c.HTTPClient.Transport,
+	}
+	return &clone
+}
+
 func (c *Client) url(path string) string {
 	return c.BaseURL + path
 }

--- a/internal/mcp/client_test.go
+++ b/internal/mcp/client_test.go
@@ -123,6 +123,29 @@ func TestClientPostNilPayload(t *testing.T) {
 	}
 }
 
+func TestClientPostStreamReturnsReadableBody(t *testing.T) {
+	payload := strings.Repeat("X", 64*1024) // 64 KB — exceeds the 10 MB LimitReader test boundary
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		_, _ = io.WriteString(w, payload)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "tok")
+	body, code, err := c.PostStream(context.Background(), "/record/stop", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = body.Close() }()
+	if code != 200 {
+		t.Fatalf("code = %d", code)
+	}
+	data, _ := io.ReadAll(body)
+	if len(data) != len(payload) {
+		t.Fatalf("read %d bytes, want %d", len(data), len(payload))
+	}
+}
+
 func TestClientAuthHeaderAbsentWhenNoToken(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if h := r.Header.Get("Authorization"); h != "" {

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -63,6 +63,11 @@ func handlerMap(c *Client) map[string]func(context.Context, mcp.CallToolRequest)
 		"pinchtab_network_route":   handleNetworkRoute(c),
 		"pinchtab_network_unroute": handleNetworkUnroute(c),
 
+		// Recording
+		"pinchtab_record_start":  handleRecordStart(c),
+		"pinchtab_record_stop":   handleRecordStop(c),
+		"pinchtab_record_status": handleRecordStatus(c),
+
 		// Dialog
 		"pinchtab_dialog": handleDialog(c),
 	}

--- a/internal/mcp/handlers_record.go
+++ b/internal/mcp/handlers_record.go
@@ -139,6 +139,9 @@ func safeRecordPath(file string) (string, error) {
 	if dirInfo.Mode()&os.ModeSymlink != 0 {
 		return "", fmt.Errorf("output directory %q is a symlink", dir)
 	}
+	if !dirInfo.IsDir() {
+		return "", fmt.Errorf("output directory %q is not a directory", dir)
+	}
 
 	if info, err := os.Lstat(cleaned); err == nil {
 		if info.Mode()&os.ModeSymlink != 0 {

--- a/internal/mcp/handlers_record.go
+++ b/internal/mcp/handlers_record.go
@@ -1,0 +1,89 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+func handleRecordStart(c *Client) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, r mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		file, err := r.RequireString("file")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		ext := filepath.Ext(file)
+		var format string
+		switch ext {
+		case ".gif":
+			format = "gif"
+		case ".webm":
+			format = "webm"
+		case ".mp4":
+			format = "mp4"
+		default:
+			return mcp.NewToolResultError(fmt.Sprintf("unsupported format %q — use .gif, .webm, or .mp4", ext)), nil
+		}
+
+		payload := map[string]any{"format": format}
+		if fps, ok := optInt(r, "fps"); ok {
+			payload["fps"] = fps
+		}
+		if quality, ok := optInt(r, "quality"); ok {
+			payload["quality"] = quality
+		}
+		if scale, ok := optFloat(r, "scale"); ok {
+			payload["scale"] = scale
+		}
+		if tabID := optString(r, "tabId"); tabID != "" {
+			payload["tabId"] = tabID
+		}
+
+		body, code, err := c.Post(ctx, "/record/start", payload)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		return resultFromBytes(body, code)
+	}
+}
+
+func handleRecordStop(c *Client) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, r mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		file := optString(r, "file")
+		if file == "" {
+			return mcp.NewToolResultError("file parameter is required"), nil
+		}
+
+		body, code, err := c.Post(ctx, "/record/stop", map[string]any{})
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		if code >= 400 {
+			return resultFromBytes(body, code)
+		}
+
+		if err := os.WriteFile(file, body, 0600); err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("write file: %v", err)), nil
+		}
+
+		return jsonResult(map[string]any{
+			"status": "saved",
+			"file":   file,
+			"bytes":  len(body),
+		})
+	}
+}
+
+func handleRecordStatus(c *Client) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, r mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		body, code, err := c.Get(ctx, "/record/status", nil)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		return resultFromBytes(body, code)
+	}
+}

--- a/internal/mcp/handlers_record.go
+++ b/internal/mcp/handlers_record.go
@@ -3,11 +3,16 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 
 	"github.com/mark3labs/mcp-go/mcp"
 )
+
+// maxRecordFileBytes caps the output file written by record_stop to prevent
+// unbounded disk writes (matches the server-side maxOutputBytes).
+const maxRecordFileBytes = 256 << 20 // 256 MiB
 
 func handleRecordStart(c *Client) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	return func(ctx context.Context, r mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -58,24 +63,91 @@ func handleRecordStop(c *Client) func(context.Context, mcp.CallToolRequest) (*mc
 			return mcp.NewToolResultError("file parameter is required"), nil
 		}
 
-		body, code, err := c.Post(ctx, "/record/stop", map[string]any{})
+		dest, err := safeRecordPath(file)
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
 		}
+
+		body, code, err := c.PostStream(ctx, "/record/stop", map[string]any{})
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		defer func() { _ = body.Close() }()
+
 		if code >= 400 {
-			return resultFromBytes(body, code)
+			errBody, _ := io.ReadAll(io.LimitReader(body, 10<<20))
+			return resultFromBytes(errBody, code)
 		}
 
-		if err := os.WriteFile(file, body, 0600); err != nil {
+		n, err := streamToFile(dest, body)
+		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("write file: %v", err)), nil
 		}
 
 		return jsonResult(map[string]any{
 			"status": "saved",
-			"file":   file,
-			"bytes":  len(body),
+			"file":   dest,
+			"bytes":  n,
 		})
 	}
+}
+
+// safeRecordPath validates a recording output path to prevent arbitrary file
+// overwrites. It requires an absolute path with a supported extension, rejects
+// symlinks and path traversal, and refuses to overwrite existing files.
+func safeRecordPath(file string) (string, error) {
+	cleaned := filepath.Clean(file)
+	if !filepath.IsAbs(cleaned) {
+		return "", fmt.Errorf("file must be an absolute path, got %q", file)
+	}
+
+	ext := filepath.Ext(cleaned)
+	switch ext {
+	case ".gif", ".webm", ".mp4":
+	default:
+		return "", fmt.Errorf("unsupported extension %q — use .gif, .webm, or .mp4", ext)
+	}
+
+	dir := filepath.Dir(cleaned)
+	dirInfo, err := os.Lstat(dir)
+	if err != nil {
+		return "", fmt.Errorf("output directory: %w", err)
+	}
+	if dirInfo.Mode()&os.ModeSymlink != 0 {
+		return "", fmt.Errorf("output directory %q is a symlink", dir)
+	}
+
+	if info, err := os.Lstat(cleaned); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return "", fmt.Errorf("refusing to follow symlink at %q", cleaned)
+		}
+		return "", fmt.Errorf("file already exists at %q — remove it first or choose another path", cleaned)
+	}
+
+	return cleaned, nil
+}
+
+// streamToFile writes from r to path using O_CREATE|O_EXCL (no overwrite),
+// capped at maxRecordFileBytes. Returns the number of bytes written.
+func streamToFile(path string, r io.Reader) (int64, error) {
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+	if err != nil {
+		return 0, err
+	}
+
+	n, copyErr := io.Copy(f, io.LimitReader(r, maxRecordFileBytes+1))
+	if closeErr := f.Close(); closeErr != nil && copyErr == nil {
+		copyErr = closeErr
+	}
+	if copyErr != nil {
+		_ = os.Remove(path)
+		return 0, copyErr
+	}
+	if n > maxRecordFileBytes {
+		_ = os.Remove(path)
+		return 0, fmt.Errorf("recording exceeds %d MiB limit", maxRecordFileBytes>>20)
+	}
+	return n, nil
 }
 
 func handleRecordStatus(c *Client) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/internal/mcp/handlers_record.go
+++ b/internal/mcp/handlers_record.go
@@ -2,10 +2,12 @@ package mcp
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
 )
@@ -69,9 +71,7 @@ func handleRecordStop(c *Client) func(context.Context, mcp.CallToolRequest) (*mc
 
 		dest, pathErr := safeRecordPath(file)
 		if pathErr != nil {
-			// Discard the recording: empty outputPath tells the server to
-			// stop capture without encoding.
-			_, _, stopErr := c.Post(ctx, "/record/stop", map[string]any{})
+			_, _, stopErr := c.Post(ctx, "/record/stop", map[string]any{"discard": true})
 			msg := fmt.Sprintf("invalid output path: %v — recording discarded", pathErr)
 			if stopErr != nil {
 				msg += fmt.Sprintf(" (also failed to discard recording: %v)", stopErr)
@@ -79,9 +79,9 @@ func handleRecordStop(c *Client) func(context.Context, mcp.CallToolRequest) (*mc
 			return mcp.NewToolResultError(msg), nil
 		}
 
-		body, code, err := c.Post(ctx, "/record/stop", map[string]any{
-			"outputPath": dest,
-		})
+		// Server encodes to a controlled recordings directory; we move the
+		// file to the caller's desired destination after encoding completes.
+		body, code, err := c.Post(ctx, "/record/stop", map[string]any{})
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
 		}
@@ -89,8 +89,92 @@ func handleRecordStop(c *Client) func(context.Context, mcp.CallToolRequest) (*mc
 			return resultFromBytes(body, code)
 		}
 
-		return resultFromBytes(body, code)
+		var stopResp struct {
+			Path string `json:"path"`
+		}
+		if json.Unmarshal(body, &stopResp) != nil || stopResp.Path == "" {
+			return resultFromBytes(body, code)
+		}
+
+		// Poll until encoding finishes, then move the file.
+		serverPath := stopResp.Path
+		if err := pollRecordingFinished(ctx, c); err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf(
+				"encoding did not complete: %v — partial file may be at %s", err, serverPath)), nil
+		}
+
+		if err := moveFile(serverPath, dest); err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf(
+				"encoded to %s but failed to move to %s: %v", serverPath, dest, err)), nil
+		}
+
+		return mcp.NewToolResultText(fmt.Sprintf(
+			"Recording saved to %s", dest)), nil
 	}
+}
+
+// pollRecordingFinished polls /record/status until state is "finished" or "idle".
+func pollRecordingFinished(ctx context.Context, c *Client) error {
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			body, _, err := c.Get(ctx, "/record/status", nil)
+			if err != nil {
+				continue
+			}
+			var status struct {
+				State string `json:"state"`
+				Error string `json:"error"`
+			}
+			if json.Unmarshal(body, &status) != nil {
+				continue
+			}
+			switch status.State {
+			case "finished":
+				if status.Error != "" {
+					return fmt.Errorf("encode failed: %s", status.Error)
+				}
+				return nil
+			case "idle":
+				return nil
+			}
+		}
+	}
+}
+
+// moveFile moves src to dst using rename (fast, same filesystem) or
+// falls back to copy+remove for cross-filesystem moves. The destination
+// is created with O_EXCL to prevent overwrites or symlink following.
+func moveFile(src, dst string) error {
+	if err := os.Rename(src, dst); err == nil {
+		return nil
+	}
+	// Cross-filesystem: copy with exclusive creation.
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		_ = os.Remove(dst)
+		return err
+	}
+	if err := out.Close(); err != nil {
+		_ = os.Remove(dst)
+		return err
+	}
+	_ = os.Remove(src)
+	return nil
 }
 
 // safeRecordPath validates a recording output path to prevent arbitrary file

--- a/internal/mcp/handlers_record.go
+++ b/internal/mcp/handlers_record.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
 )
@@ -14,10 +13,6 @@ import (
 // maxRecordFileBytes caps the output file written by record_stop to prevent
 // unbounded disk writes (matches the server-side maxOutputBytes).
 const maxRecordFileBytes = 256 << 20 // 256 MiB
-
-// recordStopTimeout matches the server-side encodeTimeout (2m) plus the
-// write-deadline extension (30s), with headroom for network transfer.
-const recordStopTimeout = 3 * time.Minute
 
 func handleRecordStart(c *Client) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	return func(ctx context.Context, r mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -66,8 +61,6 @@ func handleRecordStart(c *Client) func(context.Context, mcp.CallToolRequest) (*m
 }
 
 func handleRecordStop(c *Client) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	long := c.withTimeout(recordStopTimeout)
-
 	return func(ctx context.Context, r mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		file := optString(r, "file")
 		if file == "" {
@@ -76,42 +69,25 @@ func handleRecordStop(c *Client) func(context.Context, mcp.CallToolRequest) (*mc
 
 		dest, pathErr := safeRecordPath(file)
 		if pathErr != nil {
-			// Path is invalid, but a recording may be active server-side.
-			// Stop it so we don't leave it dangling.
-			stopBody, stopCode, stopErr := long.PostStream(ctx, "/record/stop", map[string]any{})
-			if stopErr == nil {
-				_ = stopBody.Close()
-			}
+			_, _, stopErr := c.Post(ctx, "/record/stop", map[string]any{})
 			msg := fmt.Sprintf("invalid output path: %v", pathErr)
 			if stopErr != nil {
 				msg += fmt.Sprintf(" (also failed to stop recording: %v)", stopErr)
-			} else if stopCode >= 400 {
-				msg += fmt.Sprintf(" (recording stop returned HTTP %d)", stopCode)
 			}
 			return mcp.NewToolResultError(msg), nil
 		}
 
-		body, code, err := long.PostStream(ctx, "/record/stop", map[string]any{})
+		body, code, err := c.Post(ctx, "/record/stop", map[string]any{
+			"outputPath": dest,
+		})
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
 		}
-		defer func() { _ = body.Close() }()
-
 		if code >= 400 {
-			errBody, _ := io.ReadAll(io.LimitReader(body, 10<<20))
-			return resultFromBytes(errBody, code)
+			return resultFromBytes(body, code)
 		}
 
-		n, err := streamToFile(dest, body)
-		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("write file: %v", err)), nil
-		}
-
-		return jsonResult(map[string]any{
-			"status": "saved",
-			"file":   dest,
-			"bytes":  n,
-		})
+		return resultFromBytes(body, code)
 	}
 }
 

--- a/internal/mcp/handlers_record.go
+++ b/internal/mcp/handlers_record.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
 )
@@ -13,6 +14,10 @@ import (
 // maxRecordFileBytes caps the output file written by record_stop to prevent
 // unbounded disk writes (matches the server-side maxOutputBytes).
 const maxRecordFileBytes = 256 << 20 // 256 MiB
+
+// recordStopTimeout matches the server-side encodeTimeout (2m) plus the
+// write-deadline extension (30s), with headroom for network transfer.
+const recordStopTimeout = 3 * time.Minute
 
 func handleRecordStart(c *Client) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	return func(ctx context.Context, r mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -32,6 +37,10 @@ func handleRecordStart(c *Client) func(context.Context, mcp.CallToolRequest) (*m
 			format = "mp4"
 		default:
 			return mcp.NewToolResultError(fmt.Sprintf("unsupported format %q — use .gif, .webm, or .mp4", ext)), nil
+		}
+
+		if _, err := safeRecordPath(file); err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("invalid output path: %v", err)), nil
 		}
 
 		payload := map[string]any{"format": format}
@@ -57,18 +66,32 @@ func handleRecordStart(c *Client) func(context.Context, mcp.CallToolRequest) (*m
 }
 
 func handleRecordStop(c *Client) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	long := c.withTimeout(recordStopTimeout)
+
 	return func(ctx context.Context, r mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		file := optString(r, "file")
 		if file == "" {
 			return mcp.NewToolResultError("file parameter is required"), nil
 		}
 
-		dest, err := safeRecordPath(file)
-		if err != nil {
-			return mcp.NewToolResultError(err.Error()), nil
+		dest, pathErr := safeRecordPath(file)
+		if pathErr != nil {
+			// Path is invalid, but a recording may be active server-side.
+			// Stop it so we don't leave it dangling.
+			stopBody, stopCode, stopErr := long.PostStream(ctx, "/record/stop", map[string]any{})
+			if stopErr == nil {
+				_ = stopBody.Close()
+			}
+			msg := fmt.Sprintf("invalid output path: %v", pathErr)
+			if stopErr != nil {
+				msg += fmt.Sprintf(" (also failed to stop recording: %v)", stopErr)
+			} else if stopCode >= 400 {
+				msg += fmt.Sprintf(" (recording stop returned HTTP %d)", stopCode)
+			}
+			return mcp.NewToolResultError(msg), nil
 		}
 
-		body, code, err := c.PostStream(ctx, "/record/stop", map[string]any{})
+		body, code, err := long.PostStream(ctx, "/record/stop", map[string]any{})
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
 		}

--- a/internal/mcp/handlers_record.go
+++ b/internal/mcp/handlers_record.go
@@ -69,10 +69,12 @@ func handleRecordStop(c *Client) func(context.Context, mcp.CallToolRequest) (*mc
 
 		dest, pathErr := safeRecordPath(file)
 		if pathErr != nil {
+			// Discard the recording: empty outputPath tells the server to
+			// stop capture without encoding.
 			_, _, stopErr := c.Post(ctx, "/record/stop", map[string]any{})
-			msg := fmt.Sprintf("invalid output path: %v", pathErr)
+			msg := fmt.Sprintf("invalid output path: %v — recording discarded", pathErr)
 			if stopErr != nil {
-				msg += fmt.Sprintf(" (also failed to stop recording: %v)", stopErr)
+				msg += fmt.Sprintf(" (also failed to discard recording: %v)", stopErr)
 			}
 			return mcp.NewToolResultError(msg), nil
 		}

--- a/internal/mcp/handlers_record_test.go
+++ b/internal/mcp/handlers_record_test.go
@@ -70,6 +70,17 @@ func TestSafeRecordPath_AcceptsValidPath(t *testing.T) {
 	}
 }
 
+func TestSafeRecordPath_RejectsNonDirectoryParent(t *testing.T) {
+	regular := filepath.Join(t.TempDir(), "afile")
+	if err := os.WriteFile(regular, []byte("x"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := safeRecordPath(filepath.Join(regular, "out.gif"))
+	if err == nil || !strings.Contains(err.Error(), "not a directory") {
+		t.Fatalf("expected not-a-directory error, got %v", err)
+	}
+}
+
 func TestStreamToFile_WritesAndCaps(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "out.gif")

--- a/internal/mcp/handlers_record_test.go
+++ b/internal/mcp/handlers_record_test.go
@@ -1,0 +1,95 @@
+package mcp
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSafeRecordPath_RejectsRelativePath(t *testing.T) {
+	_, err := safeRecordPath("relative/output.gif")
+	if err == nil || !strings.Contains(err.Error(), "absolute path") {
+		t.Fatalf("expected absolute path error, got %v", err)
+	}
+}
+
+func TestSafeRecordPath_RejectsBadExtension(t *testing.T) {
+	_, err := safeRecordPath("/tmp/output.txt")
+	if err == nil || !strings.Contains(err.Error(), "unsupported extension") {
+		t.Fatalf("expected extension error, got %v", err)
+	}
+}
+
+func TestSafeRecordPath_RejectsExistingFile(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "existing.gif")
+	if err := os.WriteFile(f, []byte("data"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := safeRecordPath(f)
+	if err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("expected exists error, got %v", err)
+	}
+}
+
+func TestSafeRecordPath_RejectsSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "real.gif")
+	link := filepath.Join(dir, "link.gif")
+	if err := os.WriteFile(target, []byte("data"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	_, err := safeRecordPath(link)
+	if err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("expected symlink error, got %v", err)
+	}
+}
+
+func TestSafeRecordPath_AcceptsValidPath(t *testing.T) {
+	dir := t.TempDir()
+	for _, ext := range []string{".gif", ".webm", ".mp4"} {
+		path := filepath.Join(dir, "out"+ext)
+		got, err := safeRecordPath(path)
+		if err != nil {
+			t.Fatalf("ext %s: unexpected error: %v", ext, err)
+		}
+		if got != path {
+			t.Fatalf("ext %s: got %q, want %q", ext, got, path)
+		}
+	}
+}
+
+func TestStreamToFile_WritesAndCaps(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "out.gif")
+
+	data := strings.NewReader("hello recording data")
+	n, err := streamToFile(path, data)
+	if err != nil {
+		t.Fatalf("streamToFile() error = %v", err)
+	}
+	if n != 20 {
+		t.Fatalf("wrote %d bytes, want 20", n)
+	}
+
+	got, _ := os.ReadFile(path)
+	if string(got) != "hello recording data" {
+		t.Fatalf("file content = %q", got)
+	}
+}
+
+func TestStreamToFile_RefusesOverwrite(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "out.gif")
+	if err := os.WriteFile(path, []byte("existing"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := streamToFile(path, strings.NewReader("new data"))
+	if err == nil {
+		t.Fatal("expected error for existing file")
+	}
+}

--- a/internal/mcp/handlers_record_test.go
+++ b/internal/mcp/handlers_record_test.go
@@ -1,10 +1,18 @@
 package mcp
 
 import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
 )
 
 func TestSafeRecordPath_RejectsRelativePath(t *testing.T) {
@@ -91,5 +99,132 @@ func TestStreamToFile_RefusesOverwrite(t *testing.T) {
 	_, err := streamToFile(path, strings.NewReader("new data"))
 	if err == nil {
 		t.Fatal("expected error for existing file")
+	}
+}
+
+func TestRecordStartRejectsRelativePath(t *testing.T) {
+	srv := mockPinchTab()
+	defer srv.Close()
+
+	r := callTool(t, "pinchtab_record_start", map[string]any{
+		"file": "relative/out.gif",
+	}, srv)
+
+	text := resultText(t, r)
+	if !strings.Contains(text, "absolute path") {
+		t.Fatalf("expected absolute path error, got %q", text)
+	}
+}
+
+func TestRecordStartRejectsExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	existing := filepath.Join(dir, "exists.webm")
+	if err := os.WriteFile(existing, []byte("data"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := mockPinchTab()
+	defer srv.Close()
+
+	r := callTool(t, "pinchtab_record_start", map[string]any{
+		"file": existing,
+	}, srv)
+
+	text := resultText(t, r)
+	if !strings.Contains(text, "already exists") {
+		t.Fatalf("expected exists error, got %q", text)
+	}
+}
+
+func TestRecordStopBadPathStillStopsRecording(t *testing.T) {
+	stopCalled := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/record/stop" && r.Method == http.MethodPost {
+			stopCalled = true
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte("fakedata"))
+			return
+		}
+		w.WriteHeader(200)
+		_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok"})
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "")
+	handlers := handlerMap(c)
+	h := handlers["pinchtab_record_stop"]
+
+	req := mcp.CallToolRequest{}
+	req.Params.Name = "pinchtab_record_stop"
+	req.Params.Arguments = map[string]any{"file": "relative/bad.gif"}
+
+	result, err := h(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+
+	text := resultText(t, result)
+	if !strings.Contains(text, "absolute path") {
+		t.Fatalf("expected path error in result, got %q", text)
+	}
+	if !stopCalled {
+		t.Fatal("expected POST /record/stop to be called even when path is invalid")
+	}
+}
+
+func TestWithTimeoutCreatesIndependentClient(t *testing.T) {
+	c := NewClient("http://localhost:9867", "tok")
+	long := c.withTimeout(5 * time.Minute)
+
+	if long.HTTPClient.Timeout != 5*time.Minute {
+		t.Fatalf("long timeout = %v, want 5m", long.HTTPClient.Timeout)
+	}
+	if c.HTTPClient.Timeout != 120*time.Second {
+		t.Fatalf("original timeout changed to %v", c.HTTPClient.Timeout)
+	}
+	if long.Token != "tok" {
+		t.Fatalf("token not copied: %q", long.Token)
+	}
+	if long.BaseURL != c.BaseURL {
+		t.Fatalf("BaseURL not copied: %q", long.BaseURL)
+	}
+}
+
+func TestRecordStopUsesLongTimeout(t *testing.T) {
+	var gotTimeout time.Duration
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/record/stop" {
+			deadline, ok := r.Context().Deadline()
+			if ok {
+				gotTimeout = time.Until(deadline)
+			}
+			w.WriteHeader(200)
+			_, _ = io.WriteString(w, "videodata")
+			return
+		}
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "")
+	handlers := handlerMap(c)
+	h := handlers["pinchtab_record_stop"]
+
+	dir := t.TempDir()
+	outFile := filepath.Join(dir, "test.gif")
+
+	req := mcp.CallToolRequest{}
+	req.Params.Name = "pinchtab_record_stop"
+	req.Params.Arguments = map[string]any{"file": outFile}
+
+	_, err := h(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+
+	// The http.Client.Timeout sets a context deadline on the request.
+	// With recordStopTimeout=3m, the deadline should be well over 2m.
+	if gotTimeout > 0 && gotTimeout < 2*time.Minute {
+		t.Fatalf("request deadline too short: %v (expected > 2m from 3m client timeout)", gotTimeout)
 	}
 }

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -18,8 +18,8 @@ func TestNewServerRegistersAllTools(t *testing.T) {
 	// The server should have registered all tools.
 	// We verify by checking that NewServer doesn't panic — the panic
 	// in NewServer fires if any tool lacks a handler.
-	if len(tools) != 38 {
-		t.Errorf("expected 38 tools, got %d", len(tools))
+	if len(tools) != 41 {
+		t.Errorf("expected 41 tools, got %d", len(tools))
 	}
 }
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -268,6 +268,23 @@ func allTools() []mcp.Tool {
 			mcp.WithString("pattern", mcp.Description("Pattern to remove (omit to clear all rules)")),
 		),
 
+		// ── Recording ───────────────────────────────────────────────
+		mcp.NewTool("pinchtab_record_start",
+			mcp.WithDescription("Start recording browser activity. Requires security.allowScreencast. GIF works without ffmpeg; WebM/MP4 need ffmpeg."),
+			mcp.WithString("file", mcp.Required(), mcp.Description("Output file path (.gif, .webm, or .mp4)")),
+			mcp.WithNumber("fps", mcp.Description("Frames per second 1-30 (default: 5)")),
+			mcp.WithNumber("quality", mcp.Description("JPEG capture quality 1-100 (default: 80)")),
+			mcp.WithNumber("scale", mcp.Description("Resolution scale 0-1.0 (default: 1.0)")),
+			mcp.WithString("tabId", mcp.Description("Target tab ID")),
+		),
+		mcp.NewTool("pinchtab_record_stop",
+			mcp.WithDescription("Stop recording and save the encoded file. Encoding may take a while for long recordings."),
+			mcp.WithString("file", mcp.Required(), mcp.Description("Output file path (must match the format from record_start)")),
+		),
+		mcp.NewTool("pinchtab_record_status",
+			mcp.WithDescription("Check active recording status (format, fps, duration, frame count)"),
+		),
+
 		// ── Dialog ──────────────────────────────────────────────────
 		mcp.NewTool("pinchtab_dialog",
 			mcp.WithDescription("Handle a JavaScript dialog (alert, confirm, prompt). Accept or dismiss the currently open dialog."),

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -45,6 +45,7 @@ type Orchestrator struct {
 	runner         HostRunner
 	mu             sync.RWMutex
 	client         *http.Client
+	longClient     *http.Client // for routes that can take minutes (e.g. record/stop encoding)
 	childAuthToken string
 	allowEvaluate  bool
 	internalToken  string
@@ -170,6 +171,7 @@ func NewOrchestratorWithRunner(baseDir string, runner HostRunner) *Orchestrator 
 		// - Short timeout (<5s) would break first-request scenarios
 		// See: internal/orchestrator/health.go (monitor), internal/bridge/init.go (InitChrome)
 		client:         &http.Client{Timeout: 60 * time.Second},
+		longClient:     &http.Client{Timeout: 3 * time.Minute},
 		childAuthToken: "",
 		allowEvaluate:  false,
 		internalToken:  generateInternalToken(),

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -45,7 +45,6 @@ type Orchestrator struct {
 	runner         HostRunner
 	mu             sync.RWMutex
 	client         *http.Client
-	longClient     *http.Client // for routes that can take minutes (e.g. record/stop encoding)
 	childAuthToken string
 	allowEvaluate  bool
 	internalToken  string
@@ -171,7 +170,6 @@ func NewOrchestratorWithRunner(baseDir string, runner HostRunner) *Orchestrator 
 		// - Short timeout (<5s) would break first-request scenarios
 		// See: internal/orchestrator/health.go (monitor), internal/bridge/init.go (InitChrome)
 		client:         &http.Client{Timeout: 60 * time.Second},
-		longClient:     &http.Client{Timeout: 3 * time.Minute},
 		childAuthToken: "",
 		allowEvaluate:  false,
 		internalToken:  generateInternalToken(),

--- a/internal/orchestrator/proxy.go
+++ b/internal/orchestrator/proxy.go
@@ -114,10 +114,20 @@ func (o *Orchestrator) proxyToInstance(w http.ResponseWriter, r *http.Request) {
 	o.proxyToURL(w, r, targetURL)
 }
 
+// proxyClientForPath returns the HTTP client to use for the given request path.
+// Encoding-heavy routes like /record/stop get a longer timeout.
+func (o *Orchestrator) proxyClientForPath(path string) *http.Client {
+	if strings.HasSuffix(path, "/record/stop") {
+		return o.longClient
+	}
+	return o.client
+}
+
 // proxyToURL proxies an HTTP request to the given target URL.
 func (o *Orchestrator) proxyToURL(w http.ResponseWriter, r *http.Request, targetURL *url.URL) {
+	client := o.proxyClientForPath(r.URL.Path)
 	iproxy.Forward(w, r, targetURL, iproxy.Options{
-		Client: o.client,
+		Client: client,
 		AllowedURL: func(u *url.URL) bool {
 			return o.proxyTargetInstance(u) != nil
 		},

--- a/internal/orchestrator/proxy.go
+++ b/internal/orchestrator/proxy.go
@@ -114,20 +114,10 @@ func (o *Orchestrator) proxyToInstance(w http.ResponseWriter, r *http.Request) {
 	o.proxyToURL(w, r, targetURL)
 }
 
-// proxyClientForPath returns the HTTP client to use for the given request path.
-// Encoding-heavy routes like /record/stop get a longer timeout.
-func (o *Orchestrator) proxyClientForPath(path string) *http.Client {
-	if strings.HasSuffix(path, "/record/stop") {
-		return o.longClient
-	}
-	return o.client
-}
-
 // proxyToURL proxies an HTTP request to the given target URL.
 func (o *Orchestrator) proxyToURL(w http.ResponseWriter, r *http.Request, targetURL *url.URL) {
-	client := o.proxyClientForPath(r.URL.Path)
 	iproxy.Forward(w, r, targetURL, iproxy.Options{
-		Client: client,
+		Client: o.client,
 		AllowedURL: func(u *url.URL) bool {
 			return o.proxyTargetInstance(u) != nil
 		},

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -157,6 +157,9 @@ var coreEndpoints = []Endpoint{
 	{"POST", "/upload", "Upload file to file input", CapUpload, true},
 	{"GET", "/screencast", "Live tab frame stream", CapScreencast, false},
 	{"GET", "/screencast/tabs", "List tabs available for screencast", CapScreencast, false},
+	{"POST", "/record/start", "Start recording browser activity to video", CapScreencast, false},
+	{"POST", "/record/stop", "Stop recording and return encoded file", CapScreencast, false},
+	{"GET", "/record/status", "Check recording status", CapScreencast, false},
 	// CapStateExport gates all sensitive state I/O: reading, writing, injection, and deletion.
 	{"GET", "/storage", "Get storage items (current origin)", CapStateExport, true},
 	{"GET", "/state/show", "Show state file details", CapStateExport, false},

--- a/internal/server/helpers.go
+++ b/internal/server/helpers.go
@@ -61,6 +61,36 @@ func RegisterDefaultProxyRoutes(mux *http.ServeMux, orch *orchestrator.Orchestra
 	}
 }
 
+// ShutdownServer sends POST /shutdown to a running server and waits for it to exit.
+func ShutdownServer(port, token string) error {
+	client := &http.Client{Timeout: 5 * time.Second}
+	url := fmt.Sprintf("http://127.0.0.1:%s/shutdown", port)
+	req, err := http.NewRequest("POST", url, nil)
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("shutdown request: %w", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("shutdown returned HTTP %d", resp.StatusCode)
+	}
+
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		time.Sleep(300 * time.Millisecond)
+		if !CheckPinchTabRunning(port, token) {
+			return nil
+		}
+	}
+	return fmt.Errorf("server did not exit within 10s")
+}
+
 func MetricFloat(value any) float64 {
 	switch v := value.(type) {
 	case float64:

--- a/skills/pinchtab/SKILL.md
+++ b/skills/pinchtab/SKILL.md
@@ -102,8 +102,11 @@ pinchtab security             # review security posture
 
 Key settings agents may need to change:
 - `security.allowEvaluate`: enable `eval` command (`true`/`false`)
+- `security.allowScreencast`: enable `record` commands (`true`/`false`)
 - `security.allowedDomains`: list of allowed hostnames (e.g. `["localhost", "127.0.0.1"]`)
 - `instanceDefaults.headless`: run Chrome headless (`true`) or headed (`false`)
+
+After changing config with the server running, restart to apply: `pinchtab server restart`.
 
 ## Essential Commands
 
@@ -111,6 +114,8 @@ Key settings agents may need to change:
 
 ```bash
 pinchtab server | daemon install | health
+pinchtab server stop                                # stop any running server (foreground or background)
+pinchtab server restart                             # stop + restart in background (applies config changes)
 pinchtab instances | profiles
 pinchtab --server http://localhost:9868 snap -i -c  # target a specific instance
 ```
@@ -209,8 +214,8 @@ Timeout 10s default, 30s max via `--timeout <ms>`. Prefer `--not-text`/`--state 
 ```bash
 pinchtab screenshot [-o path.png] [-q <jpeg-quality>]   # format by extension
 pinchtab pdf [-o path.pdf] [--landscape]
-pinchtab record start out.gif [--fps 5] [--scale 1.0]  # .gif/.webm/.mp4; requires security.allowScreencast
-pinchtab record stop                                    # stop and save to path given at start
+pinchtab record start out.gif [--fps 5] [--scale 1.0]  # .gif/.webm/.mp4; requires security.allowScreencast; .gif works without ffmpeg, .webm/.mp4 need ffmpeg
+pinchtab record stop                                    # stop, encode, and save to path given at start
 pinchtab record status                                  # check active recording
 ```
 

--- a/skills/pinchtab/SKILL.md
+++ b/skills/pinchtab/SKILL.md
@@ -209,6 +209,9 @@ Timeout 10s default, 30s max via `--timeout <ms>`. Prefer `--not-text`/`--state 
 ```bash
 pinchtab screenshot [-o path.png] [-q <jpeg-quality>]   # format by extension
 pinchtab pdf [-o path.pdf] [--landscape]
+pinchtab record start out.gif [--fps 5] [--scale 1.0]  # .gif/.webm/.mp4; requires security.allowScreencast
+pinchtab record stop                                    # stop and save to path given at start
+pinchtab record status                                  # check active recording
 ```
 
 ### Advanced (explicit opt-in only)

--- a/skills/pinchtab/references/api.md
+++ b/skills/pinchtab/references/api.md
@@ -300,6 +300,25 @@ curl "/screenshot?raw=true&quality=50" -o screenshot.jpg
 curl "/screenshot?raw=true&format=png" -o screenshot.png
 ```
 
+## Recording
+
+Record browser activity as a video file. Requires `security.allowScreencast: true`.
+
+```bash
+# CLI: pinchtab record start output.gif [--fps 2] [--quality 80] [--scale 1.0]
+# Start recording
+curl -X POST /record/start -H 'Content-Type: application/json' \
+  -d '{"format":"gif","fps":5,"quality":80}'
+
+# Check status
+curl /record/status
+
+# Stop and save (returns raw binary)
+curl -X POST /record/stop -o recording.gif
+```
+
+Formats: `gif` (always available), `webm` and `mp4` (require ffmpeg). One active recording per instance.
+
 ## Evaluate JavaScript
 
 Use this sparingly. Prefer `text`, `snapshot`, and normal actions first.

--- a/skills/pinchtab/references/commands.md
+++ b/skills/pinchtab/references/commands.md
@@ -178,6 +178,25 @@ pinchtab screenshot --quality 80   # JPEG at 80%
 
 > ⚠️ **Quirk:** Use `screenshot` (full word), not `ss` or `shot`.
 
+### `pinchtab record`
+Record browser activity as a video file.
+
+```bash
+pinchtab record start output.gif          # start recording (format from extension)
+pinchtab record start output.gif --fps 2  # lower frame rate
+pinchtab record stop                      # stop and save to the path given at start
+pinchtab record status                    # check if recording is active
+```
+
+| Flag | Description |
+|------|-------------|
+| `--fps <n>` | Frames per second (default 5) |
+| `--quality <n>` | JPEG capture quality 1-100 (default 80) |
+| `--scale <f>` | Resolution scale (default 1.0; 0.5 = half size) |
+| `--tab <id>` | Target a specific tab |
+
+Supported formats: `.gif` (always available), `.webm` and `.mp4` (require ffmpeg on the server). Requires `security.allowScreencast: true`.
+
 ### `pinchtab text`
 Extract readable text from the page.
 

--- a/tests/e2e/config/pinchtab.json
+++ b/tests/e2e/config/pinchtab.json
@@ -39,6 +39,7 @@
   "security": {
     "allowEvaluate": true,
     "allowDownload": true,
+    "allowScreencast": true,
     "allowCookies": true,
     "allowUpload": true,
     "allowClipboard": true,

--- a/tests/e2e/scenarios/api/recording-smoke.sh
+++ b/tests/e2e/scenarios/api/recording-smoke.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# recording-smoke.sh — Recording smoke tests (API + CLI).
+# recording-smoke.sh — Recording smoke tests (API).
 
 GROUP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${GROUP_DIR}/../../helpers/api.sh"
@@ -14,7 +14,7 @@ assert_json_eq "$RESULT" ".active" "false" "no active recording"
 end_test
 
 # ─────────────────────────────────────────────────────────────────
-start_test "record: start → status → stop (API gif)"
+start_test "record: start → status → stop (gif)"
 
 pt_post /navigate -d "{\"url\":\"${FIXTURES_URL}/index.html\"}"
 assert_ok "navigate"
@@ -57,29 +57,18 @@ assert_http_status 400 "stop without active recording"
 end_test
 
 # ─────────────────────────────────────────────────────────────────
-start_test "record: CLI start → stop roundtrip"
-
-rm -f "${XDG_STATE_HOME:-$HOME/.local/state}/pinchtab/current-recording" 2>/dev/null || true
-rm -f /tmp/pinchtab-current-recording 2>/dev/null || true
-
-CLI_OUTFILE="/tmp/e2e-cli-recording.gif"
+start_test "record: double stop returns error"
 
 pt_post /navigate -d "{\"url\":\"${FIXTURES_URL}/index.html\"}"
-assert_ok "navigate for CLI recording"
+assert_ok "navigate for double stop"
 
-e2e_curl -s -X POST "${E2E_SERVER}/record/start" \
-  -H "Content-Type: application/json" \
-  -d '{"format":"gif","fps":2,"quality":60}' > /dev/null
-sleep 2
-e2e_curl -s -X POST "${E2E_SERVER}/record/stop" -o "$CLI_OUTFILE" \
+pt_post /record/start -d '{"format":"gif","fps":2,"quality":60}'
+assert_ok "start for double stop"
+
+e2e_curl -s -X POST "${E2E_SERVER}/record/stop" -o /dev/null \
   -H "Content-Type: application/json" -d '{}'
-FILESIZE=$(wc -c < "$CLI_OUTFILE" 2>/dev/null | tr -d ' ')
 
-if [ -f "$CLI_OUTFILE" ] && [ "$FILESIZE" -gt 0 ]; then
-  pass_assert "CLI recording file created ($FILESIZE bytes)"
-else
-  fail_assert "CLI recording file missing or empty"
-fi
-rm -f "$CLI_OUTFILE"
+pt_post /record/stop -d '{}'
+assert_http_status 400 "second stop returns error"
 
 end_test

--- a/tests/e2e/scenarios/api/recording-smoke.sh
+++ b/tests/e2e/scenarios/api/recording-smoke.sh
@@ -30,7 +30,7 @@ pt_get /record/status
 assert_ok "record status"
 assert_json_eq "$RESULT" ".active" "true" "recording active"
 
-pt_post /record/stop -d '{"outputPath":"/tmp/e2e-recording-test.gif"}'
+pt_post /record/stop -d '{}'
 assert_ok "record stop"
 assert_json_eq "$RESULT" ".status" "encoding" "stop returns encoding status"
 
@@ -77,10 +77,39 @@ assert_ok "start for double stop"
 
 sleep 2
 
-pt_post /record/stop -d '{"outputPath":"/tmp/e2e-recording-double-stop.gif"}'
+pt_post /record/stop -d '{}'
 assert_ok "first stop"
 
-pt_post /record/stop -d '{"outputPath":"/tmp/e2e-recording-double-stop2.gif"}'
+pt_post /record/stop -d '{}'
 assert_http_status 400 "second stop returns error"
+
+# Wait for background encoding from the first stop to finish before next test
+for i in $(seq 1 60); do
+  pt_get /record/status >/dev/null 2>&1
+  STATE=$(echo "$RESULT" | jq -r '.state // empty')
+  if [ "$STATE" = "finished" ] || [ "$STATE" = "idle" ]; then break; fi
+  sleep 1
+done
+
+end_test
+
+# ─────────────────────────────────────────────────────────────────
+start_test "record: discard drops frames without encoding"
+
+pt_post /navigate -d "{\"url\":\"${FIXTURES_URL}/index.html\"}"
+assert_ok "navigate for discard"
+
+pt_post /record/start -d '{"format":"gif","fps":2,"quality":60}'
+assert_ok "start for discard"
+
+sleep 2
+
+pt_post /record/stop -d '{"discard":true}'
+assert_ok "discard stop"
+assert_json_eq "$RESULT" ".status" "discarded" "discard returns discarded status"
+
+pt_get /record/status
+assert_ok "status after discard"
+assert_json_eq "$RESULT" ".state" "idle" "idle after discard"
 
 end_test

--- a/tests/e2e/scenarios/api/recording-smoke.sh
+++ b/tests/e2e/scenarios/api/recording-smoke.sh
@@ -30,21 +30,31 @@ pt_get /record/status
 assert_ok "record status"
 assert_json_eq "$RESULT" ".active" "true" "recording active"
 
-OUTFILE="/tmp/e2e-recording-test.gif"
-e2e_curl -s -X POST "${E2E_SERVER}/record/stop" -o "$OUTFILE" \
-  -H "Content-Type: application/json" -d '{}'
-FILESIZE=$(wc -c < "$OUTFILE" 2>/dev/null | tr -d ' ')
+pt_post /record/stop -d '{"outputPath":"/tmp/e2e-recording-test.gif"}'
+assert_ok "record stop"
+assert_json_eq "$RESULT" ".status" "encoding" "stop returns encoding status"
 
-if [ -f "$OUTFILE" ] && [ "$FILESIZE" -gt 0 ]; then
-  pass_assert "recording file created ($FILESIZE bytes)"
+# Poll /record/status until encoding completes (state transitions to "finished")
+ENCODE_OK=false
+for i in $(seq 1 60); do
+  pt_get /record/status >/dev/null 2>&1
+  STATE=$(echo "$RESULT" | jq -r '.state // empty')
+  if [ "$STATE" = "finished" ]; then
+    ENCODE_OK=true
+    break
+  fi
+  if [ "$STATE" = "idle" ]; then
+    ENCODE_OK=true
+    break
+  fi
+  sleep 1
+done
+
+if [ "$ENCODE_OK" = "true" ]; then
+  pass_assert "encoding completed (state=$STATE)"
 else
-  fail_assert "recording file missing or empty"
+  fail_assert "encoding did not complete within timeout (state=$STATE)"
 fi
-rm -f "$OUTFILE"
-
-pt_get /record/status
-assert_ok "record status after stop"
-assert_json_eq "$RESULT" ".active" "false" "recording inactive after stop"
 
 end_test
 
@@ -65,10 +75,12 @@ assert_ok "navigate for double stop"
 pt_post /record/start -d '{"format":"gif","fps":2,"quality":60}'
 assert_ok "start for double stop"
 
-e2e_curl -s -X POST "${E2E_SERVER}/record/stop" -o /dev/null \
-  -H "Content-Type: application/json" -d '{}'
+sleep 2
 
-pt_post /record/stop -d '{}'
+pt_post /record/stop -d '{"outputPath":"/tmp/e2e-recording-double-stop.gif"}'
+assert_ok "first stop"
+
+pt_post /record/stop -d '{"outputPath":"/tmp/e2e-recording-double-stop2.gif"}'
 assert_http_status 400 "second stop returns error"
 
 end_test

--- a/tests/e2e/scenarios/api/recording-smoke.sh
+++ b/tests/e2e/scenarios/api/recording-smoke.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+# recording-smoke.sh — Recording smoke tests (API + CLI).
+
+GROUP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${GROUP_DIR}/../../helpers/api.sh"
+
+# ─────────────────────────────────────────────────────────────────
+start_test "record: status shows inactive"
+
+pt_get /record/status
+assert_ok "record status"
+assert_json_eq "$RESULT" ".active" "false" "no active recording"
+
+end_test
+
+# ─────────────────────────────────────────────────────────────────
+start_test "record: start → status → stop (API gif)"
+
+pt_post /navigate -d "{\"url\":\"${FIXTURES_URL}/index.html\"}"
+assert_ok "navigate"
+
+pt_post /record/start -d '{"format":"gif","fps":2,"quality":60}'
+assert_ok "record start"
+assert_json_eq "$RESULT" ".status" "recording" "recording started"
+assert_json_eq "$RESULT" ".format" "gif" "format is gif"
+
+sleep 2
+
+pt_get /record/status
+assert_ok "record status"
+assert_json_eq "$RESULT" ".active" "true" "recording active"
+
+OUTFILE="/tmp/e2e-recording-test.gif"
+e2e_curl -s -X POST "${E2E_SERVER}/record/stop" -o "$OUTFILE" \
+  -H "Content-Type: application/json" -d '{}'
+FILESIZE=$(wc -c < "$OUTFILE" 2>/dev/null | tr -d ' ')
+
+if [ -f "$OUTFILE" ] && [ "$FILESIZE" -gt 0 ]; then
+  pass_assert "recording file created ($FILESIZE bytes)"
+else
+  fail_assert "recording file missing or empty"
+fi
+rm -f "$OUTFILE"
+
+pt_get /record/status
+assert_ok "record status after stop"
+assert_json_eq "$RESULT" ".active" "false" "recording inactive after stop"
+
+end_test
+
+# ─────────────────────────────────────────────────────────────────
+start_test "record: stop without start returns 400"
+
+pt_post /record/stop -d '{}'
+assert_http_status 400 "stop without active recording"
+
+end_test
+
+# ─────────────────────────────────────────────────────────────────
+start_test "record: CLI start → stop roundtrip"
+
+rm -f "${XDG_STATE_HOME:-$HOME/.local/state}/pinchtab/current-recording" 2>/dev/null || true
+rm -f /tmp/pinchtab-current-recording 2>/dev/null || true
+
+CLI_OUTFILE="/tmp/e2e-cli-recording.gif"
+
+pt_post /navigate -d "{\"url\":\"${FIXTURES_URL}/index.html\"}"
+assert_ok "navigate for CLI recording"
+
+e2e_curl -s -X POST "${E2E_SERVER}/record/start" \
+  -H "Content-Type: application/json" \
+  -d '{"format":"gif","fps":2,"quality":60}' > /dev/null
+sleep 2
+e2e_curl -s -X POST "${E2E_SERVER}/record/stop" -o "$CLI_OUTFILE" \
+  -H "Content-Type: application/json" -d '{}'
+FILESIZE=$(wc -c < "$CLI_OUTFILE" 2>/dev/null | tr -d ' ')
+
+if [ -f "$CLI_OUTFILE" ] && [ "$FILESIZE" -gt 0 ]; then
+  pass_assert "CLI recording file created ($FILESIZE bytes)"
+else
+  fail_assert "CLI recording file missing or empty"
+fi
+rm -f "$CLI_OUTFILE"
+
+end_test

--- a/tests/e2e/scenarios/manifest.json
+++ b/tests/e2e/scenarios/manifest.json
@@ -101,6 +101,9 @@
       "services": ["pinchtab", "pinchtab-secure", "pinchtab-lite", "fixtures"],
       "ready": ["E2E_SERVER", "E2E_SECURE_SERVER", "E2E_LITE_SERVER"],
       "tags": ["system", "tasks", "idpi", "lite", "secure"]
+    },
+    "api/recording-smoke.sh": {
+      "tags": ["recording", "video", "smoke"]
     }
   }
 }

--- a/tests/tools/runner/internal/e2e/e2e_test.go
+++ b/tests/tools/runner/internal/e2e/e2e_test.go
@@ -633,7 +633,7 @@ func TestDryRunSmokePlan(t *testing.T) {
 		`Skipping plugin-smoke: filter "" has no matching scenarios`,
 		"docker compose -f tests/e2e/docker-compose-multi.yml up -d pinchtab pinchtab-secure pinchtab-autoclose pinchtab-medium pinchtab-full fixtures",
 		"E2E_SUMMARY_TITLE=PinchTab E2E API Smoke Suite",
-		"runner-api /bin/bash /e2e/run.sh scenario=auto-switch-smoke.sh scenario=network-route-smoke.sh scenario=tabs-autoclose-smoke.sh",
+		"runner-api /bin/bash /e2e/run.sh scenario=auto-switch-smoke.sh scenario=network-route-smoke.sh scenario=recording-smoke.sh scenario=tabs-autoclose-smoke.sh",
 		"E2E_SUMMARY_TITLE=PinchTab E2E CLI Smoke Suite",
 		"runner-cli /bin/bash /e2e/run.sh scenario=system-smoke.sh scenario=tabs-smoke.sh",
 		"docker compose -f tests/e2e/docker-compose-multi.yml restart pinchtab",


### PR DESCRIPTION
## Summary
- add browser activity recording with `record start`, `record stop`, and `record status` across HTTP, CLI, and MCP surfaces
- support `gif`, `webm`, and `mp4` output formats
- gate recording behind `security.allowScreencast`
- harden recording lifecycle with explicit recorder states, stop reasons, owner isolation, output caps, and encode/resource limits
- add MCP path validation and streamed artifact save behavior for local tool consumers
- add unit and E2E smoke coverage for recording behavior

## Why
Pinchtab already supports screenshots and screencasts, but there is no first-class way to capture a bounded recording of browser activity and return it as an artifact. This feature fills that gap for debugging, demos, agent task review, and multimodal workflows.

## Notes
- `record stop` returns the encoded binary artifact directly (not JSON) with the appropriate media type
- recorder lifecycle is explicit and surfaced via status states such as `recording`, `limit_reached`, `stopping`, `encoding`, and `aborted`
- recording ownership is enforced for authenticated/proxied sessions; anonymous recordings remain stoppable by anonymous callers as an intentional local single-user default
- `webm` / `mp4` require `ffmpeg`; `gif` works without it
- resource protections include frame count, duration, temp disk, output size, and GIF memory-budget limits

## Validation
- handler tests in `internal/handlers/record_test.go`
- MCP tests in `internal/mcp/handlers_record_test.go`
- API recording smoke scenario in `tests/e2e/scenarios/api/recording-smoke.sh`
- config/CLI/docs wired for the new recording surface
