### PR TITLE
fix: add reset button to form fixture success state

### DIFF
--- a/tests/tools/fixtures/form.html
+++ b/tests/tools/fixtures/form.html
@@ -86,6 +86,7 @@
       <h2>Form Submitted Successfully!</h2>
       <p class="verification-text">VERIFY_FORM_SUBMITTED_SUCCESS</p>
       <div id="submitted-data"></div>
+      <button type="button" id="reset-form-btn" onclick="resetForm()">Reset Form</button>
     </div>
   </main>
   
@@ -147,6 +148,13 @@
       `;
       form.style.display = 'none';
     });
+
+    function resetForm() {
+      const form = document.getElementById('contact-form');
+      form.reset();
+      form.style.display = '';
+      document.getElementById('form-result').style.display = 'none';
+    }
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- The benchmark form fixture hid the entire form on submission, making the reset button invisible
- The baseline expected `RESET_BUTTON_VISIBLE` but agents correctly observed `RESET_BUTTON_HIDDEN`
- Added a "Reset Form" button to the success state so the page matches the baseline expectation

## Test plan
- [x] Verified fixture renders the reset button after form submission
- [x] Ran full opt loop — step 3.2 was the only failure, now fixed
- [x] Cold-start test still passes 11/11

🤖 Generated with [Claude Code](https://claude.com/claude-code)