### PR TITLE
fix(upload): keep decoded uploads until the browser reads them at submit

### DIFF
--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -107,6 +107,8 @@ func New(b bridge.BridgeAPI, cfg *config.RuntimeConfig, p bridge.ProfileService,
 
 	// Clean up .tmp export files orphaned by a previous crash.
 	go CleanupStaleTmpExports(cfg.StateDir)
+	// Clean up decoded base64 upload staging dirs left by older runs.
+	go CleanupStaleUploads(cfg.StateDir)
 
 	return h
 }

--- a/internal/handlers/upload.go
+++ b/internal/handlers/upload.go
@@ -91,15 +91,40 @@ func (h *Handlers) HandleUpload(w http.ResponseWriter, r *http.Request) {
 		req.Paths[i] = safe
 	}
 
-	// Decode base64 files to temp dir.
+	// Decode base64 files into a staged dir that OUTLIVES this request. CDP
+	// SetFileInputFiles only records the path on the <input>; the browser reads the
+	// bytes LAZILY at form-submit time, which is typically a separate, later
+	// request. Deleting the decoded file when this handler returns (the previous
+	// `defer os.RemoveAll`) left the file gone by submit time, so multipart
+	// submissions failed with ERR_FILE_NOT_FOUND ("Your file couldn't be accessed.
+	// It may have been moved, edited, or deleted."). Keep the staged files on the
+	// success path (reclaimed with the session StateDir) and only remove them if
+	// the upload fails before attaching to a tab.
 	var tempFiles []string
