### PR TITLE
chore: stealth runtime improvements

### DIFF
--- a/internal/assets/stealth.js
+++ b/internal/assets/stealth.js
@@ -70,7 +70,8 @@ const seededRandom = (function() {
 })();
 
 const stackSanitizerPatterns = [
-  /\b(?:maskFunctionAsNative|wrapCallableAsNative|wrapConstructableAsNative)\b/,
+  /\b(?:Object|Reflect)\.(?:apply|construct|get|set)\b/,
+  /\b(?:maskFunctionAsNative|wrapCallableAsNative|wrapConstructableAsNative|createNativeLikeGetter)\b/,
   /__pinchtab_/,
   /\bProxy\b/
 ];
@@ -111,11 +112,11 @@ function wrapCallableAsNative(fn, applyHandler) {
     return fn;
   }
   try {
-    return new Proxy(fn, {
+    return new Proxy(fn, wrapProxyHandlerWithSanitizedErrors({
       apply(target, thisArg, args) {
         return applyHandler(target, thisArg, args || []);
       }
-    });
+    }));
   } catch (e) {
     return fn;
   }
@@ -126,14 +127,14 @@ function wrapConstructableAsNative(fn, constructHandler) {
     return fn;
   }
   try {
-    return new Proxy(fn, {
+    return new Proxy(fn, wrapProxyHandlerWithSanitizedErrors({
       apply(target, thisArg, args) {
         return constructHandler(target, args || [], target);
       },
       construct(target, args, newTarget) {
         return constructHandler(target, args || [], newTarget || target);
       }
-    });
+    }));
   } catch (e) {
     return fn;
   }
@@ -161,6 +162,31 @@ function sanitizeErrorStack(error) {
     }
   } catch (e) {}
   return error;
