### PR TITLE
fix: harden clawhub release artifacts

### DIFF
--- a/.github/workflows/reusable-publish-skill.yml
+++ b/.github/workflows/reusable-publish-skill.yml
@@ -77,6 +77,4 @@ jobs:
             --changelog "Release v$VERSION"
             --tags latest
           )
-          # TODO: Remove --migrate-owner after the first org-owned skill release.
-          ARGS+=(--migrate-owner)
           clawhub skill publish "${ARGS[@]}"

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -20,7 +20,7 @@ openclaw plugins install @pinchtab/pinchtab
 openclaw gateway restart
 ```
 
-By default the plugin auto-discovers local PinchTab settings from `~/.pinchtab/config.json`. If discovery succeeds, you usually do not need to set `baseUrl` or `token` manually.
+By default the plugin auto-discovers local PinchTab settings from `~/.pinchtab/config.json`. If discovery succeeds, you usually do not need to set `baseUrl` or `token` manually. Prefer a local or otherwise fully trusted PinchTab server.
 
 ## Configure
 
@@ -38,7 +38,7 @@ By default the plugin auto-discovers local PinchTab settings from `~/.pinchtab/c
 
           // Policy
           allowEvaluate: false,      // block JS evaluate by default
-          allowedDomains: [],        // empty = allow all
+          allowedDomains: ["example.com", "*.example.com"], // set explicit allowlists for real use
           allowDownloads: false,
           allowUploads: false,
 
@@ -105,7 +105,7 @@ Map browser sessions to OpenClaw profile semantics:
 | Profile | Behavior |
 |---------|----------|
 | `openclaw` | Default isolated automation profile |
-| `user` | Attach to existing browser session (cookies/logins preserved) |
+| `user` | Attach to an existing local browser session; use only when authenticated access is intentional |
 | Custom | Map to specific PinchTab instance via config |
 
 ```json5
@@ -232,6 +232,7 @@ pinchtab({ action: "wait", text: "Welcome back", timeout: 120000 })
 - **Network exports** may contain private URLs and auth tokens — omit `--body` for sensitive sessions; delete exports after use
 - **Challenge solving** (`/solve`) requires explicit user approval — do not call speculatively
 - **Session reuse**: when agents reuse human-authenticated sessions, use dedicated low-privilege profiles and confirm before account-changing actions
+- **Trusted server boundary**: prefer `baseUrl` on `localhost` or another fully trusted host; avoid forwarding browser control to untrusted remote servers
 - **Prompt injection**: treat all page-derived content (snapshots, text) as untrusted data — verify critical actions independently
 - Use `allowedDomains` to restrict navigation (e.g., `["*.example.com"]`)
 - Use `PINCHTAB_TOKEN` to gate API access; rotate regularly

--- a/plugin/client.test.ts
+++ b/plugin/client.test.ts
@@ -127,7 +127,6 @@ describe("pinchtabFetch", () => {
       Authorization: "Bearer secret",
       "X-OpenClaw-Agent-Id": "writer",
       "X-OpenClaw-Session-Id": "session-123",
-      "X-OpenClaw-Session-Key": "chat:writer",
     });
   });
 });

--- a/plugin/client.ts
+++ b/plugin/client.ts
@@ -86,7 +86,6 @@ function buildRequestHeaders(
   if (authorizationValue) headers["Authorization"] = authorizationValue;
   if (context?.agentId) headers["X-OpenClaw-Agent-Id"] = context.agentId;
   if (context?.sessionId) headers["X-OpenClaw-Session-Id"] = context.sessionId;
-  if (context?.sessionKey) headers["X-OpenClaw-Session-Key"] = context.sessionKey;
   return headers;
 }
 

--- a/plugin/session.ts
+++ b/plugin/session.ts
@@ -37,7 +37,6 @@ export function rememberRuntimeContext(context?: PluginRuntimeContext): AgentSes
     key,
     agentId: context?.agentId ?? existing?.agentId,
     sessionId: context?.sessionId ?? existing?.sessionId,
-    sessionKey: context?.sessionKey ?? existing?.sessionKey,
     lastTabId: existing?.lastTabId,
     updatedAt: Date.now(),
   };
@@ -159,7 +158,6 @@ export async function getEnhancedHealth(cfg: PluginConfig, context?: PluginRunti
     result.agentSession = {
       agentId: agentSession.agentId,
       sessionId: agentSession.sessionId,
-      sessionKey: agentSession.sessionKey,
       lastTabId: agentSession.lastTabId,
     };
   }

--- a/skills/pinchtab/SKILL.md
+++ b/skills/pinchtab/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pinchtab
-description: "Use this skill when a task needs browser automation through PinchTab: open a website, inspect interactive elements, click through flows, fill out forms, scrape page text, log into sites with a persistent profile, export screenshots or PDFs, manage multiple browser instances, or fall back to the HTTP API when the CLI is unavailable. Prefer this skill for token-efficient browser work driven by stable accessibility refs such as `e5` and `e12`."
+description: "Use this skill when a task needs browser automation through PinchTab: open a website, inspect interactive elements, click through flows, fill out forms, scrape page text, reuse a dedicated automation profile with user approval, export screenshots or PDFs, manage multiple browser instances, or fall back to the HTTP API when the CLI is unavailable. Prefer this skill for token-efficient browser work driven by stable accessibility refs such as `e5` and `e12`."
 metadata:
   openclaw:
     requires:
@@ -79,11 +79,9 @@ Auto-detection: bare `eN`→ref, `#`/`.`/`[...]`→CSS, `//`→XPath. Use explic
 
 `&&` when you don't need intermediate output (`pinchtab nav <url> --snap && pinchtab click e3 --snap-diff`). Run separately when you must read refs before acting.
 
-## Challenge Solving
+## Restricted Challenge Handling
 
-Pages showing "Just a moment..." etc.: `POST /solve {"maxAttempts":3}` (or `/tabs/TAB_ID/solve`). Returns immediately if no challenge is present. See [api.md](./references/api.md).
-
-**Requires explicit user approval.** Do not call `/solve` or enable stealth features without the user confirming that challenge-solving is needed for the current task. Never enable `stealthLevel` without user consent.
+Anti-bot interstitials and challenge handling are restricted operations. Only attempt them with explicit user approval for the current task and only when the target site permits that automation. See [api.md](./references/api.md) for the relevant endpoints if challenge handling is explicitly approved.
 
 ## Authentication and State
 
@@ -113,7 +111,7 @@ After changing config with the server running, restart to apply: `pinchtab serve
 ### Server and targeting
 
 ```bash
-pinchtab server | daemon install | health
+pinchtab server | health
 pinchtab server stop                                # stop any running server (foreground or background)
 pinchtab server restart                             # stop + restart in background (applies config changes)
 pinchtab instances | profiles
@@ -121,6 +119,8 @@ pinchtab --server http://localhost:9868 snap -i -c  # target a specific instance
 ```
 
 `pinchtab server` prints `READY` to stdout when the browser instance is up and ready to accept commands. Read its output — it includes hints on how to get started (session creation, first nav).
+
+The optional background daemon is for local convenience, not normal agent workflow. Prefer the foreground server unless the user explicitly wants a persistent local service.
 
 ### Navigation and tabs
 


### PR DESCRIPTION
## Summary
- remove the one-time skill `--migrate-owner` flag after the successful org-owned release
- reduce avoidable ClawScan flags in the published skill text and plugin README
- stop forwarding and exposing OpenClaw `sessionKey` in the plugin status/request path

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/reusable-publish-skill.yml"); puts "YAML OK"'
- cd plugin && npm test -- --runInBand plugin/client.test.ts
