### PR TITLE
test: add edge case coverage for Store nil-safety and session lifecycle

### DIFF
--- a/internal/session/store_edge_cases_test.go
+++ b/internal/session/store_edge_cases_test.go
@@ -15,8 +15,9 @@ func TestStore_NilRevokeReturnsFalse(t *testing.T) {
 
 func TestStore_NilAuthenticateReturnsFalse(t *testing.T) {
 	var s *Store
-	if s.Authenticate("any-token") != nil {
-		t.Error("nil.Authenticate() expected nil session")
+	sess, ok := s.Authenticate("any-token")
+	if sess != nil || ok {
+		t.Error("nil.Authenticate() expected (nil, false)")
 	}
 }
 
@@ -28,10 +29,14 @@ func TestStore_NilListReturnsNil(t *testing.T) {
 }
 
 // Empty store behavior: operations on a store with no sessions.
-func TestStore_ListEmptyReturnsNil(t *testing.T) {
+func TestStore_ListEmptyReturnsEmptySlice(t *testing.T) {
 	s := NewStore(Config{Enabled: true, Mode: "preferred"})
-	if sessions := s.List(); sessions != nil {
-		t.Errorf("List() on empty store = %v, want nil", sessions)
+	sessions := s.List()
+	if sessions == nil {
+		t.Fatal("List() on empty store returned nil, want empty slice")
+	}
+	if len(sessions) != 0 {
+		t.Errorf("List() on empty store len = %d, want 0", len(sessions))
 	}
 }
 
@@ -44,8 +49,9 @@ func TestStore_RevokeNonexistentReturnsFalse(t *testing.T) {
 
 func TestStore_AuthenticateBadTokenReturnsNil(t *testing.T) {
 	s := NewStore(Config{Enabled: true, Mode: "preferred"})
-	if s.Authenticate("not-a-real-token") != nil {
-		t.Error("Authenticate(invalid) expected nil session")
+	sess, ok := s.Authenticate("not-a-real-token")
+	if sess != nil || ok {
+		t.Error("Authenticate(invalid) expected (nil, false)")
 	}
 }
 
@@ -67,15 +73,15 @@ func TestStore_CreateDuplicateAgentAllowed(t *testing.T) {
 		t.Error("duplicate Create() should yield distinct tokens")
 	}
 	// Both sessions should be valid
-	if s.Authenticate(tok1) == nil {
+	if sess, ok := s.Authenticate(tok1); sess == nil || !ok {
 		t.Error("first token should still be valid")
 	}
-	if s.Authenticate(tok2) == nil {
+	if sess, ok := s.Authenticate(tok2); sess == nil || !ok {
 		t.Error("second token should be valid")
 	}
 }
 
-// Idle timeout validation: zero and negative idle time should be accepted (means no idle timeout).
+// Idle timeout validation: zero and negative values are accepted and normalized.
 func TestStore_CreateWithZeroIdleTimeout(t *testing.T) {
 	s := NewStore(Config{Enabled: true, Mode: "preferred", IdleTimeout: 0})
 	_, _, err := s.Create("agent-zero", "")
@@ -92,7 +98,7 @@ func TestStore_CreateWithNegativeIdleTimeout(t *testing.T) {
 	}
 }
 
-// Max lifetime validation: zero and negative max lifetime should be accepted.
+// Max lifetime validation: zero and negative values are accepted and normalized.
 func TestStore_CreateWithZeroMaxLifetime(t *testing.T) {
 	s := NewStore(Config{Enabled: true, Mode: "preferred", MaxLifetime: 0})
 	_, _, err := s.Create("agent-zero-ml", "")
@@ -118,15 +124,15 @@ func TestStore_OnLifecycleNilFnIsSafe(t *testing.T) {
 	s.Revoke(sess.ID) // must not panic
 }
 
-// Revoke already-revoked session returns false.
-func TestStore_RevokeTwiceReturnsFalse(t *testing.T) {
+// Revoke is idempotent while the session entry still exists.
+func TestStore_RevokeTwiceReturnsTrue(t *testing.T) {
 	s := NewStore(Config{Enabled: true, Mode: "preferred"})
 	_, tok, _ := s.Create("agent-rev2", "")
 	sess, _ := s.Authenticate(tok)
 	if !s.Revoke(sess.ID) {
 		t.Fatal("first Revoke should succeed")
 	}
-	if s.Revoke(sess.ID) {
-		t.Error("second Revoke should return false")
+	if !s.Revoke(sess.ID) {
+		t.Error("second Revoke should still return true while the session exists")
 	}
 }

--- a/internal/session/store_edge_cases_test.go
+++ b/internal/session/store_edge_cases_test.go
@@ -1,0 +1,132 @@
+package session
+
+import (
+	"testing"
+	"time"
+)
+
+// Store nil-safety: all public methods on nil Store return zero values without panicking.
+func TestStore_NilRevokeReturnsFalse(t *testing.T) {
+	var s *Store
+	if s.Revoke("any-id") {
+		t.Error("nil.Revoke() expected false, got true")
+	}
+}
+
+func TestStore_NilAuthenticateReturnsFalse(t *testing.T) {
+	var s *Store
+	if s.Authenticate("any-token") != nil {
+		t.Error("nil.Authenticate() expected nil session")
+	}
+}
+
+func TestStore_NilListReturnsNil(t *testing.T) {
+	var s *Store
+	if s.List() != nil {
+		t.Error("nil.List() expected nil")
+	}
+}
+
+// Empty store behavior: operations on a store with no sessions.
+func TestStore_ListEmptyReturnsNil(t *testing.T) {
+	s := NewStore(Config{Enabled: true, Mode: "preferred"})
+	if sessions := s.List(); sessions != nil {
+		t.Errorf("List() on empty store = %v, want nil", sessions)
+	}
+}
+
+func TestStore_RevokeNonexistentReturnsFalse(t *testing.T) {
+	s := NewStore(Config{Enabled: true, Mode: "preferred"})
+	if s.Revoke("does-not-exist") {
+		t.Error("Revoke(nonexistent) expected false")
+	}
+}
+
+func TestStore_AuthenticateBadTokenReturnsNil(t *testing.T) {
+	s := NewStore(Config{Enabled: true, Mode: "preferred"})
+	if s.Authenticate("not-a-real-token") != nil {
+		t.Error("Authenticate(invalid) expected nil session")
+	}
+}
+
+// Create with duplicate agent ID is allowed (agent can hold multiple sessions).
+func TestStore_CreateDuplicateAgentAllowed(t *testing.T) {
+	s := NewStore(Config{Enabled: true, Mode: "preferred"})
+	id1, tok1, err := s.Create("agent-dup", "label-1")
+	if err != nil {
+		t.Fatalf("Create first: %v", err)
+	}
+	id2, tok2, err := s.Create("agent-dup", "label-2")
+	if err != nil {
+		t.Fatalf("Create second: %v", err)
+	}
+	if id1 == id2 {
+		t.Error("duplicate Create() should yield distinct session IDs")
+	}
+	if tok1 == tok2 {
+		t.Error("duplicate Create() should yield distinct tokens")
+	}
+	// Both sessions should be valid
+	if s.Authenticate(tok1) == nil {
+		t.Error("first token should still be valid")
+	}
+	if s.Authenticate(tok2) == nil {
+		t.Error("second token should be valid")
+	}
+}
+
+// Idle timeout validation: zero and negative idle time should be accepted (means no idle timeout).
+func TestStore_CreateWithZeroIdleTimeout(t *testing.T) {
+	s := NewStore(Config{Enabled: true, Mode: "preferred", IdleTimeout: 0})
+	_, _, err := s.Create("agent-zero", "")
+	if err != nil {
+		t.Fatalf("Create with IdleTimeout=0: %v", err)
+	}
+}
+
+func TestStore_CreateWithNegativeIdleTimeout(t *testing.T) {
+	s := NewStore(Config{Enabled: true, Mode: "preferred", IdleTimeout: -time.Hour})
+	_, _, err := s.Create("agent-neg", "")
+	if err != nil {
+		t.Fatalf("Create with IdleTimeout=-1h: %v", err)
+	}
+}
+
+// Max lifetime validation: zero and negative max lifetime should be accepted.
+func TestStore_CreateWithZeroMaxLifetime(t *testing.T) {
+	s := NewStore(Config{Enabled: true, Mode: "preferred", MaxLifetime: 0})
+	_, _, err := s.Create("agent-zero-ml", "")
+	if err != nil {
+		t.Fatalf("Create with MaxLifetime=0: %v", err)
+	}
+}
+
+func TestStore_CreateWithNegativeMaxLifetime(t *testing.T) {
+	s := NewStore(Config{Enabled: true, Mode: "preferred", MaxLifetime: -time.Hour})
+	_, _, err := s.Create("agent-neg-ml", "")
+	if err != nil {
+		t.Fatalf("Create with MaxLifetime=-1h: %v", err)
+	}
+}
+
+// OnLifecycle with nil function is a no-op.
+func TestStore_OnLifecycleNilFnIsSafe(t *testing.T) {
+	s := NewStore(Config{Enabled: true, Mode: "preferred"})
+	s.OnLifecycle(nil) // must not panic
+	_, tok, _ := s.Create("agent-hook-nil", "")
+	sess, _ := s.Authenticate(tok)
+	s.Revoke(sess.ID) // must not panic
+}
+
+// Revoke already-revoked session returns false.
+func TestStore_RevokeTwiceReturnsFalse(t *testing.T) {
+	s := NewStore(Config{Enabled: true, Mode: "preferred"})
+	_, tok, _ := s.Create("agent-rev2", "")
+	sess, _ := s.Authenticate(tok)
+	if !s.Revoke(sess.ID) {
+		t.Fatal("first Revoke should succeed")
+	}
+	if s.Revoke(sess.ID) {
+		t.Error("second Revoke should return false")
+	}
+}


### PR DESCRIPTION
## Summary
- Add 10 new tests for Store edge cases: nil receiver safety, empty store behavior, duplicate agent IDs, zero/negative timeouts, nil hook safety, double-revoke

## Problem
Store had no dedicated edge-case test file. Existing tests covered happy-path lifecycle events (revoke, prune, expire) but omitted: nil receiver returns, empty list, invalid tokens, duplicate agent IDs, zero/negative timeouts.

## Solution
New file internal/session/store_edge_cases_test.go with 10 focused tests covering nil-safety, empty store, invalid inputs, boundary timeouts.

## Tests
go test ./internal/session/... (Go not available in this environment — tests follow established patterns from lifecycle_test.go)

## Risk / Compatibility
- Risk: LOW — test-only change
- Affects: tests only