### PR TITLE
Expose security.trustLoopbackProxy in config show with test and docs

### DIFF
--- a/cmd/pinchtab/cmd_config_test.go
+++ b/cmd/pinchtab/cmd_config_test.go
@@ -177,6 +177,36 @@ func TestConfigShowLoadsLegacyFlatConfigWithoutToken(t *testing.T) {
 	}
 }
 
+func TestConfigShowIncludesTrustLoopbackProxy(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("PINCHTAB_CONFIG", configPath)
+	t.Setenv("PINCHTAB_TOKEN", "")
+
+	fc := config.DefaultFileConfig()
+	if fc.Security.TrustLoopbackProxy == nil {
+		t.Fatal("default trustLoopbackProxy pointer is nil")
+	}
+	*fc.Security.TrustLoopbackProxy = true
+	if err := config.SaveFileConfig(&fc, configPath); err != nil {
+		t.Fatalf("SaveFileConfig() error = %v", err)
+	}
+
+	t.Cleanup(func() {
+		rootCmd.SetArgs(nil)
+	})
+
+	output := captureStdout(t, func() {
+		rootCmd.SetArgs([]string{"config", "show"})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+	})
+
+	if !strings.Contains(output, "Trust Loopback Proxy: true") {
+		t.Fatalf("expected config show output to include trust loopback proxy setting, got %q", output)
+	}
+}
+
 func TestConfigGetMasksServerToken(t *testing.T) {
 	configPath := filepath.Join(t.TempDir(), "config.json")
 	t.Setenv("PINCHTAB_CONFIG", configPath)

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -67,6 +67,7 @@ pinchtab config show
 ```
 
 Secret values such as `server.token` remain masked in this output.
+The Security section also includes `security.trustLoopbackProxy` as `Trust Loopback Proxy` so proxy trust posture is explicit.
 
 ### `pinchtab config token`
 

--- a/internal/cli/report/config_report.go
+++ b/internal/cli/report/config_report.go
@@ -22,6 +22,7 @@ func HandleConfigShow(cfg *config.RuntimeConfig) {
 	fmt.Printf("  Download:       %v\n", cfg.AllowDownload)
 	fmt.Printf("  Cookies:        %v\n", cfg.AllowCookies)
 	fmt.Printf("  Upload:         %v\n", cfg.AllowUpload)
+	fmt.Printf("  Trust Loopback Proxy: %v\n", cfg.TrustLoopbackProxy)
 	fmt.Println()
 	fmt.Println(styleStdout(headingStyle, "Browser / Instance Defaults"))
 	fmt.Printf("  Headless:       %v\n", cfg.Headless)


### PR DESCRIPTION
## What Changed?
- Exposed `security.trustLoopbackProxy` in `pinchtab config show` by adding `Trust Loopback Proxy: <true|false>` to the Security section.
- Added `TestConfigShowIncludesTrustLoopbackProxy` in `cmd/pinchtab/cmd_config_test.go` to verify the value appears in CLI output when set to `true`.
- Updated `docs/reference/config.md` to document that `config show` includes this security setting in the Security section.

## Why?
`security.trustLoopbackProxy` was already part of config/runtime behavior, but it was not visible in `config show`.  
This made it harder for operators to quickly verify effective proxy-trust posture from the CLI.  
This change closes that visibility gap and aligns runtime output, tests, and docs.

## Testing
- `go test ./cmd/pinchtab -run TestConfigShowIncludesTrustLoopbackProxy -count=1`
- `go test ./cmd/pinchtab -run 'TestConfigShow(LoadsLegacyFlatConfigWithoutToken|IncludesTrustLoopbackProxy)$' -count=1`

- [x] Unit and/or Docker E2E tests added or updated
- [ ] Manual testing completed (describe below)

## Checklist
See [DEFINITION_OF_DONE.md](./DEFINITION_OF_DONE.md) for the full checklist.

**Automated (CI enforces):**
- [ ] gofmt + golangci-lint passes
- [ ] All tests pass
- [ ] Build succeeds

**Manual:**
- [x] Error handling explicit (wrapped with `%w`)
- [x] No regressions in stealth/performance/persistence
- [x] README/CHANGELOG updated (if user-facing)
- [x] npm install works (if npm changes)

## Impact
- No breaking changes.
- No behavioral changes to config parsing/defaults/security enforcement.
- User-facing improvement in CLI observability and documentation clarity.