### PR TITLE
feat(autosolver): implement CapSolver external solver + Arkose FunCaptcha blob capture

### DIFF
--- a/internal/autosolver/external/capsolver.go
+++ b/internal/autosolver/external/capsolver.go
@@ -1,12 +1,18 @@
-// Package external provides skeleton implementations for third-party
-// CAPTCHA solving services (Capsolver, 2Captcha). These are designed
-// as pluggable solvers enabled via configuration.
+// Package external provides implementations for third-party CAPTCHA
+// solving services (Capsolver, 2Captcha). These are pluggable solvers
+// enabled via configuration.
 package external
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"regexp"
 	"strings"
+	"time"
 
 	"github.com/pinchtab/pinchtab/internal/autosolver"
 )
@@ -15,12 +21,16 @@ import (
 type CapsolverConfig struct {
 	APIKey  string `json:"apiKey"`
 	BaseURL string `json:"baseUrl,omitempty"` // Default: https://api.capsolver.com
+	// PollInterval is the getTaskResult poll cadence. Default: 3s.
+	PollInterval time.Duration `json:"-"`
 }
 
 // Capsolver implements autosolver.Solver using the Capsolver API.
-// It supports reCAPTCHA v2/v3, hCaptcha, and Cloudflare Turnstile.
+// It supports reCAPTCHA v2, hCaptcha, Cloudflare Turnstile, and Arkose
+// Labs FunCaptcha.
 type Capsolver struct {
 	config CapsolverConfig
+	client *http.Client
 }
 
 // NewCapsolver creates a Capsolver solver with the given configuration.
@@ -28,7 +38,13 @@ func NewCapsolver(cfg CapsolverConfig) *Capsolver {
 	if cfg.BaseURL == "" {
 		cfg.BaseURL = "https://api.capsolver.com"
 	}
-	return &Capsolver{config: cfg}
+	if cfg.PollInterval <= 0 {
+		cfg.PollInterval = 3 * time.Second
+	}
+	return &Capsolver{
+		config: cfg,
+		client: &http.Client{Timeout: 30 * time.Second},
+	}
 }
 
 func (c *Capsolver) Name() string  { return "capsolver" }
@@ -45,27 +61,12 @@ func (c *Capsolver) CanHandle(ctx context.Context, page autosolver.Page) (bool, 
 		return false, nil
 	}
 
-	lower := strings.ToLower(html)
-	captchaPatterns := []string{
-		"recaptcha",
-		"hcaptcha",
-		"challenges.cloudflare.com/turnstile",
-		"g-recaptcha",
-		"h-captcha",
-	}
-	for _, p := range captchaPatterns {
-		if strings.Contains(lower, p) {
-			return true, nil
-		}
-	}
-	return false, nil
+	return detectCaptchaType(html) != "", nil
 }
 
