### PR TITLE
fix: redact action text responses

### DIFF
--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -131,7 +131,8 @@ pinchtab fill e3 "user@example.com"
 {
   "success": true,
   "result": {
-    "filled": "user@example.com"
+    "filled": true,
+    "len": 16
   }
 }
 ```

--- a/internal/bridge/action_text.go
+++ b/internal/bridge/action_text.go
@@ -3,9 +3,18 @@ package bridge
 import (
 	"context"
 	"fmt"
+	"unicode/utf8"
 
 	"github.com/chromedp/chromedp"
 )
+
+func textEntryResult(kind, text string) map[string]any {
+	result := map[string]any{
+		kind:  true,
+		"len": utf8.RuneCountInString(text),
+	}
+	return result
+}
 
 func (b *Bridge) actionType(ctx context.Context, req ActionRequest) (map[string]any, error) {
 	if req.Text == "" {
@@ -15,26 +24,26 @@ func (b *Bridge) actionType(ctx context.Context, req ActionRequest) (map[string]
 		return b.actionHumanizedType(ctx, req)
 	}
 	if req.Selector != "" {
-		return map[string]any{"typed": req.Text}, chromedp.Run(ctx,
+		return textEntryResult("typed", req.Text), chromedp.Run(ctx,
 			chromedp.Click(req.Selector, chromedp.ByQuery),
 			chromedp.SendKeys(req.Selector, req.Text, chromedp.ByQuery),
 		)
 	}
 	if req.NodeID > 0 {
-		return map[string]any{"typed": req.Text}, TypeByNodeID(ctx, req.NodeID, req.Text)
+		return textEntryResult("typed", req.Text), TypeByNodeID(ctx, req.NodeID, req.Text)
 	}
 	return nil, fmt.Errorf("need selector or ref")
 }
 
 func (b *Bridge) actionFill(ctx context.Context, req ActionRequest) (map[string]any, error) {
 	if req.Selector != "" {
-		return map[string]any{"filled": req.Text}, chromedp.Run(ctx, chromedp.SetValue(req.Selector, req.Text, chromedp.ByQuery))
+		return textEntryResult("filled", req.Text), chromedp.Run(ctx, chromedp.SetValue(req.Selector, req.Text, chromedp.ByQuery))
 	}
 	if req.NodeID > 0 {
 		if err := FillByNodeID(ctx, req.NodeID, req.Text); err != nil {
 			return nil, err
 		}
-		result := map[string]any{"filled": req.Text}
+		result := textEntryResult("filled", req.Text)
 		if actual, err := ReadInputValue(ctx, req.NodeID); err == nil && req.Text != "" && actual != req.Text {
 			result["warning"] = "fill may not have been picked up by the page (e.g. React controlled input); try 'type' instead"
 		}
@@ -76,7 +85,9 @@ func (b *Bridge) actionHumanizedType(ctx context.Context, req ActionRequest) (ma
 		return nil, err
 	}
 
-	return map[string]any{"typed": req.Text, "human": true}, nil
+	result := textEntryResult("typed", req.Text)
+	result["human"] = true
+	return result, nil
 }
 
 // keyboardTypeThreshold is the character count above which we switch from
@@ -145,7 +156,7 @@ func (b *Bridge) keyboardTypePerChar(ctx context.Context, text string) (map[stri
 	if err != nil {
 		return nil, err
 	}
-	return map[string]any{"typed": text}, nil
+	return textEntryResult("typed", text), nil
 }
 
 // keyboardTypeBatchedEdgeChars is how many characters to type with real
@@ -189,7 +200,9 @@ func (b *Bridge) keyboardTypeBatched(ctx context.Context, text string) (map[stri
 		return nil, err
 	}
 
-	return map[string]any{"typed": text, "batched": true}, nil
+	result := textEntryResult("typed", text)
+	result["batched"] = true
+	return result, nil
 }
 
 func (b *Bridge) actionKeyboardInsert(ctx context.Context, req ActionRequest) (map[string]any, error) {
@@ -204,7 +217,7 @@ func (b *Bridge) actionKeyboardInsert(ctx context.Context, req ActionRequest) (m
 	if err != nil {
 		return nil, err
 	}
-	return map[string]any{"inserted": req.Text}, nil
+	return textEntryResult("inserted", req.Text), nil
 }
 
 func (b *Bridge) actionKeyDown(ctx context.Context, req ActionRequest) (map[string]any, error) {

--- a/internal/handlers/action_execution.go
+++ b/internal/handlers/action_execution.go
@@ -110,7 +110,7 @@ func (h *Handlers) executeLiteAction(ctx context.Context, req bridge.ActionReque
 		if err := h.Router.Lite().Type(ctx, req.TabID, req.Ref, text); err != nil {
 			return nil, "lite", err
 		}
-		return map[string]any{"typed": text}, "lite", nil
+		return map[string]any{"typed": true, "len": len([]rune(text))}, "lite", nil
 	default:
 		return nil, "lite", fmt.Errorf("%w: %s", engine.ErrLiteNotSupported, req.Kind)
 	}

--- a/tests/e2e/fixtures/secrets.html
+++ b/tests/e2e/fixtures/secrets.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>E2E Test - Secret Fields</title>
+</head>
+<body>
+  <h1>Secret Fields</h1>
+  <form>
+    <div>
+      <label for="username">Username</label>
+      <input type="text" id="username" name="username" autocomplete="username">
+    </div>
+    <div>
+      <label for="password">Password</label>
+      <input type="password" id="password" name="password" autocomplete="current-password">
+    </div>
+    <div>
+      <label for="new-password">New password</label>
+      <input type="password" id="new-password" name="new-password" autocomplete="new-password">
+    </div>
+    <div>
+      <label for="otp-code">OTP code</label>
+      <input type="text" id="otp-code" name="otp-code" autocomplete="one-time-code" inputmode="numeric">
+    </div>
+    <input type="hidden" id="otp-hidden" name="otp-hidden" autocomplete="one-time-code" value="">
+  </form>
+</body>
+</html>

--- a/tests/e2e/scenarios/api/secrets-extended.sh
+++ b/tests/e2e/scenarios/api/secrets-extended.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+# secrets-extended.sh — regression coverage for secret leakage in action responses.
+
+GROUP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${GROUP_DIR}/../../helpers/api.sh"
+
+secrets_navigate() {
+  pt_post /navigate -d "{\"url\":\"${FIXTURES_URL}/secrets.html\"}" > /dev/null
+  assert_ok "navigate"
+}
+
+assert_field_value() {
+  local selector="$1"
+  local expected="$2"
+  local desc="$3"
+  local body
+  body=$(jq -nc --arg sel "$selector" '{expression: "document.querySelector(\"" + $sel + "\")?.value || \"\""}')
+  pt_post /evaluate "$body" > /dev/null
+  assert_ok "evaluate $selector"
+  assert_json_eq "$RESULT" '.result' "$expected" "$desc"
+}
+
+assert_action_response_does_not_echo_secret() {
+  local secret="$1"
+  local desc="$2"
+  assert_not_contains "$RESULT" "$secret" "$desc"
+}
+
+focus_selector() {
+  local selector="$1"
+  pt_post /action -d "{\"kind\":\"focus\",\"selector\":\"$selector\"}" > /dev/null
+  assert_ok "focus $selector"
+}
+
+# ─────────────────────────────────────────────────────────────────
+start_test "fill password selector does not echo raw secret"
+
+secrets_navigate
+SECRET="pw-fill-secret-557"
+pt_post /action -d "{\"kind\":\"fill\",\"selector\":\"#password\",\"text\":\"$SECRET\"}" > /dev/null
+assert_ok "fill password field"
+assert_action_response_does_not_echo_secret "$SECRET" "fill password response should not echo raw secret"
+assert_field_value "#password" "$SECRET" "password value persisted after fill"
+
+end_test
+
+# ─────────────────────────────────────────────────────────────────
+start_test "type password selector does not echo raw secret"
+
+secrets_navigate
+SECRET="pw-type-secret-557"
+pt_post /action -d "{\"kind\":\"type\",\"selector\":\"#password\",\"text\":\"$SECRET\"}" > /dev/null
+assert_ok "type password field"
+assert_action_response_does_not_echo_secret "$SECRET" "type password response should not echo raw secret"
+assert_field_value "#password" "$SECRET" "password value persisted after type"
+
+end_test
+
+# ─────────────────────────────────────────────────────────────────
+start_test "humanized type password selector does not echo raw secret"
+
+secrets_navigate
+SECRET="pw-human-secret-557"
+pt_post /action -d "{\"kind\":\"type\",\"selector\":\"#password\",\"text\":\"$SECRET\",\"humanize\":true,\"fast\":true}" > /dev/null
+assert_ok "humanized type password field"
+assert_action_response_does_not_echo_secret "$SECRET" "humanized type password response should not echo raw secret"
+assert_field_value "#password" "$SECRET" "password value persisted after humanized type"
+
+end_test
+
+# ─────────────────────────────────────────────────────────────────
+start_test "keyboard-type password does not echo raw secret"
+
+secrets_navigate
+focus_selector "#password"
+SECRET="pw-keyboard-secret-557"
+pt_post /action -d "{\"kind\":\"keyboard-type\",\"text\":\"$SECRET\"}" > /dev/null
+assert_ok "keyboard-type password field"
+assert_action_response_does_not_echo_secret "$SECRET" "keyboard-type response should not echo raw secret"
+assert_field_value "#password" "$SECRET" "password value persisted after keyboard-type"
+
+end_test
+
+# ─────────────────────────────────────────────────────────────────
+start_test "keyboard-inserttext password does not echo raw secret"
+
+secrets_navigate
+focus_selector "#password"
+SECRET="pw-insert-secret-557"
+pt_post /action -d "{\"kind\":\"keyboard-inserttext\",\"text\":\"$SECRET\"}" > /dev/null
+assert_ok "keyboard-inserttext password field"
+assert_action_response_does_not_echo_secret "$SECRET" "keyboard-inserttext response should not echo raw secret"
+assert_field_value "#password" "$SECRET" "password value persisted after keyboard-inserttext"
+
+end_test
+
+# ─────────────────────────────────────────────────────────────────
+start_test "fill one-time-code field does not echo raw secret"
+
+secrets_navigate
+SECRET="654321"
+pt_post /action -d "{\"kind\":\"fill\",\"selector\":\"#otp-code\",\"text\":\"$SECRET\"}" > /dev/null
+assert_ok "fill otp field"
+assert_action_response_does_not_echo_secret "$SECRET" "fill one-time-code response should not echo raw secret"
+assert_field_value "#otp-code" "$SECRET" "otp value persisted after fill"
+
+end_test
+
+# ─────────────────────────────────────────────────────────────────
+start_test "fill new-password field does not echo raw secret"
+
+secrets_navigate
+SECRET="new-password-secret-557"
+pt_post /action -d "{\"kind\":\"fill\",\"selector\":\"#new-password\",\"text\":\"$SECRET\"}" > /dev/null
+assert_ok "fill new-password field"
+assert_action_response_does_not_echo_secret "$SECRET" "fill new-password response should not echo raw secret"
+assert_field_value "#new-password" "$SECRET" "new-password value persisted after fill"
+
+end_test
+
+finish_suite

--- a/tests/e2e/scenarios/manifest.json
+++ b/tests/e2e/scenarios/manifest.json
@@ -35,6 +35,9 @@
       "ready": ["E2E_SERVER", "E2E_FULL_SERVER"],
       "tags": ["network", "route", "interception", "smoke"]
     },
+    "api/secrets-extended.sh": {
+      "tags": ["actions", "secrets", "credentials"]
+    },
     "cli/actions-basic.sh": {
       "tags": ["actions", "pr"]
     },


### PR DESCRIPTION
## Summary

Closes #557.

Stop echoing submitted text back in action responses for text-entry actions and replace it with metadata-only payloads.

## Changes

- return metadata-only results for `fill`, `type`, humanized `type`, `keyboard-type`, and `keyboard-inserttext`
- align lite-mode text-entry responses with the same metadata-only contract
- add a focused `secrets-extended` e2e regression covering password, new-password, and one-time-code cases
- update the showcase example to reflect the new response shape

## Verification

- `go test ./internal/bridge ./internal/handlers ./internal/mcp`
- `go run ./tests/tools/runner e2e --suite extended --filter actions --logs hide`
- `go run ./tests/tools/runner e2e --suite plugin --logs hide`