### PR TITLE
ci: hardcode pinchtab skill owner migration

### DIFF
--- a/.github/workflows/reusable-publish-skill.yml
+++ b/.github/workflows/reusable-publish-skill.yml
@@ -68,9 +68,15 @@ jobs:
         env:
           VERSION: ${{ steps.version.outputs.value }}
         run: |
-          clawhub publish skills/pinchtab \
-            --slug pinchtab \
-            --name "Pinchtab" \
-            --version "$VERSION" \
-            --changelog "Release v$VERSION" \
+          ARGS=(
+            skills/pinchtab
+            --owner pinchtab
+            --slug pinchtab
+            --name "Pinchtab"
+            --version "$VERSION"
+            --changelog "Release v$VERSION"
             --tags latest
+          )
+          # TODO: Remove --migrate-owner after the first org-owned skill release.
+          ARGS+=(--migrate-owner)
+          clawhub skill publish "${ARGS[@]}"


### PR DESCRIPTION
## Summary
- publish the Pinchtab skill explicitly as owner `pinchtab`
- add the one-time `--migrate-owner` flag for the next org-owned skill release
- leave a TODO to remove `--migrate-owner` after that first migration release

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/reusable-publish-skill.yml"); puts "YAML OK"'