-// Solve submits the CAPTCHA to the Capsolver API and injects the result.
-//
-// This is a skeleton implementation. The actual HTTP client logic
-// (create task → poll result → inject token) must be filled in
-// with the Capsolver API v1 protocol.
+// Solve submits the CAPTCHA to the Capsolver API (createTask → poll
+// getTaskResult), then injects the returned token into the page and
+// fires the challenge callback where applicable.
 func (c *Capsolver) Solve(ctx context.Context, page autosolver.Page, executor autosolver.ActionExecutor) (*autosolver.Result, error) {
 	result := &autosolver.Result{SolverUsed: "capsolver"}
 
@@ -86,63 +87,383 @@ func (c *Capsolver) Solve(ctx context.Context, page autosolver.Page, executor au
 		return result, fmt.Errorf("no supported CAPTCHA detected on page")
 	}
 
-	sitekey := extractSitekey(html, captchaType)
-	if sitekey == "" {
+	key := extractSitekey(html, captchaType)
+	if key == "" {
 		result.Error = "sitekey not found"
-		return result, fmt.Errorf("could not extract sitekey from page")
+		return result, fmt.Errorf("could not extract sitekey/public key from page")
 	}
 
-	// TODO: Implement HTTP client for Capsolver API v1.
-	// POST /createTask with task type + sitekey + page URL.
-	_ = sitekey
-	_ = page.URL()
+	taskType, ok := capsolverTaskType(captchaType)
+	if !ok {
+		result.Error = fmt.Sprintf("unsupported captcha type for capsolver: %s", captchaType)
+		return result, fmt.Errorf("unsupported captcha type: %s", captchaType)
+	}
 
-	result.Error = "capsolver API client not yet implemented"
-	return result, fmt.Errorf("capsolver: API client not yet implemented — skeleton only")
+	// FunCaptcha additionally needs the Arkose API JS subdomain and — for
+	// modern deployments (LinkedIn) — the per-session data blob. The blob,
+	// public key, and service URL are captured at document-start by the bridge's
+	// Arkose hook (window.__ptArkose); prefer those live values over static HTML.
+	arkoseSubdomain := ""
+	blob := ""
+	if captchaType == "funcaptcha" {
+		arkoseSubdomain = extractArkoseSubdomain(html)
+		if ac := readArkoseCapture(ctx, executor); ac != nil {
+			if ac.Blob != "" {
+				blob = ac.Blob
+			}
+			if ac.PK != "" {
+				key = ac.PK
+			}
+			if ac.Surl != "" {
+				arkoseSubdomain = ac.Surl
+			}
+		}
+	}
+
+	token, err := c.solveRemote(ctx, captchaType, taskType, page.URL(), key, arkoseSubdomain, blob)
+	if err != nil {
+		result.Error = err.Error()
+		return result, err
+	}
+
+	if err := injectToken(ctx, executor, captchaType, token); err != nil {
+		result.Error = fmt.Sprintf("inject token: %v", err)
+		return result, err
+	}
+
+	result.Solved = true
+	result.FinalTitle = page.Title()
+	result.FinalURL = page.URL()
+	return result, nil
 }
 
+// capsolverTaskType maps an internal captcha type to a Capsolver
+// proxyless task type. Proxyless means Capsolver solves from its own
+// infrastructure — browsing-side proxying is a separate concern.
+func capsolverTaskType(captchaType string) (string, bool) {
+	switch captchaType {
+	case "recaptcha":
+		return "ReCaptchaV2TaskProxyLess", true
+	case "hcaptcha":
+		return "HCaptchaTaskProxyLess", true
+	case "turnstile":
+		return "AntiTurnstileTaskProxyLess", true
+	case "funcaptcha":
+		return "FunCaptchaTaskProxyLess", true
+	default:
+		return "", false
+	}
+}
+
+// --- Capsolver API v1 client ---
+
+type capsolverTask struct {
+	Type       string `json:"type"`
+	WebsiteURL string `json:"websiteURL"`
+	// reCAPTCHA / hCaptcha / Turnstile use websiteKey (data-sitekey).
+	WebsiteKey string `json:"websiteKey,omitempty"`
+	// FunCaptcha uses websitePublicKey (data-pkey) + the Arkose API subdomain,
+	// and (for modern deployments like LinkedIn) the per-session data blob,
+	// passed as a JSON-encoded string e.g. {"blob":"…"}.
+	WebsitePublicKey         string `json:"websitePublicKey,omitempty"`
+	FuncaptchaApiJSSubdomain string `json:"funcaptchaApiJSSubdomain,omitempty"`
+	Data                     string `json:"data,omitempty"`
+}
+
+type capsolverCreateRequest struct {
+	ClientKey string        `json:"clientKey"`
+	Task      capsolverTask `json:"task"`
+}
+
+type capsolverResultRequest struct {
+	ClientKey string `json:"clientKey"`
+	TaskID    string `json:"taskId"`
+}
+
+type capsolverSolution struct {
+	GRecaptchaResponse string `json:"gRecaptchaResponse"`
+	Token              string `json:"token"`
+}
+
+type capsolverResponse struct {
+	ErrorID          int               `json:"errorId"`
+	ErrorCode        string            `json:"errorCode"`
+	ErrorDescription string            `json:"errorDescription"`
+	TaskID           string            `json:"taskId"`
+	Status           string            `json:"status"`
+	Solution         capsolverSolution `json:"solution"`
+}
+
+// solveRemote runs the full create → poll cycle and returns the token.
+func (c *Capsolver) solveRemote(ctx context.Context, captchaType, taskType, pageURL, key, arkoseSubdomain, blob string) (string, error) {
+	task := capsolverTask{Type: taskType, WebsiteURL: pageURL}
+	if captchaType == "funcaptcha" {
+		task.WebsitePublicKey = key
+		task.FuncaptchaApiJSSubdomain = arkoseSubdomain
+		if blob != "" {
+			if b, err := json.Marshal(map[string]string{"blob": blob}); err == nil {
+				task.Data = string(b)
+			}
+		}
+	} else {
+		task.WebsiteKey = key
+	}
+
+	var created capsolverResponse
+	if err := c.postJSON(ctx, "/createTask", capsolverCreateRequest{ClientKey: c.config.APIKey, Task: task}, &created); err != nil {
+		return "", fmt.Errorf("capsolver createTask: %w", err)
+	}
+	if created.ErrorID != 0 {
+		return "", fmt.Errorf("capsolver createTask error %s: %s", created.ErrorCode, created.ErrorDescription)
+	}
+	// Defensive fast-path: the ProxyLess task types we submit always return a
+	// taskId and require polling, so created.Solution is empty here in practice.
+	// This handles the documented case where a future/synchronous task type
+	// returns the solution inline — guarded so we never poll a task we've solved.
+	if tok := pickToken(created.Solution); tok != "" {
+		return tok, nil
+	}
+	if created.TaskID == "" {
+		return "", fmt.Errorf("capsolver createTask returned no taskId")
+	}
+
+	ticker := time.NewTicker(c.config.PollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return "", fmt.Errorf("capsolver: context cancelled while polling: %w", ctx.Err())
+		case <-ticker.C:
+			var res capsolverResponse
+			err := c.postJSON(ctx, "/getTaskResult", capsolverResultRequest{
+				ClientKey: c.config.APIKey,
+				TaskID:    created.TaskID,
+			}, &res)
+			if err != nil {
+				return "", fmt.Errorf("capsolver getTaskResult: %w", err)
+			}
+			if res.ErrorID != 0 {
+				return "", fmt.Errorf("capsolver getTaskResult error %s: %s", res.ErrorCode, res.ErrorDescription)
+			}
+			switch res.Status {
+			case "ready":
+				if tok := pickToken(res.Solution); tok != "" {
+					return tok, nil
+				}
+				return "", fmt.Errorf("capsolver returned ready with empty token")
+			case "failed", "error":
+				// Terminal failure that didn't set errorId — stop polling
+				// instead of burning the whole solver deadline.
+				return "", fmt.Errorf("capsolver task failed (status %q): %s %s", res.Status, res.ErrorCode, res.ErrorDescription)
+			}
+			// status "processing" / "idle" → keep polling
+		}
+	}
+}
+
+// arkoseCapture holds the per-session Arkose values grabbed by the bridge's
+// document-start hook (window.__ptArkose).
+type arkoseCapture struct {
+	Blob string `json:"blob"`
+	PK   string `json:"pk"`
+	Surl string `json:"surl"`
+}
+
+// readArkoseCapture reads window.__ptArkose from the live page. Returns nil if
+// the hook captured nothing (non-Arkose page, or blob not yet set).
+func readArkoseCapture(ctx context.Context, executor autosolver.ActionExecutor) *arkoseCapture {
+	var raw string
+	expr := `(function(){try{return window.__ptArkose?JSON.stringify(window.__ptArkose):"";}catch(e){return "";}})()`
+	if err := executor.Evaluate(ctx, expr, &raw); err != nil || raw == "" {
+		return nil
+	}
+	var ac arkoseCapture
+	if err := json.Unmarshal([]byte(raw), &ac); err != nil {
+		return nil
+	}
+	return &ac
+}
+
+// pickToken returns the solve token regardless of which field CapSolver used.
+// Across the four supported types the two fields are mutually exclusive —
+// reCAPTCHA/hCaptcha populate gRecaptchaResponse, Turnstile/FunCaptcha populate
+// token — so preference order is irrelevant today. If a future task type ever
+// populates both, this preference becomes load-bearing; revisit then.
+func pickToken(s capsolverSolution) string {
+	if s.GRecaptchaResponse != "" {
+		return s.GRecaptchaResponse
+	}
+	return s.Token
+}
+
+func (c *Capsolver) postJSON(ctx context.Context, path string, body, out interface{}) error {
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.config.BaseURL+path, bytes.NewReader(buf))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	data, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("http %d: %s", resp.StatusCode, strings.TrimSpace(string(data)))
+	}
+	return json.Unmarshal(data, out)
+}
+
+// --- token injection ---
+
+// injectToken writes the solved token into the page's response field(s)
+// and, for reCAPTCHA, fires the registered callback so the host page
+// advances without a manual submit.
+func injectToken(ctx context.Context, executor autosolver.ActionExecutor, captchaType, token string) error {
+	var js string
+	switch captchaType {
+	case "recaptcha":
+		js = recaptchaInjectJS
+	case "hcaptcha":
+		js = hcaptchaInjectJS
+	case "turnstile":
+		js = turnstileInjectJS
+	case "funcaptcha":
+		js = funcaptchaInjectJS
+	default:
+		return fmt.Errorf("no injector for captcha type %q", captchaType)
+	}
+	// The injector is an IIFE taking the token as its argument. Encode the
+	// token with json.Marshal — not %q — so it is a valid JS string literal
+	// (Go's %q does not escape U+2028/U+2029, which break a JS string).
+	tokenLit, err := json.Marshal(token)
+	if err != nil {
+		return fmt.Errorf("encode token for injection: %w", err)
+	}
+	var ok bool
+	expr := fmt.Sprintf("(%s)(%s)", js, tokenLit)
+	return executor.Evaluate(ctx, expr, &ok)
+}
+
+const recaptchaInjectJS = `function(token){
+  var els=document.querySelectorAll('textarea#g-recaptcha-response, textarea[name="g-recaptcha-response"]');
+  if(!els.length){
+    var ta=document.createElement('textarea');
+    ta.id='g-recaptcha-response'; ta.name='g-recaptcha-response';
+    ta.style.display='none'; document.body.appendChild(ta);
+    els=[ta];
+  }
+  els.forEach(function(el){el.value=token;});
+  try{
+    var cfg=window.___grecaptcha_cfg;
+    if(cfg&&cfg.clients){
+      for(var cid in cfg.clients){
+        var client=cfg.clients[cid];
+        for(var k in client){
+          var o=client[k];
+          if(o&&typeof o==='object'){
+            for(var kk in o){
+              var oo=o[kk];
+              if(oo&&typeof oo==='object'&&typeof oo.callback==='function'){
+                try{oo.callback(token);}catch(e){}
+              }
+            }
+          }
+        }
+      }
+    }
+  }catch(e){}
+  return true;
+}`
+
+const hcaptchaInjectJS = `function(token){
+  document.querySelectorAll('textarea[name="h-captcha-response"], textarea[name="g-recaptcha-response"]').forEach(function(el){el.value=token;});
+  return true;
+}`
+
+const turnstileInjectJS = `function(token){
+  document.querySelectorAll('input[name="cf-turnstile-response"], textarea[name="cf-turnstile-response"]').forEach(function(el){el.value=token;});
+  return true;
+}`
+
+// funcaptchaInjectJS is best-effort: Arkose token consumption is
+// integration-specific. We populate the common hidden token fields and
+// emit the standard Arkose "challenge complete" postMessage that many
+// enforcement embeds listen for. Sites with a custom callback may still
+// require site-specific glue after the token is obtained.
+const funcaptchaInjectJS = `function(token){
+  var sel='input[name="fc-token"], input[name="verification-token"], input[name="arkose-token"], input[id*="arkose"], input[name*="captcha-token"], input[name="captchaResponse"]';
+  document.querySelectorAll(sel).forEach(function(el){el.value=token;});
+  // Preferred path: deliver the token through the site's own Arkose completion
+  // callback, captured at document-start by the bridge hook.
+  try{ if(typeof window.__ptArkoseOnCompleted==='function'){ window.__ptArkoseOnCompleted({token:token}); } }catch(e){}
+  try{ window.postMessage(JSON.stringify({eventId:'challenge-complete',payload:{sessionToken:token}}),'*'); }catch(e){}
+  return true;
+}`
+
+// detectCaptchaType classifies the CAPTCHA on a page from its HTML, or "" if
+// none is recognized. FunCaptcha is matched first because Arkose embeds often
+// also pull in a reCAPTCHA-like script; its markers (arkoselabs, data-pkey) are
+// specific enough that the ordering rarely misfires. Note: reCAPTCHA v2 and v3
+// both report as "recaptcha" and the solver submits a V2 task, so a v3-only page
+// (grecaptcha.execute, no checkbox) is detected but not correctly solvable yet.
 func detectCaptchaType(html string) string {
 	lower := strings.ToLower(html)
 	switch {
-	case strings.Contains(lower, "g-recaptcha") || strings.Contains(lower, "recaptcha"):
-		return "recaptcha"
+	case strings.Contains(lower, "funcaptcha") || strings.Contains(lower, "arkoselabs") ||
+		strings.Contains(lower, "arkose-labs") || strings.Contains(lower, "data-pkey"):
+		return "funcaptcha"
+	case strings.Contains(lower, "challenges.cloudflare.com/turnstile") || strings.Contains(lower, "cf-turnstile"):
+		return "turnstile"
 	case strings.Contains(lower, "h-captcha") || strings.Contains(lower, "hcaptcha"):
 		return "hcaptcha"
-	case strings.Contains(lower, "challenges.cloudflare.com/turnstile"):
-		return "turnstile"
+	case strings.Contains(lower, "g-recaptcha") || strings.Contains(lower, "recaptcha"):
+		return "recaptcha"
 	default:
 		return ""
 	}
 }
 