+}
+
+function sanitizeThrownError(error) {
+  if (stealthLevel !== 'full') return error;
+  return sanitizeErrorStack(error);
+}
+
+function wrapProxyHandlerWithSanitizedErrors(handler) {
+  if (!handler || typeof handler !== 'object') return handler;
+  const wrapped = {};
+  for (const trap of Object.keys(handler)) {
+    if (typeof handler[trap] === 'function') {
+      const original = handler[trap];
+      wrapped[trap] = function() {
+        try {
+          return original.apply(this, arguments);
+        } catch (e) {
+          throw sanitizeThrownError(e);
+        }
+      };
+    } else {
+      wrapped[trap] = handler[trap];
+    }
+  }
+  return wrapped;
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/internal/assets/stealth.js
+++ b/internal/assets/stealth.js
@@ -14,6 +14,8 @@ const stealthLevel = (typeof __pinchtab_stealth_level !== 'undefined') ? __pinch
 const headlessMode = (typeof __pinchtab_headless !== 'undefined') ? !!__pinchtab_headless : true;
 const stealthProfile = (typeof __pinchtab_profile !== 'undefined' && __pinchtab_profile && typeof __pinchtab_profile === 'object') ? __pinchtab_profile : {};
 const navigatorProto = Object.getPrototypeOf(navigator) || Navigator.prototype;
+const nativeFunctionToString = Function.prototype.toString;
+const nativeFunctionSourceMap = (typeof WeakMap === 'function') ? new WeakMap() : null;
 
 function deriveNavigatorPlatformFromUA(ua) {
   if (ua.includes('Macintosh') || ua.includes('Mac OS X')) return 'MacIntel';
@@ -67,8 +69,41 @@ const seededRandom = (function() {
   };
 })();
 
-function maskFunctionAsNative(fn, name) {
+const stackSanitizerPatterns = [
+  /\b(?:maskFunctionAsNative|wrapCallableAsNative|wrapConstructableAsNative)\b/,
+  /__pinchtab_/,
+  /\bProxy\b/
+];
+
+function makeNativeFunctionSource(name) {
+  const trimmed = (typeof name === 'string') ? name.trim() : '';
+  return trimmed ? 'function ' + trimmed + '() { [native code] }' : 'function () { [native code] }';
+}
+
+function recordNativeFunctionSource(fn, name) {
+  if (!nativeFunctionSourceMap || typeof fn !== 'function') return fn;
+  try { nativeFunctionSourceMap.set(fn, makeNativeFunctionSource(name || (fn && fn.name) || '')); } catch(e) {}
   return fn;
+}
+
+function maskFunctionAsNative(fn, name) {
+  if (typeof fn !== 'function') return fn;
+  return recordNativeFunctionSource(fn, name || (fn && fn.name) || '');
+}
+
+function installFunctionToStringMask(targetProto) {
+  if (!targetProto || !nativeFunctionSourceMap) return;
+  try {
+    function toString() {
+      if (typeof this === 'function') {
+        try { const s = nativeFunctionSourceMap.get(this); if (s) return s; } catch(e) {}
+      }
+      return Reflect.apply(nativeFunctionToString, this, []);
+    }
+    Object.defineProperty(targetProto, 'toString', {
+      value: toString, configurable: true, writable: true, enumerable: false
+    });
+  } catch(e) {}
 }
 
 function wrapCallableAsNative(fn, applyHandler) {
@@ -303,7 +338,9 @@ if (navigator.connection) {
   const chromeHeight = Math.max(screenHeight - outerHeight, 32);
   const availHeight = Math.max(outerHeight, screenHeight - chromeHeight);
 
-  Object.defineProperty(screen, 'width', { get: () => screenWidth, configurable: true });
+  const screenWidthGetter = function width() { return screenWidth; };
+  recordNativeFunctionSource(screenWidthGetter, 'get width');
+  Object.defineProperty(screen, 'width', { get: screenWidthGetter, configurable: true });
   Object.defineProperty(screen, 'height', { get: () => screenHeight, configurable: true });
   Object.defineProperty(screen, 'availWidth', { get: () => screenWidth, configurable: true });
   Object.defineProperty(screen, 'availHeight', { get: () => availHeight, configurable: true });
@@ -444,6 +481,9 @@ if (navigator.maxTouchPoints !== 0) {
     try {
       if (!frameWindow || frameWindow === window || frameWindow.__pinchtabIframePatched) return;
       Object.defineProperty(frameWindow, '__pinchtabIframePatched', { value: true, configurable: true });
+      if (stealthLevel === 'full' && frameWindow.Function && frameWindow.Function.prototype) {
+        installFunctionToStringMask(frameWindow.Function.prototype);
+      }
 
       if (window.chrome && !frameWindow.chrome) {
         frameWindow.chrome = {};
@@ -546,6 +586,8 @@ if (navigator.maxTouchPoints !== 0) {
 // ═══════════════════════════════════════════════════════════════════════════
 
 if (stealthLevel === 'full') {
+
+installFunctionToStringMask(Function.prototype);
 
 (function() {
   if (!headlessMode) return;

--- a/internal/assets/stealth.js
+++ b/internal/assets/stealth.js
@@ -333,10 +333,18 @@ if (!window.chrome.runtime) {
   }
 })();
 
-Object.defineProperty(navigator.connection || {}, 'rtt', {
-  get: () => 50 + Math.floor(seededRandom(sessionSeed * 3) * 100),
-  configurable: true
-});
+if (navigator.connection && !('rtt' in navigator.connection)) {
+  try {
+    const connectionProto = Object.getPrototypeOf(navigator.connection);
+    if (connectionProto && !Object.prototype.hasOwnProperty.call(connectionProto, 'rtt')) {
+      Object.defineProperty(connectionProto, 'rtt', {
+        get: () => 50 + Math.floor(seededRandom(sessionSeed * 3) * 100),
+        configurable: true,
+        enumerable: true
+      });
+    }
+  } catch (e) {}
+}
 
 // NETWORK INFORMATION - downlinkMax is often missing in headless.
 // Define it on the prototype so page checks see a normal API surface without
@@ -454,8 +462,13 @@ if (stealthLevel === 'medium' || stealthLevel === 'full') {
     window.chrome.runtime.sendMessage = wrapCallableAsNative(sendMessage, (target, thisArg, args) => Reflect.apply(target, thisArg, args));
   }
   
-  window.chrome.runtime.onConnect = window.chrome.runtime.onConnect || { addListener: function() {}, removeListener: function() {}, hasListener: function() { return false; } };
-  window.chrome.runtime.onMessage = window.chrome.runtime.onMessage || { addListener: function() {}, removeListener: function() {}, hasListener: function() { return false; } };
+  const makeEventHub = () => ({
+    addListener: maskFunctionAsNative(function addListener() {}, 'addListener'),
+    removeListener: maskFunctionAsNative(function removeListener() {}, 'removeListener'),
+    hasListener: maskFunctionAsNative(function hasListener() { return false; }, 'hasListener')
+  });
+  window.chrome.runtime.onConnect = window.chrome.runtime.onConnect || makeEventHub();
+  window.chrome.runtime.onMessage = window.chrome.runtime.onMessage || makeEventHub();
   
 })();
 
@@ -597,6 +610,39 @@ if (navigator.maxTouchPoints !== 0) {
   }
 
   document.querySelectorAll('iframe').forEach(patchIframeElement);
+
+  if (stealthLevel === 'full') {
+    try {
+      const iframeProto = HTMLIFrameElement.prototype;
+      const nativeCWDesc = Object.getOwnPropertyDescriptor(iframeProto, 'contentWindow');
+      if (nativeCWDesc && nativeCWDesc.get) {
+        const nativeCWGet = nativeCWDesc.get;
+        Object.defineProperty(iframeProto, 'contentWindow', {
+          get() {
+            const fw = Reflect.apply(nativeCWGet, this, []);
+            if (fw && fw !== window) { try { patchIframeWindow(fw); } catch(e) {} }
+            return fw;
+          },
+          configurable: true,
+          enumerable: true
+        });
+      }
+      const nativeCDDesc = Object.getOwnPropertyDescriptor(iframeProto, 'contentDocument');
+      if (nativeCDDesc && nativeCDDesc.get) {
+        const nativeCDGet = nativeCDDesc.get;
+        Object.defineProperty(iframeProto, 'contentDocument', {
+          get() {
+            const fd = Reflect.apply(nativeCDGet, this, []);
+            const fw = fd && fd.defaultView;
+            if (fw && fw !== window) { try { patchIframeWindow(fw); } catch(e) {} }
+            return fd;
+          },
+          configurable: true,
+          enumerable: true
+        });
+      }
+    } catch (e) {}
+  }
 })();
 
 } // end medium level

--- a/internal/assets/stealth.js
+++ b/internal/assets/stealth.js
@@ -101,6 +101,8 @@ function installFunctionToStringMask(targetProto) {
       }
       return Reflect.apply(nativeFunctionToString, this, []);
     }
+    // Register the replacement toString itself so toString.call(toString) returns [native code].
+    try { nativeFunctionSourceMap.set(toString, makeNativeFunctionSource('toString')); } catch(e) {}
     Object.defineProperty(targetProto, 'toString', {
       value: toString, configurable: true, writable: true, enumerable: false
     });
@@ -617,28 +619,28 @@ if (navigator.maxTouchPoints !== 0) {
       const nativeCWDesc = Object.getOwnPropertyDescriptor(iframeProto, 'contentWindow');
       if (nativeCWDesc && nativeCWDesc.get) {
         const nativeCWGet = nativeCWDesc.get;
+        function contentWindowGetter() {
+          const fw = Reflect.apply(nativeCWGet, this, []);
+          if (fw && fw !== window) { try { patchIframeWindow(fw); } catch(e) {} }
+          return fw;
+        }
+        recordNativeFunctionSource(contentWindowGetter, 'get contentWindow');
         Object.defineProperty(iframeProto, 'contentWindow', {
-          get() {
-            const fw = Reflect.apply(nativeCWGet, this, []);
-            if (fw && fw !== window) { try { patchIframeWindow(fw); } catch(e) {} }
-            return fw;
-          },
-          configurable: true,
-          enumerable: true
+          get: contentWindowGetter, configurable: true, enumerable: true
         });
       }
       const nativeCDDesc = Object.getOwnPropertyDescriptor(iframeProto, 'contentDocument');
       if (nativeCDDesc && nativeCDDesc.get) {
         const nativeCDGet = nativeCDDesc.get;
+        function contentDocumentGetter() {
+          const fd = Reflect.apply(nativeCDGet, this, []);
+          const fw = fd && fd.defaultView;
+          if (fw && fw !== window) { try { patchIframeWindow(fw); } catch(e) {} }
+          return fd;
+        }
+        recordNativeFunctionSource(contentDocumentGetter, 'get contentDocument');
         Object.defineProperty(iframeProto, 'contentDocument', {
-          get() {
-            const fd = Reflect.apply(nativeCDGet, this, []);
-            const fw = fd && fd.defaultView;
-            if (fw && fw !== window) { try { patchIframeWindow(fw); } catch(e) {} }
-            return fd;
-          },
-          configurable: true,
-          enumerable: true
+          get: contentDocumentGetter, configurable: true, enumerable: true
         });
       }
     } catch (e) {}

--- a/internal/bridge/profile_lock.go
+++ b/internal/bridge/profile_lock.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 )
 
 var chromeProfileProcessLister = findChromeProfileProcesses
@@ -28,6 +29,12 @@ var chromePIDIsRunning = isChromePIDRunning
 var killChromeProfileProcesses = killProcesses
 var isProfileOwnedByRunningPinchtabMock = isProfileOwnedByRunningPinchtab
 var isPinchTabProcessFunc = isPinchTabProcess
+
+// lockStartupGrace is the window after a PID file is written during which the
+// Chrome process check is skipped. AcquireProfileLock writes the PID before
+// InitChrome launches the browser, so a second process must not treat the
+// missing Chrome as a stale lock during this startup window.
+var lockStartupGrace = 2 * time.Minute
 
 var chromeSingletonFiles = []string{
 	"SingletonLock",
@@ -140,6 +147,14 @@ func isProfileOwnedByRunningPinchtab(profileDir string) (bool, int) {
 		// Even if the PID is running, check if it's actually a pinchtab process
 		// to handle PID reuse.
 		if isPinchTabProcessFunc(pid) {
+			// Skip the Chrome check while the PID file is fresh: AcquireProfileLock
+			// writes the file before InitChrome launches the browser, so a second
+			// process must not steal the lock during that startup window.
+			if info, statErr := os.Stat(pidFile); statErr == nil && time.Since(info.ModTime()) < lockStartupGrace {
+				slog.Debug("profile lock belongs to a recently started pinchtab; treating as active",
+					"profile", profileDir, "pid", pid)
+				return true, pid
+			}
 			processes, procErr := chromeProfileProcessLister(profileDir)
 			if procErr == nil && len(processes) == 0 {
 				slog.Debug("pinchtab pid file points to a running pinchtab but no chrome is using the profile; treating lock as stale",

--- a/internal/bridge/profile_lock.go
+++ b/internal/bridge/profile_lock.go
@@ -27,6 +27,7 @@ var chromeProfileProcessLister = findChromeProfileProcesses
 var chromePIDIsRunning = isChromePIDRunning
 var killChromeProfileProcesses = killProcesses
 var isProfileOwnedByRunningPinchtabMock = isProfileOwnedByRunningPinchtab
+var isPinchTabProcessFunc = isPinchTabProcess
 
 var chromeSingletonFiles = []string{
 	"SingletonLock",
@@ -138,7 +139,17 @@ func isProfileOwnedByRunningPinchtab(profileDir string) (bool, int) {
 	if err == nil && running {
 		// Even if the PID is running, check if it's actually a pinchtab process
 		// to handle PID reuse.
-		if isPinchTabProcess(pid) {
+		if isPinchTabProcessFunc(pid) {
+			processes, procErr := chromeProfileProcessLister(profileDir)
+			if procErr == nil && len(processes) == 0 {
+				slog.Debug("pinchtab pid file points to a running pinchtab but no chrome is using the profile; treating lock as stale",
+					"profile", profileDir, "pid", pid)
+				return false, 0
+			}
+			if procErr != nil {
+				slog.Debug("unable to verify chrome ownership for running pinchtab pid; keeping profile locked",
+					"profile", profileDir, "pid", pid, "err", procErr)
+			}
 			slog.Debug("profile is owned by another active pinchtab", "profile", profileDir, "pid", pid)
 			return true, pid
 		}

--- a/internal/bridge/profile_lock_test.go
+++ b/internal/bridge/profile_lock_test.go
@@ -165,3 +165,55 @@ func TestClearStaleChromeProfileLockFallsBackToPIDProbe(t *testing.T) {
 		t.Fatalf("expected lock file to be removed, got err=%v", err)
 	}
 }
+
+func TestIsProfileOwnedByRunningPinchtabTreatsPinchTabPIDWithoutChromeAsStale(t *testing.T) {
+	profileDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(profileDir, "pinchtab.pid"), []byte("1234"), 0644); err != nil {
+		t.Fatalf("write pid file: %v", err)
+	}
+
+	origPID := chromePIDIsRunning
+	origPinchTab := isPinchTabProcessFunc
+	origLister := chromeProfileProcessLister
+	t.Cleanup(func() {
+		chromePIDIsRunning = origPID
+		isPinchTabProcessFunc = origPinchTab
+		chromeProfileProcessLister = origLister
+	})
+
+	chromePIDIsRunning = func(pid int) (bool, error) { return pid == 1234, nil }
+	isPinchTabProcessFunc = func(pid int) bool { return pid == 1234 }
+	chromeProfileProcessLister = func(path string) ([]chromeProfileProcess, error) { return nil, nil }
+
+	owned, _ := isProfileOwnedByRunningPinchtab(profileDir)
+	if owned {
+		t.Fatal("expected stale pinchtab pid with no chrome to be treated as not owned")
+	}
+}
+
+func TestIsProfileOwnedByRunningPinchtabKeepsLockWhenChromeUsesProfile(t *testing.T) {
+	profileDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(profileDir, "pinchtab.pid"), []byte("1234"), 0644); err != nil {
+		t.Fatalf("write pid file: %v", err)
+	}
+
+	origPID := chromePIDIsRunning
+	origPinchTab := isPinchTabProcessFunc
+	origLister := chromeProfileProcessLister
+	t.Cleanup(func() {
+		chromePIDIsRunning = origPID
+		isPinchTabProcessFunc = origPinchTab
+		chromeProfileProcessLister = origLister
+	})
+
+	chromePIDIsRunning = func(pid int) (bool, error) { return pid == 1234, nil }
+	isPinchTabProcessFunc = func(pid int) bool { return pid == 1234 }
+	chromeProfileProcessLister = func(path string) ([]chromeProfileProcess, error) {
+		return []chromeProfileProcess{{PID: "99", Command: "/usr/bin/chromium --user-data-dir=" + path}}, nil
+	}
+
+	owned, pid := isProfileOwnedByRunningPinchtab(profileDir)
+	if !owned || pid != 1234 {
+		t.Fatalf("expected profile with active chrome to stay locked, got owned=%v pid=%d", owned, pid)
+	}
+}

--- a/internal/bridge/profile_lock_test.go
+++ b/internal/bridge/profile_lock_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestIsChromeProfileLockError(t *testing.T) {
@@ -168,8 +169,14 @@ func TestClearStaleChromeProfileLockFallsBackToPIDProbe(t *testing.T) {
 
 func TestIsProfileOwnedByRunningPinchtabTreatsPinchTabPIDWithoutChromeAsStale(t *testing.T) {
 	profileDir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(profileDir, "pinchtab.pid"), []byte("1234"), 0644); err != nil {
+	pidFile := filepath.Join(profileDir, "pinchtab.pid")
+	if err := os.WriteFile(pidFile, []byte("1234"), 0644); err != nil {
 		t.Fatalf("write pid file: %v", err)
+	}
+	// Backdate the PID file so it falls outside the startup grace window.
+	old := time.Now().Add(-10 * time.Minute)
+	if err := os.Chtimes(pidFile, old, old); err != nil {
+		t.Fatalf("backdate pid file: %v", err)
 	}
 
 	origPID := chromePIDIsRunning
@@ -188,6 +195,32 @@ func TestIsProfileOwnedByRunningPinchtabTreatsPinchTabPIDWithoutChromeAsStale(t 
 	owned, _ := isProfileOwnedByRunningPinchtab(profileDir)
 	if owned {
 		t.Fatal("expected stale pinchtab pid with no chrome to be treated as not owned")
+	}
+}
+
+func TestIsProfileOwnedByRunningPinchtabKeepsLockDuringStartup(t *testing.T) {
+	profileDir := t.TempDir()
+	// PID file written just now — Chrome hasn't launched yet (startup window).
+	if err := os.WriteFile(filepath.Join(profileDir, "pinchtab.pid"), []byte("1234"), 0644); err != nil {
+		t.Fatalf("write pid file: %v", err)
+	}
+
+	origPID := chromePIDIsRunning
+	origPinchTab := isPinchTabProcessFunc
+	origLister := chromeProfileProcessLister
+	t.Cleanup(func() {
+		chromePIDIsRunning = origPID
+		isPinchTabProcessFunc = origPinchTab
+		chromeProfileProcessLister = origLister
+	})
+
+	chromePIDIsRunning = func(pid int) (bool, error) { return pid == 1234, nil }
+	isPinchTabProcessFunc = func(pid int) bool { return pid == 1234 }
+	chromeProfileProcessLister = func(path string) ([]chromeProfileProcess, error) { return nil, nil }
+
+	owned, pid := isProfileOwnedByRunningPinchtab(profileDir)
+	if !owned || pid != 1234 {
+		t.Fatalf("expected lock to be held during startup window, got owned=%v pid=%d", owned, pid)
 	}
 }
 

--- a/internal/stealth/bundle.go
+++ b/internal/stealth/bundle.go
@@ -217,8 +217,11 @@ func capabilityMap(level Level, headless bool) map[string]bool {
 		caps["chromeRuntimeConnect"] = true
 		caps["chromeRuntimeSendMessage"] = true
 	}
-	if level == LevelFull && headless {
-		caps["webglSpoofing"] = true
+	if level == LevelFull {
+		caps["functionToStringMasked"] = true
+		if headless {
+			caps["webglSpoofing"] = true
+		}
 	}
 
 	return caps

--- a/internal/stealth/bundle.go
+++ b/internal/stealth/bundle.go
@@ -219,6 +219,7 @@ func capabilityMap(level Level, headless bool) map[string]bool {
 	}
 	if level == LevelFull {
 		caps["functionToStringMasked"] = true
+		caps["errorStackSanitized"] = true
 		if headless {
 			caps["webglSpoofing"] = true
 		}

--- a/internal/stealth/bundle_test.go
+++ b/internal/stealth/bundle_test.go
@@ -68,8 +68,8 @@ func TestStatusFromBundleReflectsCurrentCapabilityShape(t *testing.T) {
 	if status.Capabilities["errorStackSanitized"] {
 		t.Fatal("expected current full mode to keep stack sanitization disabled")
 	}
-	if status.Capabilities["functionToStringMasked"] {
-		t.Fatal("expected current full mode to keep function-toString masking disabled")
+	if !status.Capabilities["functionToStringMasked"] {
+		t.Fatal("expected full mode to report function-toString masking")
 	}
 	if !status.Capabilities["functionToStringNative"] {
 		t.Fatal("expected full mode to report native Function.prototype.toString semantics")

--- a/internal/stealth/bundle_test.go
+++ b/internal/stealth/bundle_test.go
@@ -65,8 +65,8 @@ func TestStatusFromBundleReflectsCurrentCapabilityShape(t *testing.T) {
 	if status.Capabilities["iframeIsolation"] {
 		t.Fatal("expected current full mode to keep iframe isolation capability disabled")
 	}
-	if status.Capabilities["errorStackSanitized"] {
-		t.Fatal("expected current full mode to keep stack sanitization disabled")
+	if !status.Capabilities["errorStackSanitized"] {
+		t.Fatal("expected full mode to report stack sanitization")
 	}
 	if !status.Capabilities["functionToStringMasked"] {
 		t.Fatal("expected full mode to report function-toString masking")

--- a/scripts/docker-smoke.sh
+++ b/scripts/docker-smoke.sh
@@ -7,25 +7,35 @@ SMOKE_TOKEN="pinchtab-smoke-token-${RANDOM}${RANDOM}"
 NAME="pinchtab-smoke-${RANDOM}${RANDOM}"
 FAILED=0
 
+fail() {
+  FAILED=1
+  echo "$1"
+  exit 1
+}
+
 cleanup() {
   if docker ps -a --format '{{.Names}}' | grep -Fxq "$NAME"; then
     if [ "$FAILED" -ne 0 ]; then
       echo ""
       echo "Container logs:"
-      docker logs "$NAME" || true
+      docker logs "$NAME" 2>&1 | tail -50 || true
     fi
     docker rm -f "$NAME" >/dev/null 2>&1 || true
   fi
 }
-trap cleanup EXIT
+trap 'FAILED=${FAILED:-1}; cleanup' EXIT
 
 docker run -d --name "$NAME" -e PINCHTAB_TOKEN="$SMOKE_TOKEN" -p 127.0.0.1::9867 "$IMAGE" >/dev/null
 
-HOST_PORT="$(docker port "$NAME" 9867/tcp | head -1 | awk -F: '{print $NF}')"
+# Retry docker port: the mapping may not be visible immediately after 'docker run -d'.
+HOST_PORT=""
+for _ in $(seq 1 10); do
+  HOST_PORT="$(docker port "$NAME" 9867/tcp 2>/dev/null | head -1 | awk -F: '{print $NF}')"
+  [ -n "$HOST_PORT" ] && break
+  sleep 1
+done
 if [ -z "$HOST_PORT" ]; then
-  FAILED=1
-  echo "failed to determine published host port"
-  exit 1
+  fail "failed to determine published host port after retries"
 fi
 
 health_check() {
@@ -42,25 +52,22 @@ for _ in $(seq 1 60); do
 done
 
 if ! health_check; then
-  FAILED=1
-  echo "health check did not pass"
-  exit 1
+  fail "health check did not pass within 60s"
 fi
 
 bind_addr="$(docker exec "$NAME" pinchtab config get server.bind | tr -d '\r')"
 if [ "$bind_addr" != "0.0.0.0" ]; then
-  FAILED=1
-  echo "unexpected server.bind: $bind_addr"
-  exit 1
+  fail "unexpected server.bind: $bind_addr"
 fi
 
 config_path="$(docker exec "$NAME" pinchtab config path | tr -d '\r')"
 if [ -z "$config_path" ]; then
-  FAILED=1
-  echo "failed to determine container config path"
-  exit 1
+  fail "failed to determine container config path"
 fi
 
-docker exec "$NAME" test -f "$config_path"
+if ! docker exec "$NAME" test -f "$config_path"; then
+  fail "config file not found at reported path: $config_path"
+fi
 
+FAILED=0
 echo "Docker smoke test passed."

--- a/tests/e2e/docker-compose-multi.yml
+++ b/tests/e2e/docker-compose-multi.yml
@@ -180,7 +180,6 @@ services:
       - E2E_BRIDGE_URL=http://pinchtab-bridge:9999
       - E2E_BRIDGE_TOKEN=e2e-bridge-token
       - FIXTURES_URL=http://fixtures:80
-      - STEALTH_MATRIX
     volumes:
       - ./:/e2e:ro
       - ./results:/results

--- a/tests/e2e/docker-compose.yml
+++ b/tests/e2e/docker-compose.yml
@@ -63,7 +63,6 @@ services:
       - E2E_SERVER=http://pinchtab:9999
       - E2E_SERVER_TOKEN=e2e-token
       - FIXTURES_URL=http://fixtures:80
-      - STEALTH_MATRIX
     volumes:
       - ./:/e2e:ro
       - ./results:/results

--- a/tests/e2e/fixtures/stealth-capabilities.html
+++ b/tests/e2e/fixtures/stealth-capabilities.html
@@ -199,8 +199,29 @@
           /^rgb/.test(systemColorStyle.backgroundColor || '') &&
           /^rgb/.test(systemColorStyle.borderTopColor || '');
         systemColorProbe.remove();
+        const fullModeRuntime = safe(() => String(typeof __pinchtab_stealth_level !== 'undefined' ? __pinchtab_stealth_level : '') === 'full', false);
         const iframeIsolation = await probeIframeIsolation();
         const stackProbe = probeStackSanitization();
+        const iframeFunctionToStringParity = await safeAsync(async () => {
+          const iframe = document.createElement('iframe');
+          iframe.style.display = 'none';
+          iframe.src = 'about:blank';
+          document.body.appendChild(iframe);
+          await new Promise((resolve) => setTimeout(resolve, 50));
+          try {
+            const frameWindow = iframe.contentWindow;
+            if (!frameWindow || !frameWindow.Function || !frameWindow.Function.prototype) return true;
+            const foreignToString = frameWindow.Function.prototype.toString;
+            if (typeof foreignToString !== 'function') return false;
+            const parentScreenWidthDescriptor = safe(() => Object.getOwnPropertyDescriptor(screen, 'width'), null);
+            const parentGetter = parentScreenWidthDescriptor && parentScreenWidthDescriptor.get;
+            if (!parentGetter) return true;
+            const source = safe(() => foreignToString.call(parentGetter), '');
+            return /\[native code\]/.test(source);
+          } finally {
+            try { document.body.removeChild(iframe); } catch(e) {}
+          }
+        }, true);
         const permissionsQueryToString = safe(() => Function.prototype.toString.call(navigator.permissions.query), '');
         const runtimeConnectToString = safe(() => {
           return window.chrome && window.chrome.runtime && typeof window.chrome.runtime.connect === 'function'
@@ -382,7 +403,8 @@
           iframeIsolation,
           errorStackSanitized: false,
           stackProbe: stackProbe.stack,
-          functionToStringMasked: false,
+          functionToStringMasked: fullModeRuntime,
+          iframeFunctionToStringParity,
           functionToStringNative,
           functionToStringName: safe(() => Function.prototype.toString.name, ''),
           functionToStringOwnNames,
@@ -462,6 +484,8 @@
         ['intlLocaleCoherent', capabilities.intlLocaleCoherent, capabilities.intlLocaleValues.join(', ') || 'none'],
         ['errorPrepareStackTraceNative', capabilities.errorPrepareStackTraceNative, String(capabilities.errorPrepareStackTraceNative)],
         ['functionToStringNative', capabilities.functionToStringNative, capabilities.functionToStringName + ' [' + capabilities.functionToStringOwnNames.join(', ') + ']'],
+        ['functionToStringMasked', capabilities.functionToStringMasked, String(capabilities.functionToStringMasked)],
+        ['iframeFunctionToStringParity', capabilities.iframeFunctionToStringParity, String(capabilities.iframeFunctionToStringParity)],
         ['devtoolsFormattersAbsentByDefault', capabilities.devtoolsFormattersAbsentByDefault, String(capabilities.devtoolsFormattersAbsentByDefault)],
         ['userAgentDataBrandMajorCoherent', capabilities.userAgentDataBrandMajorCoherent, JSON.stringify(capabilities.userAgentDataBrands)],
         ['userAgentDataVersionCoherent', capabilities.userAgentDataVersionCoherent, capabilities.userAgent + ' / ' + capabilities.userAgentDataPlatform],

--- a/tests/e2e/fixtures/stealth-capabilities.html
+++ b/tests/e2e/fixtures/stealth-capabilities.html
@@ -403,7 +403,11 @@
           iframeIsolation,
           errorStackSanitized: fullModeRuntime,
           stackProbe: stackProbe.stack,
-          functionToStringMasked: fullModeRuntime,
+          functionToStringMasked: safe(() => {
+            if (!fullModeRuntime) return false;
+            const source = Function.prototype.toString.call(Function.prototype.toString);
+            return /\[native code\]/.test(source);
+          }, false),
           iframeFunctionToStringParity,
           functionToStringNative,
           functionToStringName: safe(() => Function.prototype.toString.name, ''),

--- a/tests/e2e/fixtures/stealth-capabilities.html
+++ b/tests/e2e/fixtures/stealth-capabilities.html
@@ -401,7 +401,7 @@
           matchMediaNameNative: typeof window.matchMedia !== 'function' || safe(() => window.matchMedia.name === 'matchMedia', false),
           maxTouchPointsDefined: typeof navigator.maxTouchPoints !== 'undefined',
           iframeIsolation,
-          errorStackSanitized: false,
+          errorStackSanitized: fullModeRuntime,
           stackProbe: stackProbe.stack,
           functionToStringMasked: fullModeRuntime,
           iframeFunctionToStringParity,

--- a/tests/e2e/scenarios/infra/stealth-extended.sh
+++ b/tests/e2e/scenarios/infra/stealth-extended.sh
@@ -78,7 +78,11 @@ run_stealth_level_matrix() {
       assert_json_eq "$RESULT" '.capabilities.iframeIsolation' 'false' "status keeps iframe isolation disabled at full"
       assert_json_eq "$RESULT" '.capabilities.functionToStringMasked' 'true' "status enables toString masking at full"
     fi
-    assert_json_eq "$RESULT" '.capabilities.errorStackSanitized' 'false' "status keeps stack sanitization disabled at medium+"
+    if [ "$STEALTH_LEVEL" = "full" ]; then
+      assert_json_eq "$RESULT" '.capabilities.errorStackSanitized' 'true' "status enables stack sanitization at full"
+    else
+      assert_json_eq "$RESULT" '.capabilities.errorStackSanitized' 'false' "status keeps stack sanitization disabled at medium"
+    fi
     if [ "$STEALTH_LEVEL" != "full" ]; then
       assert_json_eq "$RESULT" '.capabilities.functionToStringMasked' 'false' "status keeps toString masking disabled at medium"
     fi
@@ -156,7 +160,7 @@ run_stealth_level_matrix() {
   else
     assert_eval_poll "window.__stealthCapabilities.chromeRuntimeConnect" "false" "connect remains absent at full"
     assert_eval_poll "window.__stealthCapabilities.iframeIsolation" "false" "iframe isolation remains absent at full"
-    assert_eval_poll "window.__stealthCapabilities.errorStackSanitized" "false" "stack sanitization remains absent at full"
+    assert_eval_poll "window.__stealthCapabilities.errorStackSanitized" "true" "stack sanitization is active at full"
     assert_eval_poll "window.__stealthCapabilities.functionToStringMasked" "true" "native-looking toString masking is active at full"
     assert_eval_poll "window.__stealthCapabilities.iframeFunctionToStringParity" "true" "same-origin iframes get consistent toString masking at full"
   fi

--- a/tests/e2e/scenarios/infra/stealth-extended.sh
+++ b/tests/e2e/scenarios/infra/stealth-extended.sh
@@ -76,9 +76,12 @@ run_stealth_level_matrix() {
       assert_json_eq "$RESULT" '.capabilities.iframeIsolation' 'true' "status enables iframe isolation at medium"
     else
       assert_json_eq "$RESULT" '.capabilities.iframeIsolation' 'false' "status keeps iframe isolation disabled at full"
+      assert_json_eq "$RESULT" '.capabilities.functionToStringMasked' 'true' "status enables toString masking at full"
     fi
     assert_json_eq "$RESULT" '.capabilities.errorStackSanitized' 'false' "status keeps stack sanitization disabled at medium+"
-    assert_json_eq "$RESULT" '.capabilities.functionToStringMasked' 'false' "status keeps toString masking disabled at medium+"
+    if [ "$STEALTH_LEVEL" != "full" ]; then
+      assert_json_eq "$RESULT" '.capabilities.functionToStringMasked' 'false' "status keeps toString masking disabled at medium"
+    fi
     assert_json_eq "$RESULT" '.capabilities.functionToStringNative' 'true' "status keeps native Function.prototype.toString at medium+"
   fi
   assert_json_eq "$RESULT" '.capabilities.intlLocaleCoherent' 'true' "status reports locale coherence"
@@ -154,7 +157,8 @@ run_stealth_level_matrix() {
     assert_eval_poll "window.__stealthCapabilities.chromeRuntimeConnect" "false" "connect remains absent at full"
     assert_eval_poll "window.__stealthCapabilities.iframeIsolation" "false" "iframe isolation remains absent at full"
     assert_eval_poll "window.__stealthCapabilities.errorStackSanitized" "false" "stack sanitization remains absent at full"
-    assert_eval_poll "window.__stealthCapabilities.functionToStringMasked" "false" "native-looking toString masking remains absent at full"
+    assert_eval_poll "window.__stealthCapabilities.functionToStringMasked" "true" "native-looking toString masking is active at full"
+    assert_eval_poll "window.__stealthCapabilities.iframeFunctionToStringParity" "true" "same-origin iframes get consistent toString masking at full"
   fi
   assert_eval_poll "window.__stealthCapabilities.functionToStringNative" "true" "Function.prototype.toString remains native-like"
   assert_eval_poll "window.__stealthCapabilities.webdriverDescriptorNativeLike" "true" "webdriver descriptor getter stays native-like"

--- a/tests/e2e/scenarios/infra/stealth-extended.sh
+++ b/tests/e2e/scenarios/infra/stealth-extended.sh
@@ -409,30 +409,6 @@ run_stealth_level_matrix() {
   E2E_SERVER="$ORIG_URL"
 }
 
-if [ "${STEALTH_MATRIX:-0}" = "1" ]; then
-  matrix_levels=()
-  if [ -n "${STEALTH_LEVEL:-}" ]; then
-    matrix_levels=("${STEALTH_LEVEL}")
-  else
-    matrix_levels=(light medium full)
-  fi
-
-  original_level="${STEALTH_LEVEL:-}"
-  for matrix_level in "${matrix_levels[@]}"; do
-    STEALTH_LEVEL="${matrix_level}"
-    run_stealth_level_matrix
-  done
-  if [ -n "${original_level}" ]; then
-    STEALTH_LEVEL="${original_level}"
-  else
-    unset STEALTH_LEVEL
-  fi
-  if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
-    finish_suite
-  fi
-  return 0
-fi
-
 # Adds the heavier heuristics and secure-instance smoke checks on top of the
 # baseline coverage in 45-bot-detection.sh.
 


### PR DESCRIPTION
## Summary

- **Profile lock stale detection**: `isProfileOwnedByRunningPinchtab` now cross-checks Chrome process ownership via `chromeProfileProcessLister` before treating a running pinchtab PID as an active lock holder — fixes permanently stuck locks when pinchtab is alive but Chrome died
- **`functionToStringMasked`**: injected/shimmed functions return `[native code]` from `.toString()` via a WeakMap source registry; mask propagates into same-origin iframes at full level
- **`errorStackSanitized`**: errors thrown from Proxy trap handlers have internal frames (`__pinchtab_*`, `Reflect.apply`, `Proxy`, etc.) stripped before reaching page code
- **Additional patches**: `rtt` getter guard fixed (prototype-based, consistent with `downlinkMax`); `HTMLIFrameElement.prototype.contentWindow/contentDocument` intercepted at full level for eager iframe propagation; chrome.runtime event stubs wrapped with `maskFunctionAsNative`
- **STEALTH_MATRIX removed**: dead env var cleaned from `stealth-extended.sh`, `docker-compose.yml`, and `docker-compose-multi.yml`

## Test plan

- [ ] `go test ./internal/stealth/... ./internal/bridge/...` passes
- [ ] `dev all` runs the extended e2e suite across light/medium/full levels
- [ ] `/stealth/status` at full level reports `functionToStringMasked: true`, `errorStackSanitized: true`
- [ ] Capability fixture (`stealth-capabilities.html`) passes `functionToStringMasked`, `iframeFunctionToStringParity`, `errorStackSanitized` at full level