### PR TITLE
fix: resolve upload selectors inside open shadow roots

### DIFF
--- a/internal/bridge/action_resolve.go
+++ b/internal/bridge/action_resolve.go
@@ -403,8 +403,19 @@ const resolveSelectorAtFn = `function(kind, value, index, fromEnd) {
 		if (idx < 0 || idx >= items.length) return null;
 		return items[idx];
 	};
+	const deepQueryAll = (selector) => {
+		const out = [];
+		const visit = (scope) => {
+			if (!scope || !scope.querySelectorAll) return;
+			const elements = Array.from(scope.querySelectorAll("*"));
+			out.push(...Array.from(scope.querySelectorAll(selector)));
+			for (const el of elements) if (el.shadowRoot) visit(el.shadowRoot);
+		};
+		visit(root);
+		return out;
+	};
 	const textCandidates = (query) => {
-		const elements = Array.from((root.body || root.documentElement || root).querySelectorAll("*"));
+		const elements = deepQueryAll("*");
 		const exact = [];
 		for (const el of elements) {
 			const text = normalize(el.textContent || "");
@@ -435,7 +446,7 @@ const resolveSelectorAtFn = `function(kind, value, index, fromEnd) {
 	try {
 		switch (kind) {
 		case "css":
-			return pick(Array.from(root.querySelectorAll(value)));
+			return pick(deepQueryAll(value));
 		case "xpath": {
 			const result = root.evaluate(value, root, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null);
 			const items = [];

--- a/internal/bridge/action_resolve.go
+++ b/internal/bridge/action_resolve.go
@@ -535,69 +535,12 @@ func ResolveCSSToNodeID(ctx context.Context, css string) (int64, error) {
 }
 
 func ResolveCSSToNodeIDInFrame(ctx context.Context, frameID, css string) (int64, error) {
-	if frameID == "" {
-		var backendNodeID int64
-		err := chromedp.Run(ctx, chromedp.ActionFunc(func(ctx context.Context) error {
-			var docResult json.RawMessage
-			if err := chromedp.FromContext(ctx).Target.Execute(ctx, "DOM.getDocument", map[string]any{"depth": 0}, &docResult); err != nil {
-				return fmt.Errorf("get document: %w", err)
-			}
-			var doc struct {
-				Root struct {
-					NodeID int64 `json:"nodeId"`
-				} `json:"root"`
-			}
-			if err := json.Unmarshal(docResult, &doc); err != nil {
-				return err
-			}
-
-			var qResult json.RawMessage
-			if err := chromedp.FromContext(ctx).Target.Execute(ctx, "DOM.querySelector", map[string]any{
-				"nodeId":   doc.Root.NodeID,
-				"selector": css,
-			}, &qResult); err != nil {
-				return fmt.Errorf("querySelector: %w", err)
-			}
-			var qr struct {
-				NodeID int64 `json:"nodeId"`
-			}
-			if err := json.Unmarshal(qResult, &qr); err != nil {
-				return err
-			}
-			if qr.NodeID == 0 {
-				return fmt.Errorf("css %q: %w", css, ErrSelectorNoMatch)
-			}
-
-			var descResult json.RawMessage
-			if err := chromedp.FromContext(ctx).Target.Execute(ctx, "DOM.describeNode", map[string]any{
-				"nodeId": qr.NodeID,
-			}, &descResult); err != nil {
-				return fmt.Errorf("describe node: %w", err)
-			}
-			var desc struct {
-				Node struct {
-					BackendNodeID int64 `json:"backendNodeId"`
-				} `json:"node"`
-			}
-			if err := json.Unmarshal(descResult, &desc); err != nil {
-				return err
-			}
-			backendNodeID = desc.Node.BackendNodeID
-			return nil
-		}))
-		return backendNodeID, err
-	}
-
-	var backendNodeID int64
-	err := chromedp.Run(ctx, chromedp.ActionFunc(func(ctx context.Context) error {
-		nid, err := resolveNodeInFrame(ctx, frameID, `function(selector) { return this.querySelector(selector); }`, []map[string]any{{"value": css}})
-		if err != nil {
-			return fmt.Errorf("css %q: %w", css, err)
-		}
-		backendNodeID = nid
-		return nil
-	}))
-	return backendNodeID, err
+	// Resolve through the deep selector walker (resolveSelectorAtFn → deepQueryAll)
+	// so a CSS selector matches the first element even when it is nested in an open
+	// shadow root, not just the light DOM (issue #591). For light-DOM pages this
+	// returns the same first match as document.querySelector, and it works for both
+	// the main frame (frameID == "") and sub-frames.
+	return resolveSelectorAtInFrame(ctx, frameID, selector.Selector{Kind: selector.KindCSS, Value: css}, 0, false)
 }
 
 func ResolveXPathToNodeIDInFrame(ctx context.Context, frameID, xpath string) (int64, error) {

--- a/internal/bridge/action_resolve_test.go
+++ b/internal/bridge/action_resolve_test.go
@@ -3,6 +3,7 @@ package bridge
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/pinchtab/pinchtab/internal/selector"
@@ -21,6 +22,18 @@ func TestResolveUnifiedSelector_ErrorClassification(t *testing.T) {
 	}
 	if _, err := ResolveUnifiedSelectorInFrame(ctx, selector.Selector{Kind: "bogus", Value: "x"}, nil, ""); err == nil || errors.Is(err, ErrSelectorNoMatch) {
 		t.Errorf("unknown selector kind should be non-no-match (5xx), got %v", err)
+	}
+}
+
+func TestResolveSelectorAtFnSearchesOpenShadowRoots(t *testing.T) {
+	if !strings.Contains(resolveSelectorAtFn, "shadowRoot") {
+		t.Fatal("selector resolver should walk open shadow roots")
+	}
+	if !strings.Contains(resolveSelectorAtFn, "return pick(deepQueryAll(value))") {
+		t.Fatal("css selectors should use deepQueryAll")
+	}
+	if strings.Contains(resolveSelectorAtFn, "return pick(Array.from(root.querySelectorAll(value)))") {
+		t.Fatal("css selectors should not use document-only querySelectorAll")
 	}
 }
 

--- a/internal/bridge/upload.go
+++ b/internal/bridge/upload.go
@@ -2,57 +2,21 @@ package bridge
 
 import (
 	"context"
-	"fmt"
-	"strings"
 
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/dom"
-	"github.com/chromedp/cdproto/runtime"
 	"github.com/chromedp/chromedp"
+	"github.com/pinchtab/pinchtab/internal/selector"
 )
 
-func (b *Bridge) SetFileInputFiles(ctx context.Context, nodeID int64, paths []string) error {
+func (b *Bridge) SetFileInputFiles(ctx context.Context, backendNodeID int64, paths []string) error {
 	return chromedp.Run(ctx, chromedp.ActionFunc(func(ctx context.Context) error {
-		return dom.SetFileInputFiles(paths).WithNodeID(cdp.NodeID(nodeID)).Do(ctx)
+		return dom.SetFileInputFiles(paths).WithBackendNodeID(cdp.BackendNodeID(backendNodeID)).Do(ctx)
 	}))
 }
 
 // ResolveSelectorToNodeID finds a DOM node by a unified selector string and returns its NodeID.
 // Supports CSS (default), XPath (xpath: prefix or // auto-detect), and text (text: prefix).
-func (b *Bridge) ResolveSelectorToNodeID(ctx context.Context, selector string) (int64, error) {
-	var nodeID int64
-	err := chromedp.Run(ctx, chromedp.ActionFunc(func(ctx context.Context) error {
-		var expr string
-		switch {
-		case strings.HasPrefix(selector, "xpath:"):
-			xpath := selector[len("xpath:"):]
-			expr = fmt.Sprintf(`(function(){var r=document.evaluate(%q,document,null,XPathResult.FIRST_ORDERED_NODE_TYPE,null);return r.singleNodeValue})()`, xpath)
-		case strings.HasPrefix(selector, "//") || strings.HasPrefix(selector, "(//"):
-			expr = fmt.Sprintf(`(function(){var r=document.evaluate(%q,document,null,XPathResult.FIRST_ORDERED_NODE_TYPE,null);return r.singleNodeValue})()`, selector)
-		case strings.HasPrefix(selector, "text:"):
-			text := selector[len("text:"):]
-			expr = fmt.Sprintf(`(function(){var w=document.createTreeWalker(document.body,NodeFilter.SHOW_TEXT);while(w.nextNode()){if(w.currentNode.textContent.includes(%q))return w.currentNode.parentElement}return null})()`, text)
-		case strings.HasPrefix(selector, "css:"):
-			css := selector[len("css:"):]
-			expr = fmt.Sprintf(`document.querySelector(%q)`, css)
-		default:
-			// Bare selector — treat as CSS (backward compatible)
-			expr = fmt.Sprintf(`document.querySelector(%q)`, selector)
-		}
-
-		val, _, err := runtime.Evaluate(expr).Do(ctx)
-		if err != nil {
-			return fmt.Errorf("evaluate: %w", err)
-		}
-		if val.ObjectID == "" {
-			return fmt.Errorf("no element matches selector")
-		}
-		node, err := dom.RequestNode(val.ObjectID).Do(ctx)
-		if err != nil {
-			return fmt.Errorf("request node: %w", err)
-		}
-		nodeID = int64(node)
-		return nil
-	}))
-	return nodeID, err
+func (b *Bridge) ResolveSelectorToNodeID(ctx context.Context, raw string) (int64, error) {
+	return ResolveUnifiedSelectorInFrame(ctx, selector.Parse(raw), nil, "")
 }

--- a/tests/e2e/fixtures/upload-shadow.html
+++ b/tests/e2e/fixtures/upload-shadow.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>E2E Test - Upload (Open Shadow Root)</title>
+</head>
+<body>
+  <h1>Upload Shadow Root Test</h1>
+
+  <!-- The file input lives inside a custom element's OPEN shadow root, so a plain
+       document.querySelector('#shadow-file') returns null. The upload selector
+       resolver must walk open shadow roots (deepQueryAll) to find it (#591). -->
+  <upload-widget></upload-widget>
+
+  <div id="status">files:0</div>
+
+  <script>
+    window.__uploadedNames = "";
+    class UploadWidget extends HTMLElement {
+      constructor() {
+        super();
+        const root = this.attachShadow({ mode: "open" });
+        const input = document.createElement("input");
+        input.type = "file";
+        input.id = "shadow-file";
+        input.name = "file";
+        input.multiple = true;
+        root.appendChild(input);
+        input.addEventListener("change", () => {
+          document.getElementById("status").textContent = "files:" + input.files.length;
+          window.__uploadedNames = Array.from(input.files).map((f) => f.name).join(",");
+        });
+      }
+    }
+    customElements.define("upload-widget", UploadWidget);
+  </script>
+</body>
+</html>

--- a/tests/e2e/scenarios/api/files-extended.sh
+++ b/tests/e2e/scenarios/api/files-extended.sh
@@ -59,6 +59,24 @@ assert_contains "$RESULT" "too many files" "too many files message returned"
 
 end_test
 
+# ─────────────────────────────────────────────────────────────────
+start_test "upload: selector inside open shadow root (#591)"
+
+pt_post /navigate "{\"url\":\"${FIXTURES_URL}/upload-shadow.html\"}"
+assert_ok "navigate to upload-shadow.html"
+
+# The file input is nested in a custom element's open shadow root, so a plain
+# document.querySelector('#shadow-file') returns null — the selector resolver
+# must walk open shadow roots (deepQueryAll) to find it.
+pt_post /upload '{"selector":"#shadow-file","files":["data:text/plain;base64,SGVsbG8="]}'
+assert_ok "upload resolves a selector inside an open shadow root"
+
+# Confirm the file actually landed on the shadow-root input.
+pt_post /evaluate '{"expression":"document.querySelector(\"upload-widget\").shadowRoot.getElementById(\"shadow-file\").files.length"}'
+assert_json_eq "$RESULT" ".result" "1" "file landed on the shadow-root input"
+
+end_test
+
 # Migrated from: tests/integration/pdf_test.go (PD1-PD12)
 
 pt_post /navigate "{\"url\":\"${FIXTURES_URL}/table.html\"}"


### PR DESCRIPTION
## Summary
- route upload selector resolution through the shared unified selector resolver
- let CSS selectors walk open shadow roots before picking the matched element
- use backend node IDs when setting file inputs, matching the shared resolver output

Fixes #591.

## Test
- go test ./internal/bridge -run 'TestResolveSelectorAtFnSearchesOpenShadowRoots|TestResolveUnifiedSelector|TestParseNthSelectorValue'
- go test ./internal/handlers -run 'TestHandleUpload|TestUpload|TestCleanupStaleUploads'
- git diff --check