+var (
+	pkeyAttrRe        = regexp.MustCompile(`(?i)data-pkey=["']([^"']+)["']`)
+	publicKeyJSONRe   = regexp.MustCompile(`(?i)"?public_?key"?\s*[:=]\s*["']([0-9A-Fa-f-]{20,})["']`)
+	arkosePkURLRe     = regexp.MustCompile(`(?i)[?&]pk=([0-9A-Fa-f-]{20,})`)
+	arkoseSubdomainRe = regexp.MustCompile(`(?i)https?://([a-z0-9-]+\.arkoselabs\.com)`)
+	// Case-insensitive so extraction matches detectCaptchaType (which lowercases);
+	// tolerant of either quote style and whitespace around '='.
+	siteKeyAttrRe = regexp.MustCompile(`(?i)data-sitekey\s*=\s*["']([^"']+)["']`)
+)
+
 func extractSitekey(html, captchaType string) string {
-	var attrNames []string
-	switch captchaType {
-	case "recaptcha":
-		attrNames = []string{"data-sitekey"}
-	case "hcaptcha":
-		attrNames = []string{"data-sitekey"}
-	case "turnstile":
-		attrNames = []string{"data-sitekey"}
-	default:
+	if captchaType == "funcaptcha" {
+		for _, re := range []*regexp.Regexp{pkeyAttrRe, arkosePkURLRe, publicKeyJSONRe} {
+			if m := re.FindStringSubmatch(html); len(m) > 1 {
+				return m[1]
+			}
+		}
 		return ""
 	}
 
-	for _, attr := range attrNames {
-		idx := strings.Index(html, attr+`="`)
-		if idx == -1 {
-			idx = strings.Index(html, attr+`='`)
-		}
-		if idx == -1 {
-			continue
-		}
-		start := idx + len(attr) + 2
-		quote := html[start-1]
-		end := strings.IndexByte(html[start:], quote)
-		if end == -1 {
-			continue
-		}
-		return html[start : start+end]
+	// reCAPTCHA / hCaptcha / Turnstile all expose data-sitekey.
+	if m := siteKeyAttrRe.FindStringSubmatch(html); len(m) > 1 {
+		return m[1]
+	}
+	return ""
+}
+
+// extractArkoseSubdomain finds the Arkose API JS host (e.g.
+// client-api.arkoselabs.com, or a tenant subdomain like
+// lnkd-api.arkoselabs.com) referenced by the page's enforcement script.
+func extractArkoseSubdomain(html string) string {
+	if m := arkoseSubdomainRe.FindStringSubmatch(html); len(m) > 1 {
+		return "https://" + m[1]
 	}
 	return ""
 }

--- a/internal/autosolver/external/capsolver.go
+++ b/internal/autosolver/external/capsolver.go
@@ -125,6 +125,8 @@ func (c *Capsolver) Solve(ctx context.Context, page autosolver.Page, executor au
 				task.Data = string(b)
 			}
 		}
+		// Match the solve UA to the browser's so Arkose accepts the token.
+		task.UserAgent = readUserAgent(ctx, executor)
 	case "recaptcha-v3":
 		// v3 has no widget — the sitekey comes from ?render= and the task needs
 		// the action passed to grecaptcha.execute (best-effort; optional).
@@ -188,6 +190,10 @@ type capsolverTask struct {
 	WebsitePublicKey         string `json:"websitePublicKey,omitempty"`
 	FuncaptchaApiJSSubdomain string `json:"funcaptchaApiJSSubdomain,omitempty"`
 	Data                     string `json:"data,omitempty"`
+	// UserAgent is forwarded for FunCaptcha so CapSolver solves under the same
+	// UA the browser uses — Arkose binds the token to the UA, so a mismatch is a
+	// common cause of an otherwise-valid token being rejected. Optional.
+	UserAgent string `json:"userAgent,omitempty"`
 }
 
 type capsolverCreateRequest struct {
@@ -290,6 +296,15 @@ func readArkoseCapture(ctx context.Context, executor autosolver.ActionExecutor) 
 		return nil
 	}
 	return &ac
+}
+
+// readUserAgent reads navigator.userAgent from the live page; "" if unavailable.
+func readUserAgent(ctx context.Context, executor autosolver.ActionExecutor) string {
+	var ua string
+	if err := executor.Evaluate(ctx, "navigator.userAgent", &ua); err != nil {
+		return ""
+	}
+	return ua
 }
 
 // pickToken returns the solve token regardless of which field CapSolver used.

--- a/internal/autosolver/external/capsolver.go
+++ b/internal/autosolver/external/capsolver.go
@@ -26,8 +26,8 @@ type CapsolverConfig struct {
 }
 
 // Capsolver implements autosolver.Solver using the Capsolver API.