+	var stagedDir string
+	uploadSucceeded := false
+	defer func() {
+		if !uploadSucceeded && stagedDir != "" {
+			_ = os.RemoveAll(stagedDir)
+		}
+	}()
 	if len(req.Files) > 0 {
-		tmpDir, err := os.MkdirTemp("", "pinchtab-upload-*")
+		// Stage under StateDir/uploads when configured (persists for the session),
+		// else the OS temp dir — never the process working directory.
+		stageBase := os.TempDir()
+		if strings.TrimSpace(h.Config.StateDir) != "" {
+			if err := os.MkdirAll(uploadBase, 0o755); err != nil {
+				httpx.Error(w, 500, fmt.Errorf("create upload dir: %w", err))
+				return
+			}
+			stageBase = uploadBase
+		}
+		dir, err := os.MkdirTemp(stageBase, "pinchtab-upload-*")
 		if err != nil {
-			httpx.Error(w, 500, fmt.Errorf("create temp dir: %w", err))
+			httpx.Error(w, 500, fmt.Errorf("create staged dir: %w", err))
 			return
 		}
-		defer func() { _ = os.RemoveAll(tmpDir) }()
+		stagedDir = dir
 
 		for i, f := range req.Files {
 			data, ext, err := decodeFileData(f)
@@ -116,9 +141,9 @@ func (h *Handlers) HandleUpload(w http.ResponseWriter, r *http.Request) {
 				httpx.Error(w, 400, fmt.Errorf("upload payload too large: max %d bytes total", maxTotalBytes))
 				return
 			}
-			path := fmt.Sprintf("%s/upload-%d%s", tmpDir, i, ext)
+			path := fmt.Sprintf("%s/upload-%d%s", stagedDir, i, ext)
 			if err := os.WriteFile(path, data, 0600); err != nil {
-				httpx.Error(w, 500, fmt.Errorf("write temp file: %w", err))
+				httpx.Error(w, 500, fmt.Errorf("write staged file: %w", err))
 				return
 			}
 			tempFiles = append(tempFiles, path)
@@ -161,6 +186,10 @@ func (h *Handlers) HandleUpload(w http.ResponseWriter, r *http.Request) {
 	}
 
 	h.recordActivity(r, activity.Update{Action: "upload", TabID: resolvedTabID})
+
+	// Files attached successfully — keep the staged copies so the browser can read
+	// them at form-submit time (the deferred cleanup becomes a no-op).
+	uploadSucceeded = true
 
 	httpx.JSON(w, 200, map[string]any{
 		"status": "ok",

--- a/internal/handlers/upload.go
+++ b/internal/handlers/upload.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/dom"
@@ -25,7 +26,40 @@ type uploadRequest struct {
 }
 
 const (
-	uploadSandboxDirName = "uploads"
+	uploadSandboxDirName  = "uploads"
+	uploadStagedDirPrefix = "pinchtab-upload-"
+
+	// CDP keeps only the file path on the input, so decoded files need to remain
+	// available after /upload returns. Bound the lifetime so persistent StateDir
+	// installs do not retain successful base64 uploads forever.
+	uploadStagedRetention = 24 * time.Hour
+)
+
+var (
+	setUploadFileInputFiles = func(ctx context.Context, selector string, paths []string) error {
+		return chromedp.Run(ctx,
+			chromedp.ActionFunc(func(ctx context.Context) error {
+				nodeID, err := resolveSelector(ctx, selector)
+				if err != nil {
+					return fmt.Errorf("selector %q: %w", selector, err)
+				}
+				return dom.SetFileInputFiles(paths).WithNodeID(nodeID).Do(ctx)
+			}),
+		)
+	}
+
+	cleanupStagedUploadDirAfter = func(dir string, after time.Duration) {
+		if dir == "" {
+			return
+		}
+		if after <= 0 {
+			_ = os.RemoveAll(dir)
+			return
+		}
+		time.AfterFunc(after, func() {
+			_ = os.RemoveAll(dir)
+		})
+	}
 )
 
 // HandleUpload sets files on an <input type="file"> element via CDP.
@@ -40,7 +74,8 @@ const (
 //
 // Either "files" (base64 data) or "paths" (relative sandbox paths) must be
 // provided. Both can be combined. Files are written to a temp dir and passed to
-// CDP. Path-based uploads are limited to StateDir/uploads/.
+// CDP. Path-based uploads are limited to StateDir/uploads/. Successful base64
+// staging dirs are retained briefly for lazy browser reads, then cleaned.
 func (h *Handlers) HandleUpload(w http.ResponseWriter, r *http.Request) {
 	if !h.Config.AllowUpload {
 		httpx.ErrorCode(w, 403, "upload_disabled", httpx.DisabledEndpointMessage("upload", "security.allowUpload"), false, map[string]any{
@@ -98,7 +133,7 @@ func (h *Handlers) HandleUpload(w http.ResponseWriter, r *http.Request) {
 	// `defer os.RemoveAll`) left the file gone by submit time, so multipart
 	// submissions failed with ERR_FILE_NOT_FOUND ("Your file couldn't be accessed.
 	// It may have been moved, edited, or deleted."). Keep the staged files on the
-	// success path (reclaimed with the session StateDir) and only remove them if
+	// success path long enough for lazy reads, and only remove them immediately if
 	// the upload fails before attaching to a tab.
 	var tempFiles []string
 	var stagedDir string
@@ -109,8 +144,8 @@ func (h *Handlers) HandleUpload(w http.ResponseWriter, r *http.Request) {
 		}
 	}()
 	if len(req.Files) > 0 {
-		// Stage under StateDir/uploads when configured (persists for the session),
-		// else the OS temp dir — never the process working directory.
+		// Stage under StateDir/uploads when configured so paths survive this
+		// request, else the OS temp dir; never the process working directory.
 		stageBase := os.TempDir()
 		if strings.TrimSpace(h.Config.StateDir) != "" {
 			if err := os.MkdirAll(uploadBase, 0o755); err != nil {
@@ -119,7 +154,7 @@ func (h *Handlers) HandleUpload(w http.ResponseWriter, r *http.Request) {
 			}
 			stageBase = uploadBase
 		}
-		dir, err := os.MkdirTemp(stageBase, "pinchtab-upload-*")
+		dir, err := os.MkdirTemp(stageBase, uploadStagedDirPrefix+"*")
 		if err != nil {
 			httpx.Error(w, 500, fmt.Errorf("create staged dir: %w", err))
 			return
@@ -170,26 +205,19 @@ func (h *Handlers) HandleUpload(w http.ResponseWriter, r *http.Request) {
 	defer tCancel()
 	go httpx.CancelOnClientDone(r.Context(), tCancel)
 
-	// Find the file input node and set files via CDP.
-	if err := chromedp.Run(tCtx,
-		chromedp.ActionFunc(func(ctx context.Context) error {
-			// Evaluate selector to get the DOM node.
-			nodeID, err := resolveSelector(ctx, req.Selector)
-			if err != nil {
-				return fmt.Errorf("selector %q: %w", req.Selector, err)
-			}
-			return dom.SetFileInputFiles(allPaths).WithNodeID(nodeID).Do(ctx)
-		}),
-	); err != nil {
+	if err := setUploadFileInputFiles(tCtx, req.Selector, allPaths); err != nil {
 		httpx.Error(w, 500, fmt.Errorf("upload: %w", err))
 		return
 	}
 
 	h.recordActivity(r, activity.Update{Action: "upload", TabID: resolvedTabID})
 
-	// Files attached successfully — keep the staged copies so the browser can read
-	// them at form-submit time (the deferred cleanup becomes a no-op).
+	// Files attached successfully; keep the staged copies so the browser can read
+	// them at form-submit time, but schedule bounded cleanup.
 	uploadSucceeded = true
+	if stagedDir != "" {
+		cleanupStagedUploadDirAfter(stagedDir, uploadStagedRetention)
+	}
 
 	httpx.JSON(w, 200, map[string]any{
 		"status": "ok",
@@ -236,7 +264,7 @@ func resolveSelector(ctx context.Context, sel string) (cdp.NodeID, error) {
 		css := sel[len("css:"):]
 		expr = fmt.Sprintf(`document.querySelector(%q)`, css)
 	default:
-		// Bare selector — treat as CSS (backward compatible)
+		// Bare selector: treat as CSS (backward compatible).
 		expr = fmt.Sprintf(`document.querySelector(%q)`, sel)
 	}
 
@@ -280,6 +308,31 @@ func normalizeUploadSandboxPath(rawPath string) string {
 	trimmed := filepath.ToSlash(strings.TrimSpace(rawPath))
 	trimmed = strings.TrimPrefix(trimmed, uploadSandboxDirName+"/")
 	return filepath.FromSlash(trimmed)
+}
+
+// CleanupStaleUploads removes old decoded-upload staging dirs left in StateDir.
+// It is intentionally scoped to dirs created by HandleUpload and leaves
+// user-managed files in StateDir/uploads untouched.
+func CleanupStaleUploads(stateDir string) {
+	if strings.TrimSpace(stateDir) == "" {
+		return
+	}
+	uploadBase := filepath.Join(stateDir, uploadSandboxDirName)
+	entries, err := os.ReadDir(uploadBase)
+	if err != nil {
+		return
+	}
+	cutoff := time.Now().Add(-uploadStagedRetention)
+	for _, entry := range entries {
+		if !entry.IsDir() || !strings.HasPrefix(entry.Name(), uploadStagedDirPrefix) {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil || info.ModTime().After(cutoff) {
+			continue
+		}
+		_ = os.RemoveAll(filepath.Join(uploadBase, entry.Name()))
+	}
 }
 
 // decodeFileData handles "data:mime;base64,..." and raw base64 strings.

--- a/internal/handlers/upload_test.go
+++ b/internal/handlers/upload_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -329,5 +330,36 @@ func TestHandleUpload_Disabled(t *testing.T) {
 	h.HandleUpload(w, req)
 	if w.Code != 403 {
 		t.Errorf("expected 403 when upload disabled, got %d", w.Code)
+	}
+}
+
+// Regression: decoded base64 uploads must persist past the handler so the browser
+// can read them LAZILY at form-submit time (a separate later request). They are
+// kept on success and removed only on a pre-attach failure — never written into
+// the process working directory.
+func TestHandleUpload_StagedFilesCleanedOnFailureNotCWD(t *testing.T) {
+	tmpDir := t.TempDir()
+	h := New(&mockBridge{failTab: true}, &config.RuntimeConfig{AllowUpload: true, StateDir: tmpDir}, nil, nil, nil)
+	png := "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg=="
+	body := fmt.Sprintf(`{"selector":"input[type=file]","files":[%q]}`, png)
+	req := httptest.NewRequest("POST", "/upload?tabId=t1", bytes.NewReader([]byte(body)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.HandleUpload(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 (failTab) after decode, got %d", w.Code)
+	}
+	// The decode succeeded but the upload never attached to a tab → staged dir
+	// must be cleaned up.
+	entries, _ := os.ReadDir(filepath.Join(tmpDir, "uploads"))
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "pinchtab-upload-") {
+			t.Fatalf("staged upload dir leaked on failure: %s", e.Name())
+		}
+	}
+	// Must never create an "uploads" dir in the process working directory.
+	if _, err := os.Stat("uploads"); err == nil {
+		_ = os.RemoveAll("uploads")
+		t.Fatalf("upload handler created ./uploads in the working directory")
 	}
 }

--- a/internal/handlers/upload_test.go
+++ b/internal/handlers/upload_test.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"fmt"
 	"net/http"
@@ -335,7 +336,7 @@ func TestHandleUpload_Disabled(t *testing.T) {
 
 // Regression: decoded base64 uploads must persist past the handler so the browser
 // can read them LAZILY at form-submit time (a separate later request). They are
-// kept on success and removed only on a pre-attach failure — never written into
+// kept on success and removed only on a pre-attach failure; never written into
 // the process working directory.
 func TestHandleUpload_StagedFilesCleanedOnFailureNotCWD(t *testing.T) {
 	tmpDir := t.TempDir()
@@ -361,5 +362,108 @@ func TestHandleUpload_StagedFilesCleanedOnFailureNotCWD(t *testing.T) {
 	if _, err := os.Stat("uploads"); err == nil {
 		_ = os.RemoveAll("uploads")
 		t.Fatalf("upload handler created ./uploads in the working directory")
+	}
+}
+
+func TestHandleUpload_SuccessSchedulesStagedCleanup(t *testing.T) {
+	origSetUploadFileInputFiles := setUploadFileInputFiles
+	origCleanupStagedUploadDirAfter := cleanupStagedUploadDirAfter
+	t.Cleanup(func() {
+		setUploadFileInputFiles = origSetUploadFileInputFiles
+		cleanupStagedUploadDirAfter = origCleanupStagedUploadDirAfter
+	})
+
+	var attachedPaths []string
+	setUploadFileInputFiles = func(_ context.Context, selector string, paths []string) error {
+		if selector != "input[type=file]" {
+			t.Fatalf("selector = %q, want default file input", selector)
+		}
+		attachedPaths = append([]string(nil), paths...)
+		for _, path := range attachedPaths {
+			if _, err := os.Stat(path); err != nil {
+				t.Fatalf("staged file was not readable before attach: %v", err)
+			}
+		}
+		return nil
+	}
+
+	var cleanupDir string
+	var cleanupAfter time.Duration
+	cleanupStagedUploadDirAfter = func(dir string, after time.Duration) {
+		cleanupDir = dir
+		cleanupAfter = after
+		_ = os.RemoveAll(dir)
+	}
+
+	tmpDir := t.TempDir()
+	h := New(&mockBridge{}, &config.RuntimeConfig{AllowUpload: true, StateDir: tmpDir}, nil, nil, nil)
+	req := httptest.NewRequest("POST", "/upload?tabId=t1", bytes.NewReader([]byte(`{"files":["aGVsbG8="]}`)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.HandleUpload(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if len(attachedPaths) != 1 {
+		t.Fatalf("attached paths = %d, want 1", len(attachedPaths))
+	}
+	if cleanupDir == "" {
+		t.Fatal("successful upload did not schedule staged cleanup")
+	}
+	if cleanupAfter != uploadStagedRetention {
+		t.Fatalf("cleanup delay = %s, want %s", cleanupAfter, uploadStagedRetention)
+	}
+	if !strings.HasPrefix(filepath.Base(cleanupDir), "pinchtab-upload-") {
+		t.Fatalf("cleanup dir %q does not use staged upload prefix", cleanupDir)
+	}
+	if filepath.Dir(cleanupDir) != filepath.Join(tmpDir, "uploads") {
+		t.Fatalf("cleanup dir %q not under state uploads dir", cleanupDir)
+	}
+	if _, err := os.Stat(cleanupDir); !os.IsNotExist(err) {
+		t.Fatalf("scheduled cleanup did not remove staged dir in test: %v", err)
+	}
+}
+
+func TestNewCleansStaleUploadStagingDirs(t *testing.T) {
+	tmpDir := t.TempDir()
+	uploadsDir := filepath.Join(tmpDir, "uploads")
+	staleDir := filepath.Join(uploadsDir, "pinchtab-upload-stale")
+	freshDir := filepath.Join(uploadsDir, "pinchtab-upload-fresh")
+	userDir := filepath.Join(uploadsDir, "user-managed")
+
+	for _, dir := range []string{staleDir, freshDir, userDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "upload-0.txt"), []byte("hello"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	old := time.Now().Add(-25 * time.Hour)
+	if err := os.Chtimes(staleDir, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	_ = New(&mockBridge{}, &config.RuntimeConfig{StateDir: tmpDir}, nil, nil, nil)
+
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for {
+		_, err := os.Stat(staleDir)
+		if os.IsNotExist(err) {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("stale upload staging dir was not cleaned: %v", err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if _, err := os.Stat(freshDir); err != nil {
+		t.Fatalf("fresh upload staging dir should be kept: %v", err)
+	}
+	if _, err := os.Stat(userDir); err != nil {
+		t.Fatalf("non-staged upload sandbox dir should be kept: %v", err)
 	}
 }


### PR DESCRIPTION
Fixes #577.

### Problem

`HandleUpload` decoded base64 `files` into an `os.MkdirTemp` dir and `defer os.RemoveAll`'d it when the handler returned. `dom.SetFileInputFiles` only records the path on the `<input>`; the browser reads the bytes **lazily at form-submit time** (a separate, later request), so by then the file was gone — multipart submissions failed with `ERR_FILE_NOT_FOUND` or submitted an empty field.

### Fix

- Stage decoded files under `StateDir/uploads` (or the OS temp dir when no `StateDir` is configured) — never the process working directory.
- Keep them on the success path (reclaimed when the session `StateDir` is torn down); remove them only when the upload fails before attaching to a tab (via a `uploadSucceeded` guard).

Path-based (`paths`) uploads are unchanged.

### Test

Adds `TestHandleUpload_StagedFilesCleanedOnFailureNotCWD`: a failed upload (no tab) cleans the staged dir and never creates `./uploads`. `go test ./internal/handlers/` passes.