### PR TITLE
fix: prefer automation-dedicated Chrome on macOS to avoid hijacking the user's daily browser (#583)

### DIFF
--- a/internal/bridge/runtime/init.go
+++ b/internal/bridge/runtime/init.go
@@ -96,10 +96,17 @@ func findChromeBinary() string {
 	var candidates []string
 	switch goruntime.GOOS {
 	case "darwin":
+		// Prefer browsers dedicated to automation so we don't hijack the
+		// user's primary Google Chrome. On macOS, launching the primary
+		// Chrome.app executable registers "Google Chrome" with LaunchServices;
+		// the user can then no longer open their normal Chrome (the OS just
+		// activates our windowless automation instance). Keep the daily
+		// Google Chrome as a last resort. See issue #583.
 		candidates = []string{
-			"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+			"/Applications/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing",
 			"/Applications/Chromium.app/Contents/MacOS/Chromium",
 			"/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary",
+			"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
 		}
 	case "windows":
 		candidates = []string{


### PR DESCRIPTION
## What & why

On macOS, `findChromeBinary()` (`internal/bridge/runtime/init.go`) picked the user's **primary** Google Chrome first. Launching that app bundle's executable — even headless and with an isolated `--user-data-dir` — registers "Google Chrome" with macOS LaunchServices, so the user can no longer open their normal Chrome: clicking the Dock icon just activates our windowless automation instance. With the auto-started daemon this happens at login and looks like Chrome is broken.

Fixes #583.

## Change

Reorder the macOS candidate list to prefer browsers dedicated to automation, keeping the daily Google Chrome as a **last resort**:

```
1. Google Chrome for Testing   (the automation-recommended binary)
2. Chromium
3. Google Chrome Canary
4. Google Chrome               (daily browser — fallback only)
```

- Users with **only** daily Chrome installed are unaffected — it remains the fallback.
- Users who install *Google Chrome for Testing* (or have Chromium/Canary) get an isolated browser that doesn't collide with their daily Chrome. This mirrors Puppeteer/Playwright guidance to use Chrome for Testing for automation.
- `browser.binary` still overrides everything.

Scope kept to macOS, where the LaunchServices collision occurs.

## Testing

- `gofmt` clean; `go build ./internal/bridge/runtime/` passes.
- Verified the original behavior and workaround on macOS 15 (Darwin 25), PinchTab 0.13.2, Chrome 148: stopping/uninstalling the daemon and killing the `~/.pinchtab` Chrome restores normal Chrome — confirming the primary-Chrome launch is the cause.

## Follow-ups (not in this PR; happy to do separately)

- Warn when the resolved binary is the user's primary Chrome on macOS, and/or don't auto-launch it from the daemon by default.
- Document the `browser.binary` override and the Chrome-for-Testing recommendation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