-// It supports reCAPTCHA v2, hCaptcha, Cloudflare Turnstile, and Arkose
-// Labs FunCaptcha.
+// It supports reCAPTCHA v2, reCAPTCHA v3, hCaptcha, Cloudflare Turnstile,
+// and Arkose Labs FunCaptcha.
 type Capsolver struct {
 	config CapsolverConfig
 	client *http.Client
@@ -99,28 +99,42 @@ func (c *Capsolver) Solve(ctx context.Context, page autosolver.Page, executor au
 		return result, fmt.Errorf("unsupported captcha type: %s", captchaType)
 	}
 
-	// FunCaptcha additionally needs the Arkose API JS subdomain and — for
-	// modern deployments (LinkedIn) — the per-session data blob. The blob,
-	// public key, and service URL are captured at document-start by the bridge's
-	// Arkose hook (window.__ptArkose); prefer those live values over static HTML.
-	arkoseSubdomain := ""
-	blob := ""
-	if captchaType == "funcaptcha" {
-		arkoseSubdomain = extractArkoseSubdomain(html)
+	task := capsolverTask{Type: taskType, WebsiteURL: page.URL()}
+	switch captchaType {
+	case "funcaptcha":
+		// FunCaptcha additionally needs the Arkose API JS subdomain and — for
+		// modern deployments (LinkedIn) — the per-session data blob. The blob,
+		// public key, and service URL are captured at document-start by the
+		// bridge's Arkose hook (window.__ptArkose); prefer those live values
+		// over static HTML.
+		task.WebsitePublicKey = key
+		task.FuncaptchaApiJSSubdomain = extractArkoseSubdomain(html)
+		blob := ""
 		if ac := readArkoseCapture(ctx, executor); ac != nil {
-			if ac.Blob != "" {
-				blob = ac.Blob
-			}
 			if ac.PK != "" {
-				key = ac.PK
+				task.WebsitePublicKey = ac.PK
 			}
 			if ac.Surl != "" {
-				arkoseSubdomain = ac.Surl
+				task.FuncaptchaApiJSSubdomain = ac.Surl
+			}
+			blob = ac.Blob
+		}
+		if blob != "" {
+			// map[string]string can't fail to marshal; err branch is unreachable.
+			if b, err := json.Marshal(map[string]string{"blob": blob}); err == nil {
+				task.Data = string(b)
 			}
 		}
+	case "recaptcha-v3":
+		// v3 has no widget — the sitekey comes from ?render= and the task needs
+		// the action passed to grecaptcha.execute (best-effort; optional).
+		task.WebsiteKey = key
+		task.PageAction = extractRecaptchaAction(html)
+	default:
+		task.WebsiteKey = key
 	}
 
-	token, err := c.solveRemote(ctx, captchaType, taskType, page.URL(), key, arkoseSubdomain, blob)
+	token, err := c.solveRemote(ctx, task)
 	if err != nil {
 		result.Error = err.Error()
 		return result, err
@@ -144,6 +158,8 @@ func capsolverTaskType(captchaType string) (string, bool) {
 	switch captchaType {
 	case "recaptcha":
 		return "ReCaptchaV2TaskProxyLess", true
+	case "recaptcha-v3":
+		return "ReCaptchaV3TaskProxyLess", true
 	case "hcaptcha":
 		return "HCaptchaTaskProxyLess", true
 	case "turnstile":
@@ -160,8 +176,12 @@ func capsolverTaskType(captchaType string) (string, bool) {
 type capsolverTask struct {
 	Type       string `json:"type"`
 	WebsiteURL string `json:"websiteURL"`
-	// reCAPTCHA / hCaptcha / Turnstile use websiteKey (data-sitekey).
+	// reCAPTCHA / hCaptcha / Turnstile use websiteKey (data-sitekey, or the
+	// ?render= sitekey for reCAPTCHA v3).
 	WebsiteKey string `json:"websiteKey,omitempty"`
+	// PageAction is the reCAPTCHA v3 action (the value passed to
+	// grecaptcha.execute). Optional — CapSolver applies a default when absent.
+	PageAction string `json:"pageAction,omitempty"`
 	// FunCaptcha uses websitePublicKey (data-pkey) + the Arkose API subdomain,
 	// and (for modern deployments like LinkedIn) the per-session data blob,
 	// passed as a JSON-encoded string e.g. {"blob":"…"}.
@@ -194,21 +214,9 @@ type capsolverResponse struct {
 	Solution         capsolverSolution `json:"solution"`
 }
 
-// solveRemote runs the full create → poll cycle and returns the token.
-func (c *Capsolver) solveRemote(ctx context.Context, captchaType, taskType, pageURL, key, arkoseSubdomain, blob string) (string, error) {
-	task := capsolverTask{Type: taskType, WebsiteURL: pageURL}
-	if captchaType == "funcaptcha" {
-		task.WebsitePublicKey = key
-		task.FuncaptchaApiJSSubdomain = arkoseSubdomain
-		if blob != "" {
-			if b, err := json.Marshal(map[string]string{"blob": blob}); err == nil {
-				task.Data = string(b)
-			}
-		}
-	} else {
-		task.WebsiteKey = key
-	}
-
+// solveRemote runs the full create → poll cycle for a prebuilt task and
+// returns the token. The caller (Solve) populates the type-specific fields.
+func (c *Capsolver) solveRemote(ctx context.Context, task capsolverTask) (string, error) {
 	var created capsolverResponse
 	if err := c.postJSON(ctx, "/createTask", capsolverCreateRequest{ClientKey: c.config.APIKey, Task: task}, &created); err != nil {
 		return "", fmt.Errorf("capsolver createTask: %w", err)
@@ -329,7 +337,7 @@ func (c *Capsolver) postJSON(ctx context.Context, path string, body, out interfa
 func injectToken(ctx context.Context, executor autosolver.ActionExecutor, captchaType, token string) error {
 	var js string
 	switch captchaType {
-	case "recaptcha":
+	case "recaptcha", "recaptcha-v3":
 		js = recaptchaInjectJS
 	case "hcaptcha":
 		js = hcaptchaInjectJS
@@ -411,9 +419,10 @@ const funcaptchaInjectJS = `function(token){
 // detectCaptchaType classifies the CAPTCHA on a page from its HTML, or "" if
 // none is recognized. FunCaptcha is matched first because Arkose embeds often
 // also pull in a reCAPTCHA-like script; its markers (arkoselabs, data-pkey) are
-// specific enough that the ordering rarely misfires. Note: reCAPTCHA v2 and v3
-// both report as "recaptcha" and the solver submits a V2 task, so a v3-only page
-// (grecaptcha.execute, no checkbox) is detected but not correctly solvable yet.
+// specific enough that the ordering rarely misfires. reCAPTCHA splits into
+// "recaptcha" (v2 checkbox/invisible) and "recaptcha-v3" — see classifyRecaptcha.
+// Enterprise reCAPTCHA (recaptcha/enterprise.js) is not yet distinguished and
+// falls through to the v2 path.
 func detectCaptchaType(html string) string {
 	lower := strings.ToLower(html)
 	switch {
@@ -425,10 +434,25 @@ func detectCaptchaType(html string) string {
 	case strings.Contains(lower, "h-captcha") || strings.Contains(lower, "hcaptcha"):
 		return "hcaptcha"
 	case strings.Contains(lower, "g-recaptcha") || strings.Contains(lower, "recaptcha"):
-		return "recaptcha"
+		return classifyRecaptcha(html)
 	default:
 		return ""
 	}
+}
+
+// classifyRecaptcha separates reCAPTCHA v3 from v2. v2 (checkbox or invisible)
+// renders a widget carrying data-sitekey; v3 has no widget — it loads
+// api.js?render=<sitekey> and calls grecaptcha.execute(). We report v3 only when
+// a render sitekey is present AND there is no v2 data-sitekey widget, so a v2
+// page is never downgraded. render=explicit is the v2 programmatic-render flag,
+// not a sitekey, so it stays v2.
+func classifyRecaptcha(html string) string {
+	if !siteKeyAttrRe.MatchString(html) {
+		if m := recaptchaRenderRe.FindStringSubmatch(html); len(m) > 1 && !strings.EqualFold(m[1], "explicit") {
+			return "recaptcha-v3"
+		}
+	}
+	return "recaptcha"
 }
 
 var (
@@ -439,20 +463,47 @@ var (
 	// Case-insensitive so extraction matches detectCaptchaType (which lowercases);
 	// tolerant of either quote style and whitespace around '='.
 	siteKeyAttrRe = regexp.MustCompile(`(?i)data-sitekey\s*=\s*["']([^"']+)["']`)
+	// reCAPTCHA v3: the sitekey rides the api.js script URL as ?…render=<key>.
+	// Tolerates other query params before render= (e.g. ?onload=cb&render=key).
+	recaptchaRenderRe = regexp.MustCompile(`(?i)recaptcha/(?:enterprise|api)\.js\?[^"'>]*\brender=([0-9A-Za-z_-]+)`)
+	// reCAPTCHA v3 action: the value passed to grecaptcha.execute(key, {action:…}).
+	recaptchaActionRe = regexp.MustCompile(`(?i)grecaptcha(?:\.enterprise)?\s*\.\s*execute\s*\(\s*["'][^"']*["']\s*,\s*\{[^}]*?action\s*:\s*["']([^"']+)["']`)
+	// Fallback for the v3 action when it's declared as an HTML attribute.
+	dataActionRe = regexp.MustCompile(`(?i)data-action\s*=\s*["']([^"']+)["']`)
 )
 
 func extractSitekey(html, captchaType string) string {
-	if captchaType == "funcaptcha" {
+	switch captchaType {
+	case "funcaptcha":
 		for _, re := range []*regexp.Regexp{pkeyAttrRe, arkosePkURLRe, publicKeyJSONRe} {
 			if m := re.FindStringSubmatch(html); len(m) > 1 {
 				return m[1]
 			}
 		}
 		return ""
+	case "recaptcha-v3":
+		// v3 has no data-sitekey widget; the key is in the api.js ?render= param.
+		if m := recaptchaRenderRe.FindStringSubmatch(html); len(m) > 1 {
+			return m[1]
+		}
+		return ""
+	default:
+		// reCAPTCHA v2 / hCaptcha / Turnstile all expose data-sitekey.
+		if m := siteKeyAttrRe.FindStringSubmatch(html); len(m) > 1 {
+			return m[1]
+		}
+		return ""
 	}
+}
 
-	// reCAPTCHA / hCaptcha / Turnstile all expose data-sitekey.
-	if m := siteKeyAttrRe.FindStringSubmatch(html); len(m) > 1 {
+// extractRecaptchaAction returns the action passed to grecaptcha.execute for a
+// reCAPTCHA v3 page, or "" if none is found (the action is optional — CapSolver
+// applies a default). Falls back to a data-action attribute.
+func extractRecaptchaAction(html string) string {
+	if m := recaptchaActionRe.FindStringSubmatch(html); len(m) > 1 {
+		return m[1]
+	}
+	if m := dataActionRe.FindStringSubmatch(html); len(m) > 1 {
 		return m[1]
 	}
 	return ""

--- a/internal/autosolver/external/capsolver_test.go
+++ b/internal/autosolver/external/capsolver_test.go
@@ -54,7 +54,11 @@ func TestDetectCaptchaType(t *testing.T) {
 		`<div class="cf-turnstile" data-sitekey="x"></div>`:                 "turnstile",
 		`<div id="arkose" data-pkey="ABC"></div>`:                           "funcaptcha",
 		`<script src="https://lnkd-api.arkoselabs.com/v2/api.js"></script>`: "funcaptcha",
-		`<p>nothing here</p>`:                                               "",
+		// v3: render=<key> with no data-sitekey widget.
+		`<script src="https://www.google.com/recaptcha/api.js?render=6Lc_V3_KEY"></script>`: "recaptcha-v3",
+		// v2 wins when a data-sitekey widget is present, even alongside render=explicit.
+		`<div class="g-recaptcha" data-sitekey="x"></div><script src="https://www.google.com/recaptcha/api.js?render=explicit"></script>`: "recaptcha",
+		`<p>nothing here</p>`: "",
 	}
 	for html, want := range cases {
 		if got := detectCaptchaType(html); got != want {
@@ -77,6 +81,24 @@ func TestExtractSitekey(t *testing.T) {
 	if got := extractSitekey(`<iframe src="https://x.arkoselabs.com/fc/gt2/?pk=0152B4EB-D2DC-460A-89A1-629838B529C9"></iframe>`, "funcaptcha"); got != "0152B4EB-D2DC-460A-89A1-629838B529C9" {
 		t.Errorf("funcaptcha pk= url = %q", got)
 	}
+	// v3 sitekey lives in the api.js ?render= param, not data-sitekey.
+	if got := extractSitekey(`<script src="https://www.google.com/recaptcha/api.js?onload=cb&render=6Lc_V3_KEY"></script>`, "recaptcha-v3"); got != "6Lc_V3_KEY" {
+		t.Errorf("recaptcha-v3 render sitekey = %q", got)
+	}
+}
+
+func TestExtractRecaptchaAction(t *testing.T) {
+	cases := map[string]string{
+		`<script>grecaptcha.execute('6Lc', {action: 'login'})</script>`: "login",
+		`grecaptcha.enterprise.execute("6Lc",{action:"submit_form"})`:   "submit_form",
+		`<button data-action="checkout"></button>`:                      "checkout", // attribute fallback
+		`<p>no action here</p>`:                                         "",         // optional → empty
+	}
+	for html, want := range cases {
+		if got := extractRecaptchaAction(html); got != want {
+			t.Errorf("extractRecaptchaAction(%q) = %q, want %q", html, got, want)
+		}
+	}
 }
 
 func TestExtractArkoseSubdomain(t *testing.T) {
@@ -88,10 +110,11 @@ func TestExtractArkoseSubdomain(t *testing.T) {
 
 func TestCapsolverTaskType(t *testing.T) {
 	cases := map[string]string{
-		"recaptcha":  "ReCaptchaV2TaskProxyLess",
-		"hcaptcha":   "HCaptchaTaskProxyLess",
-		"turnstile":  "AntiTurnstileTaskProxyLess",
-		"funcaptcha": "FunCaptchaTaskProxyLess",
+		"recaptcha":    "ReCaptchaV2TaskProxyLess",
+		"recaptcha-v3": "ReCaptchaV3TaskProxyLess",
+		"hcaptcha":     "HCaptchaTaskProxyLess",
+		"turnstile":    "AntiTurnstileTaskProxyLess",
+		"funcaptcha":   "FunCaptchaTaskProxyLess",
 	}
 	for in, want := range cases {
 		got, ok := capsolverTaskType(in)
@@ -240,6 +263,42 @@ func TestSolveRecaptcha(t *testing.T) {
 		t.Errorf("recaptcha task should not set websitePublicKey")
 	}
 	if !strings.Contains(exec.lastInject, "RECAP-TOKEN") {
+		t.Errorf("token not injected: %q", exec.lastInject)
+	}
+}
+
+func TestSolveRecaptchaV3(t *testing.T) {
+	var task capsolverTask
+	srv := mockCapsolver(t, "V3-TOKEN", &task)
+	defer srv.Close()
+
+	c := NewCapsolver(CapsolverConfig{APIKey: "k", BaseURL: srv.URL})
+	page := &fakePage{
+		url:  "https://ex.com/login",
+		html: `<script src="https://www.google.com/recaptcha/api.js?render=6Lc_V3_KEY"></script><script>grecaptcha.execute('6Lc_V3_KEY', {action: 'login'});</script>`,
+	}
+	exec := &fakeExecutor{}
+
+	res, err := c.Solve(context.Background(), page, exec)
+	if err != nil {
+		t.Fatalf("Solve: %v", err)
+	}
+	if !res.Solved {
+		t.Fatalf("expected solved, got error=%q", res.Error)
+	}
+	if task.Type != "ReCaptchaV3TaskProxyLess" {
+		t.Errorf("task type = %q", task.Type)
+	}
+	if task.WebsiteKey != "6Lc_V3_KEY" {
+		t.Errorf("websiteKey = %q (want render sitekey)", task.WebsiteKey)
+	}
+	if task.PageAction != "login" {
+		t.Errorf("pageAction = %q (want login)", task.PageAction)
+	}
+	if task.WebsitePublicKey != "" {
+		t.Errorf("v3 task should not set websitePublicKey")
+	}
+	if !strings.Contains(exec.lastInject, "V3-TOKEN") {
 		t.Errorf("token not injected: %q", exec.lastInject)
 	}
 }

--- a/internal/autosolver/external/capsolver_test.go
+++ b/internal/autosolver/external/capsolver_test.go
@@ -1,0 +1,316 @@
+package external
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// --- fakes ---
+
+type fakePage struct {
+	url, title, html string
+}
+
+func (p *fakePage) URL() string   { return p.url }
+func (p *fakePage) Title() string { return p.title }
+func (p *fakePage) HTML() (string, error) {
+	return p.html, nil
+}
+func (p *fakePage) HTMLWithin(time.Duration) (string, error) { return p.html, nil }
+func (p *fakePage) Screenshot() ([]byte, error)              { return nil, nil }
+
+type fakeExecutor struct {
+	lastInject string // last non-read Evaluate expr (the token injection)
+	arkoseJSON string // value returned for the window.__ptArkose read
+}
+
+func (e *fakeExecutor) Click(context.Context, float64, float64) error        { return nil }
+func (e *fakeExecutor) Type(context.Context, string) error                   { return nil }
+func (e *fakeExecutor) WaitFor(context.Context, string, time.Duration) error { return nil }
+func (e *fakeExecutor) Navigate(context.Context, string) error               { return nil }
+func (e *fakeExecutor) Evaluate(_ context.Context, expr string, result interface{}) error {
+	if strings.Contains(expr, "window.__ptArkose?") { // the capture read, not the token injection
+		if sp, ok := result.(*string); ok {
+			*sp = e.arkoseJSON
+		}
+		return nil
+	}
+	e.lastInject = expr
+	return nil
+}
+
+// --- helper tests ---
+
+func TestDetectCaptchaType(t *testing.T) {
+	cases := map[string]string{
+		`<div class="g-recaptcha" data-sitekey="x"></div>`:                  "recaptcha",
+		`<div class="h-captcha" data-sitekey="x"></div>`:                    "hcaptcha",
+		`<div class="cf-turnstile" data-sitekey="x"></div>`:                 "turnstile",
+		`<div id="arkose" data-pkey="ABC"></div>`:                           "funcaptcha",
+		`<script src="https://lnkd-api.arkoselabs.com/v2/api.js"></script>`: "funcaptcha",
+		`<p>nothing here</p>`:                                               "",
+	}
+	for html, want := range cases {
+		if got := detectCaptchaType(html); got != want {
+			t.Errorf("detectCaptchaType(%q) = %q, want %q", html, got, want)
+		}
+	}
+}
+
+func TestExtractSitekey(t *testing.T) {
+	if got := extractSitekey(`<div data-sitekey="6LcXYZ"></div>`, "recaptcha"); got != "6LcXYZ" {
+		t.Errorf("recaptcha sitekey = %q", got)
+	}
+	// Detection lowercases, so extraction must be case-insensitive + whitespace-tolerant.
+	if got := extractSitekey(`<div Data-SiteKey = '6LcMixed'></div>`, "recaptcha"); got != "6LcMixed" {
+		t.Errorf("case-insensitive data-sitekey = %q", got)
+	}
+	if got := extractSitekey(`<div data-pkey="0152B4EB-D2DC-460A-89A1-629838B529C9"></div>`, "funcaptcha"); got != "0152B4EB-D2DC-460A-89A1-629838B529C9" {
+		t.Errorf("funcaptcha data-pkey = %q", got)
+	}
+	if got := extractSitekey(`<iframe src="https://x.arkoselabs.com/fc/gt2/?pk=0152B4EB-D2DC-460A-89A1-629838B529C9"></iframe>`, "funcaptcha"); got != "0152B4EB-D2DC-460A-89A1-629838B529C9" {
+		t.Errorf("funcaptcha pk= url = %q", got)
+	}
+}
+
+func TestExtractArkoseSubdomain(t *testing.T) {
+	html := `<script src="https://lnkd-api.arkoselabs.com/v2/0152/api.js"></script>`
+	if got := extractArkoseSubdomain(html); got != "https://lnkd-api.arkoselabs.com" {
+		t.Errorf("arkose subdomain = %q", got)
+	}
+}
+
+func TestCapsolverTaskType(t *testing.T) {
+	cases := map[string]string{
+		"recaptcha":  "ReCaptchaV2TaskProxyLess",
+		"hcaptcha":   "HCaptchaTaskProxyLess",
+		"turnstile":  "AntiTurnstileTaskProxyLess",
+		"funcaptcha": "FunCaptchaTaskProxyLess",
+	}
+	for in, want := range cases {
+		got, ok := capsolverTaskType(in)
+		if !ok || got != want {
+			t.Errorf("capsolverTaskType(%q) = %q,%v want %q", in, got, ok, want)
+		}
+	}
+	if _, ok := capsolverTaskType("bogus"); ok {
+		t.Error("expected bogus type to be unsupported")
+	}
+}
+
+// --- end-to-end Solve against a mock Capsolver API ---
+
+// mockCapsolver returns a server that answers createTask with an inline
+// ready solution, and records the last task it received.
+func mockCapsolver(t *testing.T, token string, gotTask *capsolverTask) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/createTask") {
+			var req capsolverCreateRequest
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			*gotTask = req.Task
+			resp := capsolverResponse{Status: "ready"}
+			if strings.Contains(req.Task.Type, "FunCaptcha") {
+				resp.Solution.Token = token
+			} else {
+				resp.Solution.GRecaptchaResponse = token
+			}
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+		http.Error(w, "not found", 404)
+	}))
+}
+
+// mockCapsolverPolling answers createTask with a taskId only (no inline
+// solution), then getTaskResult returns "processing" until the Nth poll, when
+// it returns "ready" with the token — exercising the real poll loop.
+func mockCapsolverPolling(t *testing.T, token string, readyOnPoll int) *httptest.Server {
+	t.Helper()
+	var mu sync.Mutex
+	polls := 0
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/createTask") {
+			_ = json.NewEncoder(w).Encode(capsolverResponse{TaskID: "task-123"})
+			return
+		}
+		if strings.HasSuffix(r.URL.Path, "/getTaskResult") {
+			mu.Lock()
+			polls++
+			n := polls
+			mu.Unlock()
+			resp := capsolverResponse{TaskID: "task-123", Status: "processing"}
+			if n >= readyOnPoll {
+				resp.Status = "ready"
+				resp.Solution.GRecaptchaResponse = token
+			}
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+		http.Error(w, "not found", 404)
+	}))
+}
+
+func TestSolveRecaptchaPolling(t *testing.T) {
+	srv := mockCapsolverPolling(t, "POLLED-TOKEN", 3) // ready on the 3rd getTaskResult
+	defer srv.Close()
+
+	c := NewCapsolver(CapsolverConfig{APIKey: "k", BaseURL: srv.URL, PollInterval: 2 * time.Millisecond})
+	page := &fakePage{url: "https://ex.com", html: `<div class="g-recaptcha" data-sitekey="6LcABC"></div>`}
+	exec := &fakeExecutor{}
+
+	res, err := c.Solve(context.Background(), page, exec)
+	if err != nil {
+		t.Fatalf("Solve: %v", err)
+	}
+	if !res.Solved {
+		t.Fatalf("expected solved via polling, got error=%q", res.Error)
+	}
+	if !strings.Contains(exec.lastInject, "POLLED-TOKEN") {
+		t.Errorf("polled token not injected: %q", exec.lastInject)
+	}
+}
+
+// TestSolveCapsolverFailedStatus also guards against the poll loop hanging on a
+// terminal failure: with the bug, status=="failed" (errorId 0) loops forever and
+// this test (ctx.Background, never cancelled) would time out instead of failing.
+func TestSolveCapsolverFailedStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/createTask") {
+			_ = json.NewEncoder(w).Encode(capsolverResponse{TaskID: "t1"})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(capsolverResponse{TaskID: "t1", Status: "failed", ErrorCode: "ERROR_CAPTCHA_UNSOLVABLE"})
+	}))
+	defer srv.Close()
+
+	c := NewCapsolver(CapsolverConfig{APIKey: "k", BaseURL: srv.URL, PollInterval: 2 * time.Millisecond})
+	page := &fakePage{url: "https://ex.com", html: `<div class="g-recaptcha" data-sitekey="6LcABC"></div>`}
+
+	res, err := c.Solve(context.Background(), page, &fakeExecutor{})
+	if err == nil || res.Solved {
+		t.Fatalf("expected failure on status=failed, got solved=%v err=%v", res.Solved, err)
+	}
+	if !strings.Contains(res.Error, "failed") {
+		t.Errorf("expected 'failed' in error, got %q", res.Error)
+	}
+}
+
+func TestSolveCapsolverCreateTaskError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(capsolverResponse{ErrorID: 1, ErrorCode: "ERROR_KEY_DENIED_ACCESS", ErrorDescription: "bad key"})
+	}))
+	defer srv.Close()
+
+	c := NewCapsolver(CapsolverConfig{APIKey: "k", BaseURL: srv.URL})
+	page := &fakePage{url: "https://ex.com", html: `<div class="g-recaptcha" data-sitekey="6LcABC"></div>`}
+
+	res, err := c.Solve(context.Background(), page, &fakeExecutor{})
+	if err == nil || res.Solved {
+		t.Fatalf("expected createTask error, got solved=%v err=%v", res.Solved, err)
+	}
+}
+
+func TestSolveRecaptcha(t *testing.T) {
+	var task capsolverTask
+	srv := mockCapsolver(t, "RECAP-TOKEN", &task)
+	defer srv.Close()
+
+	c := NewCapsolver(CapsolverConfig{APIKey: "k", BaseURL: srv.URL})
+	page := &fakePage{url: "https://ex.com", html: `<div class="g-recaptcha" data-sitekey="6LcABC"></div>`}
+	exec := &fakeExecutor{}
+
+	res, err := c.Solve(context.Background(), page, exec)
+	if err != nil {
+		t.Fatalf("Solve: %v", err)
+	}
+	if !res.Solved {
+		t.Fatalf("expected solved, got error=%q", res.Error)
+	}
+	if task.Type != "ReCaptchaV2TaskProxyLess" || task.WebsiteKey != "6LcABC" {
+		t.Errorf("task = %+v", task)
+	}
+	if task.WebsitePublicKey != "" {
+		t.Errorf("recaptcha task should not set websitePublicKey")
+	}
+	if !strings.Contains(exec.lastInject, "RECAP-TOKEN") {
+		t.Errorf("token not injected: %q", exec.lastInject)
+	}
+}
+
+func TestSolveFuncaptcha(t *testing.T) {
+	var task capsolverTask
+	srv := mockCapsolver(t, "FC-TOKEN", &task)
+	defer srv.Close()
+
+	c := NewCapsolver(CapsolverConfig{APIKey: "k", BaseURL: srv.URL})
+	page := &fakePage{
+		url:  "https://www.linkedin.com/checkpoint",
+		html: `<div data-pkey="0152B4EB-D2DC-460A-89A1-629838B529C9"></div><script src="https://lnkd-api.arkoselabs.com/v2/api.js"></script>`,
+	}
+	exec := &fakeExecutor{}
+
+	res, err := c.Solve(context.Background(), page, exec)
+	if err != nil {
+		t.Fatalf("Solve: %v", err)
+	}
+	if !res.Solved {
+		t.Fatalf("expected solved, got error=%q", res.Error)
+	}
+	if task.Type != "FunCaptchaTaskProxyLess" {
+		t.Errorf("task type = %q", task.Type)
+	}
+	if task.WebsitePublicKey != "0152B4EB-D2DC-460A-89A1-629838B529C9" {
+		t.Errorf("websitePublicKey = %q", task.WebsitePublicKey)
+	}
+	if task.WebsiteKey != "" {
+		t.Errorf("funcaptcha task should not set websiteKey")
+	}
+	if task.FuncaptchaApiJSSubdomain != "https://lnkd-api.arkoselabs.com" {
+		t.Errorf("funcaptchaApiJSSubdomain = %q", task.FuncaptchaApiJSSubdomain)
+	}
+	if task.Data != "" {
+		t.Errorf("no blob captured, expected empty data, got %q", task.Data)
+	}
+	if !strings.Contains(exec.lastInject, "FC-TOKEN") {
+		t.Errorf("token not injected: %q", exec.lastInject)
+	}
+}
+
+// TestSolveFuncaptchaWithBlob verifies the document-start hook's captured
+// blob/pk/surl (window.__ptArkose) override static extraction and are forwarded
+// to CapSolver as the task data.
+func TestSolveFuncaptchaWithBlob(t *testing.T) {
+	var task capsolverTask
+	srv := mockCapsolver(t, "FC-TOKEN", &task)
+	defer srv.Close()
+
+	c := NewCapsolver(CapsolverConfig{APIKey: "k", BaseURL: srv.URL})
+	page := &fakePage{
+		url:  "https://www.linkedin.com/checkpoint",
+		html: `<div data-pkey="STATIC-PK"></div><script src="https://lnkd-api.arkoselabs.com/v2/api.js"></script>`,
+	}
+	exec := &fakeExecutor{arkoseJSON: `{"blob":"BDA-BLOB-XYZ","pk":"LIVE-PK","surl":"https://lnkd-api.arkoselabs.com"}`}
+
+	res, err := c.Solve(context.Background(), page, exec)
+	if err != nil || !res.Solved {
+		t.Fatalf("Solve: err=%v solved=%v error=%q", err, res.Solved, res.Error)
+	}
+	if task.WebsitePublicKey != "LIVE-PK" {
+		t.Errorf("captured pk should override static; got %q", task.WebsitePublicKey)
+	}
+	// Assert the JSON shape, not just substring — a wrong wrapper key must fail.
+	var dataObj map[string]string
+	if err := json.Unmarshal([]byte(task.Data), &dataObj); err != nil {
+		t.Fatalf("task.Data is not valid JSON: %q (%v)", task.Data, err)
+	}
+	if dataObj["blob"] != "BDA-BLOB-XYZ" {
+		t.Errorf("expected data.blob=BDA-BLOB-XYZ, got %+v", dataObj)
+	}
+}

--- a/internal/autosolver/external/capsolver_test.go
+++ b/internal/autosolver/external/capsolver_test.go
@@ -28,6 +28,7 @@ func (p *fakePage) Screenshot() ([]byte, error)              { return nil, nil }
 type fakeExecutor struct {
 	lastInject string // last non-read Evaluate expr (the token injection)
 	arkoseJSON string // value returned for the window.__ptArkose read
+	userAgent  string // value returned for the navigator.userAgent read
 }
 
 func (e *fakeExecutor) Click(context.Context, float64, float64) error        { return nil }
@@ -38,6 +39,12 @@ func (e *fakeExecutor) Evaluate(_ context.Context, expr string, result interface
 	if strings.Contains(expr, "window.__ptArkose?") { // the capture read, not the token injection
 		if sp, ok := result.(*string); ok {
 			*sp = e.arkoseJSON
+		}
+		return nil
+	}
+	if strings.Contains(expr, "navigator.userAgent") { // the UA read
+		if sp, ok := result.(*string); ok {
+			*sp = e.userAgent
 		}
 		return nil
 	}
@@ -313,7 +320,7 @@ func TestSolveFuncaptcha(t *testing.T) {
 		url:  "https://www.linkedin.com/checkpoint",
 		html: `<div data-pkey="0152B4EB-D2DC-460A-89A1-629838B529C9"></div><script src="https://lnkd-api.arkoselabs.com/v2/api.js"></script>`,
 	}
-	exec := &fakeExecutor{}
+	exec := &fakeExecutor{userAgent: "Mozilla/5.0 (TestUA)"}
 
 	res, err := c.Solve(context.Background(), page, exec)
 	if err != nil {
@@ -324,6 +331,9 @@ func TestSolveFuncaptcha(t *testing.T) {
 	}
 	if task.Type != "FunCaptchaTaskProxyLess" {
 		t.Errorf("task type = %q", task.Type)
+	}
+	if task.UserAgent != "Mozilla/5.0 (TestUA)" {
+		t.Errorf("browser UA should be forwarded; got %q", task.UserAgent)
 	}
 	if task.WebsitePublicKey != "0152B4EB-D2DC-460A-89A1-629838B529C9" {
 		t.Errorf("websitePublicKey = %q", task.WebsitePublicKey)

--- a/internal/bridge/arkose_capture.go
+++ b/internal/bridge/arkose_capture.go
@@ -1,0 +1,85 @@
+package bridge
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/chromedp/cdproto/page"
+	"github.com/chromedp/chromedp"
+)
+
+// arkoseCaptureScript runs at document-start and transparently captures the
+// per-session Arkose FunCaptcha data the host page hands to ArkoseEnforcement —
+// the `data.blob`, the public key, and the service URL — onto window.__ptArkose,
+// and preserves the host page's onCompleted callback on window.__ptArkoseOnCompleted.
+//
+// The capsolver autosolver reads window.__ptArkose via Evaluate and forwards the
+// blob to CapSolver's FunCaptchaTaskProxyLess task; modern Arkose deployments
+// (e.g. LinkedIn) reject solves that lack the per-session blob, which is generated
+// by the site's JS at runtime and never present in static HTML. After the token is
+// solved, delivering it through window.__ptArkoseOnCompleted advances the site's
+// own completion flow. The hook is inert on non-Arkose pages — nothing assigns
+// window.ArkoseEnforcement there, so the accessor never fires.
+//
+// Limitation: the accessor is installed before the site's api.js runs, so the
+// property is observably "present" (a getter returning undefined). A site that
+// gates its init on `'ArkoseEnforcement' in window` could skip assigning — in
+// which case neither the capture nor the page's own widget initializes. A fully
+// transparent capture would intercept at the CDP network layer instead; this
+// in-page hook is the pragmatic tradeoff.
+const arkoseCaptureScript = `(function(){
+  if (window.__ptArkoseHook) return;
+  try { Object.defineProperty(window, '__ptArkoseHook', {value:true, configurable:true}); } catch(e){ return; }
+  function grab(cfg){
+    try{
+      if (cfg && cfg.data && typeof cfg.data.blob === 'string'){
+        window.__ptArkose = { blob: cfg.data.blob, pk: cfg.public_key || cfg.publicKey || '', surl: cfg.surl || '' };
+      }
+      if (cfg && typeof cfg.onCompleted === 'function'){ window.__ptArkoseOnCompleted = cfg.onCompleted; }
+    }catch(e){}
+  }
+  var real;
+  try{
+    Object.defineProperty(window, 'ArkoseEnforcement', {
+      configurable: true, enumerable: true,
+      get: function(){ return real; },
+      set: function(v){
+        try{
+          if (typeof v === 'function'){
+            // Idempotent: a re-assignment of ArkoseEnforcement must not wrap an
+            // already-wrapped setConfig (that makes origSet the wrapper itself →
+            // infinite recursion on the next setConfig call).
+            if (v.prototype && typeof v.prototype.setConfig === 'function' && !v.prototype.setConfig.__ptWrapped){
+              var origSet = v.prototype.setConfig;
+              var wrappedSet = function(cfg){ grab(cfg); return origSet.apply(this, arguments); };
+              wrappedSet.__ptWrapped = true;
+              v.prototype.setConfig = wrappedSet;
+            }
+            // newTarget defaults to v so new.target === v inside the real
+            // constructor (some Arkose builds tamper-check it); instanceof still
+            // holds because Wrapped.prototype === v.prototype.
+            var Wrapped = function(cfg){ grab(cfg); return Reflect.construct(v, arguments); };
+            Wrapped.prototype = v.prototype;
+            Object.setPrototypeOf(Wrapped, v);
+            real = Wrapped;
+            return;
+          }
+        }catch(e){}
+        real = v;
+      }
+    });
+  }catch(e){}
+})();`
+
+// injectArkoseCapture installs the document-start Arkose blob-capture hook on the
+// current target. Mirrors injectStealth; failures are non-fatal.
+func (b *Bridge) injectArkoseCapture(ctx context.Context) {
+	if err := chromedp.Run(ctx,
+		chromedp.ActionFunc(func(ctx context.Context) error {
+			_, err := page.AddScriptToEvaluateOnNewDocument(arkoseCaptureScript).Do(ctx)
+			return err
+		}),
+	); err != nil {
+		slog.Warn("arkose capture injection failed", "err", err)
+	}
+}

--- a/internal/bridge/bridge_lifecycle.go
+++ b/internal/bridge/bridge_lifecycle.go
@@ -100,6 +100,7 @@ func (b *Bridge) tabSetup(ctx context.Context, tabID string) {
 		b.installWorkerStealthParity(ctx)
 	}
 	b.injectStealth(ctx)
+	b.injectArkoseCapture(ctx)
 	if b.Config != nil && b.Config.NoAnimations {
 		if err := b.InjectNoAnimations(ctx); err != nil {
 			slog.Warn("no-animations injection failed", "err", err)


### PR DESCRIPTION
## Summary

Implements the previously-stubbed CapSolver solver (`internal/autosolver/external/capsolver.go` returned `"not yet implemented"`) and wires up **Arkose FunCaptcha** end-to-end, including the per-session `data` blob that modern deployments (e.g. LinkedIn) require.

Supported via the CapSolver API v1 (`createTask` → poll `getTaskResult` → inject token):

- **reCAPTCHA v2** — `ReCaptchaV2TaskProxyLess`
- **hCaptcha** — `HCaptchaTaskProxyLess`
- **Cloudflare Turnstile** — `AntiTurnstileTaskProxyLess`
- **Arkose FunCaptcha** — `FunCaptchaTaskProxyLess` (`websitePublicKey` + `funcaptchaApiJSSubdomain` + per-session `data` blob)

Registration is automatic when `autoSolver.external.capsolverKey` is set (existing wiring in `internal/handlers/autosolver.go`).

## Arkose blob capture

The FunCaptcha `data` blob is generated by the site's JS at runtime and never appears in static HTML, so it can't be scraped from `page.HTML()`. This adds a **document-start bridge hook** (`internal/bridge/arkose_capture.go`, injected in `tabSetup`) that transparently wraps `ArkoseEnforcement` to capture the `blob`, public key, and service URL onto `window.__ptArkose`, and preserves the page's `onCompleted` callback. The solver reads it via `Evaluate`, forwards the blob to CapSolver, and delivers the solved token through the site's own completion path.

The hook is designed to be low-tamper: faithful `new.target` (defaults to the real constructor so anti-tamper checks pass), an idempotent `setConfig` wrap (re-assignment can't cause recursion), and it's inert on non-Arkose pages.

## Details

- Detection + sitekey/pkey/subdomain extraction from page HTML (case-insensitive, tolerant of quote style + whitespace).
- Configurable poll interval (`CapsolverConfig.PollInterval`, default 3s); terminal `failed`/`error` status stops polling instead of running out the solver deadline.
- JS-safe token injection (`json.Marshal`, not `%q`).
- Unit tests: detection, extraction, task-type mapping, and end-to-end solve against a mock CapSolver API — reCAPTCHA + FunCaptcha, plus inline-ready, multi-poll, terminal-failure, and createTask-error paths.

## Known limitations (documented in-code)

- reCAPTCHA **v3** is detected as `recaptcha` and submitted as a V2 task; v3 score handling is out of scope here.
- The Arkose hook is a document-start in-page accessor; a site gating its init on `'ArkoseEnforcement' in window` could skip assignment. A fully transparent capture would intercept at the CDP network layer — noted as the future-robust path.

## Testing

`./dev check` (gofmt + vet + build + golangci-lint, 0 issues) and `go test ./internal/autosolver/external/ ./internal/bridge/` pass.