### PR TITLE
fix: harden daemon service environment and logs

### DIFF
--- a/internal/daemon/launchd.go
+++ b/internal/daemon/launchd.go
@@ -31,7 +31,10 @@ func (m *launchdManager) Install(configPath string) (string, error) {
 	if err := os.MkdirAll(filepath.Dir(m.ServicePath()), 0755); err != nil {
 		return "", fmt.Errorf("create LaunchAgents directory: %w", err)
 	}
-	if err := os.WriteFile(m.ServicePath(), []byte(renderLaunchdPlist(m.env.execPath, configPath)), 0644); err != nil {
+	if err := ensureDaemonLogDir(m.env); err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(m.ServicePath(), []byte(renderLaunchdPlist(m.env.execPath, configPath, m.env.homeDir, daemonStdoutLogPath(m.env), daemonStderrLogPath(m.env))), 0644); err != nil {
 		return "", fmt.Errorf("write launchd plist: %w", err)
 	}
 	_, _ = runCommand(m.runner, "launchctl", "bootout", launchdDomainTarget(m.env), m.ServicePath())
@@ -45,6 +48,9 @@ func (m *launchdManager) Install(configPath string) (string, error) {
 }
 
 func (m *launchdManager) Start() (string, error) {
+	if err := ensureDaemonLogDir(m.env); err != nil {
+		return "", err
+	}
 	if _, err := runCommand(m.runner, "launchctl", "bootstrap", launchdDomainTarget(m.env), m.ServicePath()); err != nil && !strings.Contains(err.Error(), "already bootstrapped") {
 		return "", err
 	}
@@ -111,7 +117,7 @@ func (m *launchdManager) Pid() (string, error) {
 }
 
 func (m *launchdManager) Logs(n int) (string, error) {
-	logPath := "/tmp/pinchtab.err.log"
+	logPath := daemonStderrLogPath(m.env)
 	if _, err := os.Stat(logPath); err != nil {
 		return "No logs found at " + logPath, nil
 	}
@@ -144,7 +150,7 @@ func isLaunchdIgnorableError(err error) bool {
 		strings.Contains(msg, "already bootstrapped")
 }
 
-func renderLaunchdPlist(execPath, configPath string) string {
+func renderLaunchdPlist(execPath, configPath, homeDir, stdoutPath, stderrPath string) string {
 	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -156,6 +162,8 @@ func renderLaunchdPlist(execPath, configPath string) string {
     <string>%s</string>
     <string>server</string>
   </array>
+  <key>WorkingDirectory</key>
+  <string>%s</string>
   <key>RunAtLoad</key>
   <true/>
   <key>KeepAlive</key>
@@ -164,14 +172,16 @@ func renderLaunchdPlist(execPath, configPath string) string {
   <integer>10</integer>
   <key>EnvironmentVariables</key>
   <dict>
+    <key>HOME</key>
+    <string>%s</string>
     <key>PINCHTAB_CONFIG</key>
     <string>%s</string>
   </dict>
   <key>StandardOutPath</key>
-  <string>/tmp/pinchtab.out.log</string>
+  <string>%s</string>
   <key>StandardErrorPath</key>
-  <string>/tmp/pinchtab.err.log</string>
+  <string>%s</string>
 </dict>
 </plist>
-`, pinchtabLaunchdLabel, execPath, configPath)
+	`, pinchtabLaunchdLabel, execPath, homeDir, homeDir, configPath, stdoutPath, stderrPath)
 }

--- a/internal/daemon/launchd.go
+++ b/internal/daemon/launchd.go
@@ -61,6 +61,9 @@ func (m *launchdManager) Start() (string, error) {
 }
 
 func (m *launchdManager) Restart() (string, error) {
+	if err := ensureDaemonLogDir(m.env); err != nil {
+		return "", err
+	}
 	if _, err := runCommand(m.runner, "launchctl", "kickstart", "-k", launchdDomainTarget(m.env)+"/"+pinchtabLaunchdLabel); err != nil {
 		return "", err
 	}

--- a/internal/daemon/launchd.go
+++ b/internal/daemon/launchd.go
@@ -121,10 +121,16 @@ func (m *launchdManager) Pid() (string, error) {
 
 func (m *launchdManager) Logs(n int) (string, error) {
 	logPath := daemonStderrLogPath(m.env)
-	if _, err := os.Stat(logPath); err != nil {
-		return "No logs found at " + logPath, nil
+	if info, err := os.Stat(logPath); err == nil && info.Size() > 0 {
+		return runCommand(m.runner, "tail", "-n", fmt.Sprintf("%d", n), logPath)
 	}
-	return runCommand(m.runner, "tail", "-n", fmt.Sprintf("%d", n), logPath)
+
+	legacyLogPath := "/tmp/pinchtab.err.log"
+	if _, err := os.Stat(legacyLogPath); err == nil {
+		return runCommand(m.runner, "tail", "-n", fmt.Sprintf("%d", n), legacyLogPath)
+	}
+
+	return "No logs found at " + logPath, nil
 }
 
 func (m *launchdManager) ManualInstructions() string {

--- a/internal/daemon/launchd_test.go
+++ b/internal/daemon/launchd_test.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"errors"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -39,8 +40,27 @@ func TestLaunchdManagerInstallWritesPlistAndBootstrapsAgent(t *testing.T) {
 	if !strings.Contains(content, "<string>/Applications/Pinchtab.app/Contents/MacOS/pinchtab</string>") {
 		t.Fatalf("expected executable path in plist: %s", content)
 	}
+	if !strings.Contains(content, "<key>WorkingDirectory</key>") || !strings.Contains(content, "<string>"+root+"</string>") {
+		t.Fatalf("expected working directory in plist: %s", content)
+	}
+	if !strings.Contains(content, "<key>HOME</key>") || !strings.Contains(content, "<string>"+root+"</string>") {
+		t.Fatalf("expected HOME environment in plist: %s", content)
+	}
 	if !strings.Contains(content, "<string>/tmp/pinchtab/config.json</string>") {
 		t.Fatalf("expected config path in plist: %s", content)
+	}
+	stdoutLogPath := filepath.Join(root, ".pinchtab", "logs", "daemon.out.log")
+	stderrLogPath := filepath.Join(root, ".pinchtab", "logs", "daemon.err.log")
+	if !strings.Contains(content, "<string>"+stdoutLogPath+"</string>") {
+		t.Fatalf("expected stdout log path in plist: %s", content)
+	}
+	if !strings.Contains(content, "<string>"+stderrLogPath+"</string>") {
+		t.Fatalf("expected stderr log path in plist: %s", content)
+	}
+	if info, err := os.Stat(filepath.Join(root, ".pinchtab", "logs")); err != nil {
+		t.Fatalf("expected log directory to exist: %v", err)
+	} else if !info.IsDir() {
+		t.Fatalf("expected log directory, got file")
 	}
 
 	expectedCalls := []string{

--- a/internal/daemon/launchd_test.go
+++ b/internal/daemon/launchd_test.go
@@ -92,3 +92,42 @@ func TestLaunchdManagerPreflightRequiresGUIDomain(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+func TestLaunchdManagerLogsFallsBackToLegacyPath(t *testing.T) {
+	root := t.TempDir()
+	legacyLogPath := "/tmp/pinchtab.err.log"
+	legacyContent, legacyErr := os.ReadFile(legacyLogPath)
+	hadLegacy := legacyErr == nil
+	if err := os.WriteFile(legacyLogPath, []byte("legacy launchd log\n"), 0644); err != nil {
+		t.Fatalf("write legacy log: %v", err)
+	}
+	t.Cleanup(func() {
+		if hadLegacy {
+			_ = os.WriteFile(legacyLogPath, legacyContent, 0644)
+		} else {
+			_ = os.Remove(legacyLogPath)
+		}
+	})
+
+	runner := &fakeCommandRunner{
+		outputs: map[string]string{
+			"tail -n 20 /tmp/pinchtab.err.log": "tail output",
+		},
+	}
+	manager := &launchdManager{
+		env:    environment{homeDir: root, osName: "darwin"},
+		runner: runner,
+	}
+
+	output, err := manager.Logs(20)
+	if err != nil {
+		t.Fatalf("Logs returned error: %v", err)
+	}
+	if output != "tail output" {
+		t.Fatalf("unexpected logs output: %q", output)
+	}
+	expected := "tail -n 20 /tmp/pinchtab.err.log"
+	if len(runner.calls) != 1 || runner.calls[0] != expected {
+		t.Fatalf("tail call = %v, want %q", runner.calls, expected)
+	}
+}

--- a/internal/daemon/manager.go
+++ b/internal/daemon/manager.go
@@ -137,3 +137,26 @@ func systemdUserConfigHome(env environment) string {
 	}
 	return filepath.Join(env.homeDir, ".config")
 }
+
+func pinchtabStateHome(env environment) string {
+	return filepath.Join(env.homeDir, ".pinchtab")
+}
+
+func daemonLogDir(env environment) string {
+	return filepath.Join(pinchtabStateHome(env), "logs")
+}
+
+func daemonStdoutLogPath(env environment) string {
+	return filepath.Join(daemonLogDir(env), "daemon.out.log")
+}
+
+func daemonStderrLogPath(env environment) string {
+	return filepath.Join(daemonLogDir(env), "daemon.err.log")
+}
+
+func ensureDaemonLogDir(env environment) error {
+	if err := os.MkdirAll(daemonLogDir(env), 0755); err != nil {
+		return fmt.Errorf("create daemon log directory: %w", err)
+	}
+	return nil
+}

--- a/internal/daemon/systemd.go
+++ b/internal/daemon/systemd.go
@@ -54,6 +54,9 @@ func (m *systemdUserManager) Start() (string, error) {
 }
 
 func (m *systemdUserManager) Restart() (string, error) {
+	if err := ensureDaemonLogDir(m.env); err != nil {
+		return "", err
+	}
 	if _, err := runCommand(m.runner, "systemctl", "--user", "restart", pinchtabDaemonUnitName); err != nil {
 		return "", err
 	}

--- a/internal/daemon/systemd.go
+++ b/internal/daemon/systemd.go
@@ -28,7 +28,10 @@ func (m *systemdUserManager) Install(configPath string) (string, error) {
 	if err := os.MkdirAll(filepath.Dir(m.ServicePath()), 0755); err != nil {
 		return "", fmt.Errorf("create systemd user directory: %w", err)
 	}
-	if err := os.WriteFile(m.ServicePath(), []byte(renderSystemdUnit(m.env.execPath, configPath)), 0644); err != nil {
+	if err := ensureDaemonLogDir(m.env); err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(m.ServicePath(), []byte(renderSystemdUnit(m.env.execPath, configPath, daemonStdoutLogPath(m.env), daemonStderrLogPath(m.env))), 0644); err != nil {
 		return "", fmt.Errorf("write systemd unit: %w", err)
 	}
 	if _, err := runCommand(m.runner, "systemctl", "--user", "daemon-reload"); err != nil {
@@ -41,6 +44,9 @@ func (m *systemdUserManager) Install(configPath string) (string, error) {
 }
 
 func (m *systemdUserManager) Start() (string, error) {
+	if err := ensureDaemonLogDir(m.env); err != nil {
+		return "", err
+	}
 	if _, err := runCommand(m.runner, "systemctl", "--user", "start", pinchtabDaemonUnitName); err != nil {
 		return "", err
 	}
@@ -105,7 +111,11 @@ func (m *systemdUserManager) Pid() (string, error) {
 }
 
 func (m *systemdUserManager) Logs(n int) (string, error) {
-	return runCommand(m.runner, "journalctl", "--user", "-u", pinchtabDaemonUnitName, "-n", fmt.Sprintf("%d", n), "--no-pager")
+	logPath := daemonStderrLogPath(m.env)
+	if _, err := os.Stat(logPath); err != nil {
+		return "No logs found at " + logPath, nil
+	}
+	return runCommand(m.runner, "tail", "-n", fmt.Sprintf("%d", n), logPath)
 }
 
 func (m *systemdUserManager) ManualInstructions() string {
@@ -124,7 +134,7 @@ func (m *systemdUserManager) ManualInstructions() string {
 	return b.String()
 }
 
-func renderSystemdUnit(execPath, configPath string) string {
+func renderSystemdUnit(execPath, configPath, stdoutPath, stderrPath string) string {
 	return fmt.Sprintf(`[Unit]
 Description=Pinchtab Browser Service
 After=network.target
@@ -133,10 +143,12 @@ After=network.target
 Type=simple
 ExecStart="%s" server
 Environment="PINCHTAB_CONFIG=%s"
+StandardOutput=append:%s
+StandardError=append:%s
 Restart=always
 RestartSec=5
 
 [Install]
 WantedBy=default.target
-`, execPath, configPath)
+`, execPath, configPath, stdoutPath, stderrPath)
 }

--- a/internal/daemon/systemd.go
+++ b/internal/daemon/systemd.go
@@ -115,10 +115,11 @@ func (m *systemdUserManager) Pid() (string, error) {
 
 func (m *systemdUserManager) Logs(n int) (string, error) {
 	logPath := daemonStderrLogPath(m.env)
-	if _, err := os.Stat(logPath); err != nil {
-		return "No logs found at " + logPath, nil
+	if info, err := os.Stat(logPath); err == nil && info.Size() > 0 {
+		return runCommand(m.runner, "tail", "-n", fmt.Sprintf("%d", n), logPath)
 	}
-	return runCommand(m.runner, "tail", "-n", fmt.Sprintf("%d", n), logPath)
+
+	return runCommand(m.runner, "journalctl", "--user", "-u", pinchtabDaemonUnitName, "-n", fmt.Sprintf("%d", n), "--no-pager")
 }
 
 func (m *systemdUserManager) ManualInstructions() string {

--- a/internal/daemon/systemd_test.go
+++ b/internal/daemon/systemd_test.go
@@ -40,6 +40,19 @@ func TestSystemdUserManagerInstallWritesUnitAndEnablesService(t *testing.T) {
 	if !strings.Contains(content, `Environment="PINCHTAB_CONFIG=/tmp/pinchtab/config.json"`) {
 		t.Fatalf("expected config env in unit content: %s", content)
 	}
+	stdoutLogPath := filepath.Join(root, ".pinchtab", "logs", "daemon.out.log")
+	stderrLogPath := filepath.Join(root, ".pinchtab", "logs", "daemon.err.log")
+	if !strings.Contains(content, "StandardOutput=append:"+stdoutLogPath) {
+		t.Fatalf("expected stdout log path in unit content: %s", content)
+	}
+	if !strings.Contains(content, "StandardError=append:"+stderrLogPath) {
+		t.Fatalf("expected stderr log path in unit content: %s", content)
+	}
+	if info, err := os.Stat(filepath.Join(root, ".pinchtab", "logs")); err != nil {
+		t.Fatalf("expected log directory to exist: %v", err)
+	} else if !info.IsDir() {
+		t.Fatalf("expected log directory, got file")
+	}
 
 	expectedCalls := []string{
 		"systemctl --user daemon-reload",

--- a/internal/daemon/systemd_test.go
+++ b/internal/daemon/systemd_test.go
@@ -82,3 +82,28 @@ func TestSystemdUserManagerPreflightRequiresUserSession(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+func TestSystemdUserManagerLogsFallsBackToJournalctl(t *testing.T) {
+	root := t.TempDir()
+	runner := &fakeCommandRunner{
+		outputs: map[string]string{
+			"journalctl --user -u pinchtab.service -n 15 --no-pager": "journalctl output",
+		},
+	}
+	manager := &systemdUserManager{
+		env:    environment{homeDir: root, osName: "linux"},
+		runner: runner,
+	}
+
+	output, err := manager.Logs(15)
+	if err != nil {
+		t.Fatalf("Logs returned error: %v", err)
+	}
+	if output != "journalctl output" {
+		t.Fatalf("unexpected logs output: %q", output)
+	}
+	expected := "journalctl --user -u pinchtab.service -n 15 --no-pager"
+	if len(runner.calls) != 1 || runner.calls[0] != expected {
+		t.Fatalf("journalctl call = %v, want %q", runner.calls, expected)
+	}
+}


### PR DESCRIPTION
## Summary
- harden launchd units with explicit `WorkingDirectory` and `HOME`
- move daemon logs out of `/tmp` into `~/.pinchtab/logs`
- create the daemon log directory before install and start for both launchd and systemd
- cover the new plist/unit shape in daemon tests

## Why
Issue #554 exposed that the daemon setup was brittle on clean machines. This change makes the service environment more explicit and keeps logs under PinchTab-owned state instead of relying on temporary OS paths.

## Verification
- `go test ./internal/daemon -count=1`
