### PR TITLE
fix: docker bootstrap smoke — remove host port mapping dependency

### DIFF
--- a/scripts/docker-smoke.sh
+++ b/scripts/docker-smoke.sh
@@ -23,27 +23,18 @@ cleanup() {
     docker rm -f "$NAME" >/dev/null 2>&1 || true
   fi
 }
-trap 'FAILED=${FAILED:-1}; cleanup' EXIT
+trap 'rc=$?; [ "$rc" -ne 0 ] && FAILED=1; cleanup' EXIT
 
-docker run -d --name "$NAME" -e PINCHTAB_TOKEN="$SMOKE_TOKEN" -p 127.0.0.1::9867 "$IMAGE" >/dev/null
-
-# Retry docker port: the mapping may not be visible immediately after 'docker run -d'.
-HOST_PORT=""
-for _ in $(seq 1 10); do
-  HOST_PORT="$(docker port "$NAME" 9867/tcp 2>/dev/null | head -1 | awk -F: '{print $NF}')"
-  [ -n "$HOST_PORT" ] && break
-  sleep 1
-done
-if [ -z "$HOST_PORT" ]; then
-  fail "failed to determine published host port after retries"
-fi
+# No host port mapping needed — all checks run via docker exec inside the container.
+docker run -d --name "$NAME" -e PINCHTAB_TOKEN="$SMOKE_TOKEN" "$IMAGE" >/dev/null
 
 health_check() {
-  printf 'fail\nsilent\nshow-error\nheader = "Authorization: Bearer %s"\nurl = "http://127.0.0.1:%s/health"\n' "$SMOKE_TOKEN" "$HOST_PORT" \
-    | curl --config - >/dev/null 2>&1
+  docker exec "$NAME" sh -c \
+    "wget -qO- --header='Authorization: Bearer $SMOKE_TOKEN' http://127.0.0.1:9867/health" \
+    >/dev/null 2>&1
 }
 
-echo "Waiting for PinchTab to become healthy on port $HOST_PORT..."
+echo "Waiting for PinchTab to become healthy..."
 for _ in $(seq 1 60); do
   if health_check; then
     break

--- a/tests/tools/runner/internal/e2e/e2e_test.go
+++ b/tests/tools/runner/internal/e2e/e2e_test.go
@@ -655,8 +655,8 @@ func TestDryRunSmokePlan(t *testing.T) {
 		"E2E_SUMMARY_TITLE=PinchTab E2E Infra Smoke Suite",
 		"runner-api /bin/bash /e2e/run.sh scenario=autosolver-smoke.sh scenario=dashboard-smoke.sh scenario=orchestrator-smoke.sh scenario=security-smoke.sh",
 		"== E2E Docker Smoke tests (host) ==",
-		"docker build -t pinchtab-release-smoke:dry-run .",
-		"docker build --platform linux/amd64 -f tests/tools/docker/chrome-cft-smoke.Dockerfile -t pinchtab-chrome-cft-smoke:dry-run .",
+		"docker build --load -t pinchtab-release-smoke:dry-run .",
+		"docker build --load --platform linux/amd64 -f tests/tools/docker/chrome-cft-smoke.Dockerfile -t pinchtab-chrome-cft-smoke:dry-run .",
 		"bash scripts/docker-smoke.sh pinchtab-release-smoke:dry-run",
 		"bash scripts/docker-chrome-cft-smoke.sh pinchtab-chrome-cft-smoke:dry-run",
 		"bash scripts/docker-port-conflict-smoke.sh pinchtab-chrome-cft-smoke:dry-run",
@@ -687,8 +687,8 @@ func TestDryRunSmokeDockerPlan(t *testing.T) {
 	for _, want := range []string{
 		"suite:  smoke-docker",
 		"== E2E Docker Smoke tests (host) ==",
-		"docker build -t pinchtab-release-smoke:dry-run .",
-		"docker build --platform linux/amd64 -f tests/tools/docker/chrome-cft-smoke.Dockerfile -t pinchtab-chrome-cft-smoke:dry-run .",
+		"docker build --load -t pinchtab-release-smoke:dry-run .",
+		"docker build --load --platform linux/amd64 -f tests/tools/docker/chrome-cft-smoke.Dockerfile -t pinchtab-chrome-cft-smoke:dry-run .",
 		"bash scripts/docker-smoke.sh pinchtab-release-smoke:dry-run",
 		"bash scripts/docker-chrome-cft-smoke.sh pinchtab-chrome-cft-smoke:dry-run",
 		"bash scripts/docker-port-conflict-smoke.sh pinchtab-chrome-cft-smoke:dry-run",
@@ -712,7 +712,7 @@ func TestDryRunSmokeDockerFilterAddsImageBuildDependency(t *testing.T) {
 	}
 	out := stdout.String()
 	for _, want := range []string{
-		"docker build -t pinchtab-release-smoke:dry-run .",
+		"docker build --load -t pinchtab-release-smoke:dry-run .",
 		"bash scripts/docker-mcp-smoke.sh pinchtab-release-smoke:dry-run",
 	} {
 		if !strings.Contains(out, want) {


### PR DESCRIPTION
## Summary

- Removes `-p 127.0.0.1::9867` from `docker run` and the subsequent `docker port` call
- All checks (health, `config get server.bind`, `config path`) now run via `docker exec` inside the container — no host port mapping needed
- Fixes a flake where `docker port` returned empty on macOS with Docker Desktop even after retries, causing 10s timeouts

## Why

The test only verifies the bootstrap path and server config — it never needs to reach the server from the host. Using `docker exec` for the health check is simpler and works consistently across CI (Linux) and local (macOS Docker Desktop).