### PR TITLE
feat: improve dashboard screencast interactivity

### DIFF
--- a/dashboard/src/components/screencast/ScreencastTile.test.tsx
+++ b/dashboard/src/components/screencast/ScreencastTile.test.tsx
@@ -195,6 +195,7 @@ describe("ScreencastTile", () => {
     const authFailure = vi
       .spyOn(api, "handleRealtimeAuthFailure")
       .mockResolvedValue(undefined);
+    vi.spyOn(console, "error").mockImplementation(() => {});
 
     const dropLatestSocket = async () => {
       const socket = webSocketInstances.at(-1) as {

--- a/dashboard/src/components/screencast/ScreencastTile.test.tsx
+++ b/dashboard/src/components/screencast/ScreencastTile.test.tsx
@@ -1,10 +1,4 @@
-import {
-  act,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as api from "../../services/api";
 import ScreencastTile from "../screencast/ScreencastTile";
@@ -60,7 +54,7 @@ describe("ScreencastTile", () => {
     await waitFor(() => expect(webSocketMock).toHaveBeenCalledTimes(1));
 
     expect(webSocketMock).toHaveBeenCalledWith(
-      "wss://pinchtab.com/instances/inst_123/proxy/screencast?tabId=tab_456&quality=40&maxWidth=800&fps=1",
+      "wss://pinchtab.com/instances/inst_123/proxy/screencast?tabId=tab_456&quality=60&maxWidth=1280&fps=10",
     );
   });
 
@@ -172,7 +166,7 @@ describe("ScreencastTile", () => {
     expect(createImageBitmapMock).toHaveBeenCalledTimes(2);
   });
 
-  it("reconnects when retry is clicked after the socket closes", async () => {
+  it("auto-reconnects after the socket closes", async () => {
     render(
       <ScreencastTile
         instanceId="inst_123"
@@ -191,8 +185,8 @@ describe("ScreencastTile", () => {
       firstSocket.onclose?.({} as CloseEvent);
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "Retry connection" }));
-
+    // A dropped socket reconnects on its own (short backoff) — no manual retry —
+    // so a transient blip never leaves the user stuck on a "connection lost" overlay.
     await waitFor(() => expect(webSocketMock).toHaveBeenCalledTimes(2));
   });
 });

--- a/dashboard/src/components/screencast/ScreencastTile.test.tsx
+++ b/dashboard/src/components/screencast/ScreencastTile.test.tsx
@@ -189,4 +189,62 @@ describe("ScreencastTile", () => {
     // so a transient blip never leaves the user stuck on a "connection lost" overlay.
     await waitFor(() => expect(webSocketMock).toHaveBeenCalledTimes(2));
   });
+
+  it("restores the reconnect budget when the user hits Retry connection", async () => {
+    vi.useFakeTimers();
+    const authFailure = vi
+      .spyOn(api, "handleRealtimeAuthFailure")
+      .mockResolvedValue(undefined);
+
+    const dropLatestSocket = async () => {
+      const socket = webSocketInstances.at(-1) as {
+        onclose?: (event: CloseEvent) => void;
+      };
+      await act(async () => {
+        socket.onclose?.({} as CloseEvent);
+        // Cover the longest backoff (250ms → 4s cap) so the reconnect fires.
+        await vi.advanceTimersByTimeAsync(4000);
+      });
+    };
+
+    await act(async () => {
+      render(
+        <ScreencastTile
+          instanceId="inst_123"
+          tabId="tab_456"
+          label="Example"
+          url="https://pinchtab.com"
+        />,
+      );
+    });
+
+    expect(webSocketMock).toHaveBeenCalledTimes(1);
+
+    // Exhaust the six-attempt budget; the seventh drop surfaces the error path.
+    for (let i = 0; i < 6; i++) {
+      await dropLatestSocket();
+    }
+    const lastSocket = webSocketInstances.at(-1) as {
+      onclose?: (event: CloseEvent) => void;
+    };
+    await act(async () => {
+      lastSocket.onclose?.({} as CloseEvent);
+    });
+
+    expect(authFailure).toHaveBeenCalledTimes(1);
+    const socketsBeforeRetry = webSocketMock.mock.calls.length;
+
+    await act(async () => {
+      screen.getByText("Retry connection").click();
+    });
+
+    // A fresh socket opens immediately on retry...
+    expect(webSocketMock.mock.calls.length).toBe(socketsBeforeRetry + 1);
+
+    // ...and the next drop gets a full backoff window again instead of falling
+    // straight back into the auth-failure error path.
+    await dropLatestSocket();
+    expect(authFailure).toHaveBeenCalledTimes(1);
+    expect(webSocketMock.mock.calls.length).toBe(socketsBeforeRetry + 2);
+  });
 });

--- a/dashboard/src/components/screencast/ScreencastTile.tsx
+++ b/dashboard/src/components/screencast/ScreencastTile.tsx
@@ -19,9 +19,9 @@ export default function ScreencastTile({
   tabId,
   label,
   url,
-  quality = 40,
-  maxWidth = 800,
-  fps = 1,
+  quality = 60,
+  maxWidth = 1280,
+  fps = 10,
   showTitle = true,
 }: Props) {
   const canvasRef = useRef<HTMLCanvasElement>(null);

--- a/dashboard/src/components/screencast/useScreencastInput.test.ts
+++ b/dashboard/src/components/screencast/useScreencastInput.test.ts
@@ -1,0 +1,122 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { RefObject } from "react";
+import * as api from "../../services/api";
+import { useScreencastInput } from "./useScreencastInput";
+
+function makeCanvasRef(): RefObject<HTMLCanvasElement> {
+  const canvas = document.createElement("canvas");
+  canvas.width = 800;
+  canvas.height = 600;
+  vi.spyOn(canvas, "getBoundingClientRect").mockReturnValue({
+    left: 0,
+    top: 0,
+    width: 400,
+    height: 300,
+    right: 400,
+    bottom: 300,
+    x: 0,
+    y: 0,
+    toJSON: () => ({}),
+  } as DOMRect);
+  return { current: canvas };
+}
+
+function renderInput() {
+  const canvasRef = makeCanvasRef();
+  const { result } = renderHook(() =>
+    useScreencastInput({ canvasRef, tabId: "tab_1", status: "streaming" }),
+  );
+  return result;
+}
+
+describe("useScreencastInput modifiers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("forwards the Shift modifier (bitmask 8) on click", async () => {
+    const sendAction = vi.spyOn(api, "sendAction").mockResolvedValue(undefined);
+    const result = renderInput();
+
+    await result.current.handleCanvasClick({
+      clientX: 100,
+      clientY: 75,
+      altKey: false,
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: true,
+    } as React.MouseEvent<HTMLCanvasElement>);
+
+    expect(sendAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "click",
+        // (100 / 400) * 800, (75 / 300) * 600 → frame-pixel coords
+        x: 200,
+        y: 150,
+        hasXY: true,
+        modifiers: 8,
+      }),
+    );
+  });
+
+  it("combines Cmd+Shift into the bitmask (4 | 8 = 12) on click", async () => {
+    const sendAction = vi.spyOn(api, "sendAction").mockResolvedValue(undefined);
+    const result = renderInput();
+
+    await result.current.handleCanvasClick({
+      clientX: 0,
+      clientY: 0,
+      altKey: false,
+      ctrlKey: false,
+      metaKey: true,
+      shiftKey: true,
+    } as React.MouseEvent<HTMLCanvasElement>);
+
+    expect(sendAction).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "click", modifiers: 12 }),
+    );
+  });
+
+  it("sends modifiers: 0 for a plain click", async () => {
+    const sendAction = vi.spyOn(api, "sendAction").mockResolvedValue(undefined);
+    const result = renderInput();
+
+    await result.current.handleCanvasClick({
+      clientX: 10,
+      clientY: 10,
+      altKey: false,
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: false,
+    } as React.MouseEvent<HTMLCanvasElement>);
+
+    expect(sendAction).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "click", modifiers: 0 }),
+    );
+  });
+
+  it("forwards modifiers on wheel/scroll", async () => {
+    const sendAction = vi.spyOn(api, "sendAction").mockResolvedValue(undefined);
+    const result = renderInput();
+
+    await result.current.handleCanvasWheel({
+      clientX: 100,
+      clientY: 75,
+      deltaY: 120,
+      altKey: false,
+      ctrlKey: true,
+      metaKey: false,
+      shiftKey: false,
+      preventDefault: () => {},
+    } as unknown as React.WheelEvent<HTMLCanvasElement>);
+
+    expect(sendAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "scroll",
+        scrollY: 120,
+        modifiers: 2,
+      }),
+    );
+  });
+});

--- a/dashboard/src/components/screencast/useScreencastInput.ts
+++ b/dashboard/src/components/screencast/useScreencastInput.ts
@@ -24,6 +24,10 @@ export function useScreencastInput({
       return {
         x: ((e.clientX - rect.left) / rect.width) * canvas.width,
         y: ((e.clientY - rect.top) / rect.height) * canvas.height,
+        // Tell the server which frame size these coords are in, so it can scale
+        // them into the live CSS viewport (the frame is larger on HiDPI).
+        frameW: canvas.width,
+        frameH: canvas.height,
       };
     },
     [canvasRef],
@@ -41,6 +45,8 @@ export function useScreencastInput({
           x: Math.round(coords.x),
           y: Math.round(coords.y),
           hasXY: true,
+          frameW: coords.frameW,
+          frameH: coords.frameH,
         });
       } catch (err) {
         console.error("click failed", err);
@@ -61,6 +67,8 @@ export function useScreencastInput({
           x: Math.round(coords.x),
           y: Math.round(coords.y),
           scrollY: Math.round(e.deltaY),
+          frameW: coords.frameW,
+          frameH: coords.frameH,
         });
       } catch (err) {
         console.error("scroll failed", err);

--- a/dashboard/src/components/screencast/useScreencastInput.ts
+++ b/dashboard/src/components/screencast/useScreencastInput.ts
@@ -9,6 +9,23 @@ interface UseScreencastInputArgs {
   status: ScreencastStatus;
 }
 
+// CDP modifier bitmask: Alt=1, Ctrl=2, Meta=4, Shift=8. Shared by the keyboard
+// and pointer paths so held-modifier gestures (Shift+click, Cmd/Ctrl+click,
+// Ctrl+C) reach the page with the same encoding.
+function modifierBitmask(e: {
+  altKey: boolean;
+  ctrlKey: boolean;
+  metaKey: boolean;
+  shiftKey: boolean;
+}): number {
+  return (
+    (e.altKey ? 1 : 0) |
+    (e.ctrlKey ? 2 : 0) |
+    (e.metaKey ? 4 : 0) |
+    (e.shiftKey ? 8 : 0)
+  );
+}
+
 export function useScreencastInput({
   canvasRef,
   tabId,
@@ -47,6 +64,7 @@ export function useScreencastInput({
           hasXY: true,
           frameW: coords.frameW,
           frameH: coords.frameH,
+          modifiers: modifierBitmask(e),
         });
       } catch (err) {
         console.error("click failed", err);
@@ -69,6 +87,7 @@ export function useScreencastInput({
           scrollY: Math.round(e.deltaY),
           frameW: coords.frameW,
           frameH: coords.frameH,
+          modifiers: modifierBitmask(e),
         });
       } catch (err) {
         console.error("scroll failed", err);
@@ -95,13 +114,9 @@ export function useScreencastInput({
         return;
       }
       e.preventDefault();
-      // CDP modifier bitmask: Alt=1, Ctrl=2, Meta=4, Shift=8. Forwarded with
-      // `press` so keyboard chords (Ctrl+C, Cmd+A, Shift+Arrow) reach the page.
-      const modifiers =
-        (e.altKey ? 1 : 0) |
-        (e.ctrlKey ? 2 : 0) |
-        (e.metaKey ? 4 : 0) |
-        (e.shiftKey ? 8 : 0);
+      // Forwarded with `press` so keyboard chords (Ctrl+C, Cmd+A, Shift+Arrow)
+      // reach the page.
+      const modifiers = modifierBitmask(e);
       try {
         if (e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey) {
           // Printable character with no command modifier (Shift-for-caps is

--- a/dashboard/src/components/screencast/useScreencastInput.ts
+++ b/dashboard/src/components/screencast/useScreencastInput.ts
@@ -95,15 +95,24 @@ export function useScreencastInput({
         return;
       }
       e.preventDefault();
+      // CDP modifier bitmask: Alt=1, Ctrl=2, Meta=4, Shift=8. Forwarded with
+      // `press` so keyboard chords (Ctrl+C, Cmd+A, Shift+Arrow) reach the page.
+      const modifiers =
+        (e.altKey ? 1 : 0) |
+        (e.ctrlKey ? 2 : 0) |
+        (e.metaKey ? 4 : 0) |
+        (e.shiftKey ? 8 : 0);
       try {
         if (e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey) {
+          // Printable character with no command modifier (Shift-for-caps is
+          // already reflected in e.key) → insert as text.
           await api.sendAction({
             kind: "keyboard-inserttext",
             tabId,
             text: e.key,
           });
         } else {
-          await api.sendAction({ kind: "press", tabId, key: e.key });
+          await api.sendAction({ kind: "press", tabId, key: e.key, modifiers });
         }
       } catch (err) {
         console.error("key input failed", err);

--- a/dashboard/src/components/screencast/useScreencastStream.ts
+++ b/dashboard/src/components/screencast/useScreencastStream.ts
@@ -23,6 +23,8 @@ export function useScreencastStream({
   canvasRef,
 }: UseScreencastStreamArgs) {
   const socketRef = useRef<WebSocket | null>(null);
+  const reconnectAttemptsRef = useRef(0);
+  const reconnectTimerRef = useRef<number | undefined>(undefined);
   const [status, setStatus] = useState<ScreencastStatus>("connecting");
   const [fpsDisplay, setFpsDisplay] = useState("—");
   const [sizeDisplay, setSizeDisplay] = useState("—");
@@ -37,6 +39,7 @@ export function useScreencastStream({
     setStatus("connecting");
     setHasFrame(false);
     setFallbackUrl(null);
+    reconnectAttemptsRef.current = 0; // fresh tab → fresh reconnect budget
   }, [tabId, fps]);
 
   // Clean up static preview URL on unmount or tab change
@@ -114,6 +117,8 @@ export function useScreencastStream({
 
         hasRenderedFrame = true;
         window.clearTimeout(fallbackTimer);
+        // A frame arrived: the stream is healthy, so clear the reconnect backoff.
+        reconnectAttemptsRef.current = 0;
         setHasFrame(true);
         setStatus("streaming");
       } catch (err) {
@@ -151,23 +156,37 @@ export function useScreencastStream({
       }
     };
 
-    socket.onerror = () => {
-      if (!disposed) {
+    // A dropped screencast socket is usually transient (the capture pipeline
+    // hiccupped, the tab briefly navigated, a proxy blip). Auto-reconnect with a
+    // short backoff instead of dropping the user into a permanent "connection
+    // lost" overlay. Only after repeated failures do we surface an error and run
+    // the auth-failure path, since a persistently rejected socket may mean the
+    // session is no longer valid.
+    const MAX_RECONNECT_ATTEMPTS = 6;
+    let dropHandled = false;
+    const handleDrop = () => {
+      if (disposed || dropHandled) return;
+      dropHandled = true;
+      if (reconnectAttemptsRef.current >= MAX_RECONNECT_ATTEMPTS) {
         setStatus("error");
         void api.handleRealtimeAuthFailure();
+        return;
       }
+      const attempt = reconnectAttemptsRef.current++;
+      const delay = Math.min(250 * 2 ** attempt, 4000); // 250ms → … → 4s cap
+      setStatus("connecting");
+      reconnectTimerRef.current = window.setTimeout(() => {
+        if (!disposed) setRetryKey((p) => p + 1);
+      }, delay);
     };
 
-    socket.onclose = () => {
-      if (!disposed) {
-        setStatus("error");
-        void api.handleRealtimeAuthFailure();
-      }
-    };
+    socket.onerror = handleDrop;
+    socket.onclose = handleDrop;
 
     return () => {
       disposed = true;
       window.clearTimeout(fallbackTimer);
+      window.clearTimeout(reconnectTimerRef.current);
       socket.close();
       socketRef.current = null;
     };

--- a/dashboard/src/components/screencast/useScreencastStream.ts
+++ b/dashboard/src/components/screencast/useScreencastStream.ts
@@ -204,6 +204,10 @@ export function useScreencastStream({
   const retry = () => {
     setStatus("connecting");
     setHasFrame(false);
+    // Manual retry is a fresh start: clear the exhausted reconnect budget so the
+    // next drop gets a full backoff window instead of falling straight back into
+    // the error path.
+    reconnectAttemptsRef.current = 0;
     setRetryKey((p) => p + 1);
   };
 

--- a/dashboard/src/stores/slices/settingsSlice.ts
+++ b/dashboard/src/stores/slices/settingsSlice.ts
@@ -3,7 +3,7 @@ import type { Settings } from "../../generated/types";
 import type { AppState } from "../useAppStore";
 
 const defaultSettings: Settings = {
-  screencast: { fps: 1, quality: 40, maxWidth: 800 },
+  screencast: { fps: 10, quality: 60, maxWidth: 1280 },
   stealth: "light",
   browser: { blockImages: false, blockMedia: false, noAnimations: false },
   monitoring: { memoryMetrics: false, pollInterval: 30 },

--- a/internal/assets/screencast_repaint_start.js
+++ b/internal/assets/screencast_repaint_start.js
@@ -35,6 +35,6 @@
   state.host = host;
   state.element = el;
   state.mount = mount;
-  state.timer = setInterval(tick, 250);
+  state.timer = setInterval(tick, 100);
   return state.refs;
 })()

--- a/internal/bridge/action_pointer.go
+++ b/internal/bridge/action_pointer.go
@@ -221,7 +221,25 @@ func dialogBlocking(dm *DialogManager, tabID string) error {
 	}
 }
 
+// scaleScreencastCoords rescales req.X/Y from the screencast frame pixel space
+// (req.FrameW/FrameH) into the live CSS viewport. Dashboard input maps a click on
+// the frame to frame-pixel coordinates; on HiDPI the frame is larger than the CSS
+// viewport (e.g. 2x), so without this the click would land at the wrong position
+// and miss its target. No-op when FrameW/FrameH are unset (coords already CSS px).
+func scaleScreencastCoords(ctx context.Context, req *ActionRequest) {
+	if !req.HasXY || req.FrameW <= 0 || req.FrameH <= 0 {
+		return
+	}
+	vw, vh := fetchViewportSize(ctx)
+	if vw <= 0 || vh <= 0 {
+		return
+	}
+	req.X = req.X * vw / req.FrameW
+	req.Y = req.Y * vh / req.FrameH
+}
+
 func (b *Bridge) actionClick(ctx context.Context, req ActionRequest) (result map[string]any, err error) {
+	scaleScreencastCoords(ctx, &req)
 	if b.effectiveHumanize(req) {
 		return b.actionHumanizedClick(ctx, req)
 	}
@@ -522,6 +540,7 @@ func (b *Bridge) actionMouseWheel(ctx context.Context, req ActionRequest) (map[s
 }
 
 func (b *Bridge) actionScroll(ctx context.Context, req ActionRequest) (map[string]any, error) {
+	scaleScreencastCoords(ctx, &req)
 	if req.NodeID > 0 {
 		return map[string]any{"scrolled": true}, ScrollByNodeID(ctx, req.NodeID)
 	}

--- a/internal/bridge/action_pointer.go
+++ b/internal/bridge/action_pointer.go
@@ -16,6 +16,7 @@ var scrollByCoordinateAction = ScrollByCoordinate
 var mouseMoveByCoordinateAction = MouseMoveByCoordinate
 var mouseDownByCoordinateAction = MouseDownByCoordinate
 var mouseUpByCoordinateAction = MouseUpByCoordinate
+var clickByCoordinateAction = ClickByCoordinate
 var clickElementAction = ClickElement
 var clickByNodeIDAction = ClickByNodeID
 var jsClickByBackendNodeAction = JSClickByBackendNode
@@ -301,7 +302,7 @@ func (b *Bridge) actionClick(ctx context.Context, req ActionRequest) (result map
 			}
 			err = clickByNodeIDWithMode(clickCtx, req.NodeID, req.Mode)
 		} else if req.HasXY {
-			err = ClickByCoordinate(clickCtx, req.X, req.Y)
+			err = clickByCoordinateAction(clickCtx, req.X, req.Y, req.Modifiers)
 		} else {
 			resultCh <- clickResult{err: fmt.Errorf("need selector, ref, nodeId, or x/y coordinates")}
 			return
@@ -489,7 +490,7 @@ func (b *Bridge) actionMouseDown(ctx context.Context, req ActionRequest) (map[st
 	if button == "" {
 		button = "left"
 	}
-	if err := mouseDownByCoordinateAction(ctx, x, y, button); err != nil {
+	if err := mouseDownByCoordinateAction(ctx, x, y, button, req.Modifiers); err != nil {
 		return nil, err
 	}
 	b.rememberPointerPosition(req.TabID, x, y)
@@ -505,7 +506,7 @@ func (b *Bridge) actionMouseUp(ctx context.Context, req ActionRequest) (map[stri
 	if button == "" {
 		button = "left"
 	}
-	if err := mouseUpByCoordinateAction(ctx, x, y, button); err != nil {
+	if err := mouseUpByCoordinateAction(ctx, x, y, button, req.Modifiers); err != nil {
 		return nil, err
 	}
 	b.rememberPointerPosition(req.TabID, x, y)
@@ -532,7 +533,7 @@ func (b *Bridge) actionMouseWheel(ctx context.Context, req ActionRequest) (map[s
 	if deltaX == 0 && deltaY == 0 {
 		deltaY = 120
 	}
-	if err := scrollByCoordinateAction(ctx, x, y, deltaX, deltaY); err != nil {
+	if err := scrollByCoordinateAction(ctx, x, y, deltaX, deltaY, req.Modifiers); err != nil {
 		return nil, err
 	}
 	b.rememberPointerPosition(req.TabID, x, y)
@@ -578,7 +579,7 @@ func (b *Bridge) actionScroll(ctx context.Context, req ActionRequest) (map[strin
 			"deltaX":  scrollX,
 			"deltaY":  scrollY,
 		},
-		scrollByCoordinateAction(ctx, scrollTargetX, scrollTargetY, scrollX, scrollY)
+		scrollByCoordinateAction(ctx, scrollTargetX, scrollTargetY, scrollX, scrollY, req.Modifiers)
 }
 
 func (b *Bridge) actionDrag(ctx context.Context, req ActionRequest) (map[string]any, error) {

--- a/internal/bridge/action_request.go
+++ b/internal/bridge/action_request.go
@@ -53,6 +53,15 @@ type ActionRequest struct {
 	Button string  `json:"button,omitempty"`
 	Mode   string  `json:"mode,omitempty"`
 
+	// FrameW/FrameH are the pixel dimensions of the screencast frame the caller
+	// mapped the coordinates against (the dashboard maps a click to frame-pixel
+	// space). When set, X/Y are scaled from that frame space into the live CSS
+	// viewport before dispatch, so a HiDPI frame (e.g. 2x the CSS viewport) does
+	// not land clicks at twice their intended position. Zero means X/Y are
+	// already CSS pixels.
+	FrameW float64 `json:"frameW,omitempty"`
+	FrameH float64 `json:"frameH,omitempty"`
+
 	ScrollX int `json:"scrollX"`
 	ScrollY int `json:"scrollY"`
 	// DeltaX/DeltaY are explicit mouse-wheel deltas for low-level

--- a/internal/bridge/action_request.go
+++ b/internal/bridge/action_request.go
@@ -62,6 +62,10 @@ type ActionRequest struct {
 	FrameW float64 `json:"frameW,omitempty"`
 	FrameH float64 `json:"frameH,omitempty"`
 
+	// Modifiers is the CDP key-modifier bitmask (Alt=1, Ctrl=2, Meta=4, Shift=8)
+	// held during a press, enabling keyboard chords such as Ctrl+C or Shift+Arrow.
+	Modifiers int `json:"modifiers,omitempty"`
+
 	ScrollX int `json:"scrollX"`
 	ScrollY int `json:"scrollY"`
 	// DeltaX/DeltaY are explicit mouse-wheel deltas for low-level

--- a/internal/bridge/action_text.go
+++ b/internal/bridge/action_text.go
@@ -65,7 +65,7 @@ func (b *Bridge) actionPress(ctx context.Context, req ActionRequest) (map[string
 			return nil, err
 		}
 	}
-	return map[string]any{"pressed": req.Key}, DispatchNamedKey(ctx, req.Key)
+	return map[string]any{"pressed": req.Key}, DispatchNamedKey(ctx, req.Key, req.Modifiers)
 }
 
 func (b *Bridge) actionHumanizedType(ctx context.Context, req ActionRequest) (map[string]any, error) {

--- a/internal/bridge/actions_test.go
+++ b/internal/bridge/actions_test.go
@@ -125,7 +125,7 @@ func TestMouseWheelAction_UsesExplicitWheelDeltas(t *testing.T) {
 	})
 
 	called := false
-	scrollByCoordinateAction = func(ctx context.Context, x, y float64, deltaX, deltaY int) error {
+	scrollByCoordinateAction = func(ctx context.Context, x, y float64, deltaX, deltaY, modifiers int) error {
 		called = true
 		if x != 50 || y != 75 {
 			t.Fatalf("wheel coordinates = (%v, %v), want (50, 75)", x, y)
@@ -158,6 +158,66 @@ func TestMouseWheelAction_UsesExplicitWheelDeltas(t *testing.T) {
 	}
 }
 
+func TestClickAction_ForwardsModifiers(t *testing.T) {
+	b := New(context.TODO(), nil, &config.RuntimeConfig{})
+
+	origClick := clickByCoordinateAction
+	t.Cleanup(func() { clickByCoordinateAction = origClick })
+
+	var gotModifiers int
+	called := false
+	clickByCoordinateAction = func(ctx context.Context, x, y float64, modifiers int) error {
+		called = true
+		gotModifiers = modifiers
+		return nil
+	}
+
+	// Shift+click from the screencast UI: modifier bitmask 8 must reach the
+	// CDP pointer dispatch so the page sees a held Shift.
+	if _, err := b.Actions[ActionClick](context.Background(), ActionRequest{
+		HasXY:     true,
+		X:         40,
+		Y:         60,
+		Modifiers: 8,
+	}); err != nil {
+		t.Fatalf("click returned error: %v", err)
+	}
+	if !called {
+		t.Fatal("expected coordinate click path to be used")
+	}
+	if gotModifiers != 8 {
+		t.Fatalf("click modifiers = %d, want 8 (Shift)", gotModifiers)
+	}
+}
+
+func TestMouseWheelAction_ForwardsModifiers(t *testing.T) {
+	b := New(context.TODO(), nil, &config.RuntimeConfig{})
+
+	origScroll := scrollByCoordinateAction
+	t.Cleanup(func() { scrollByCoordinateAction = origScroll })
+
+	var gotModifiers int
+	scrollByCoordinateAction = func(ctx context.Context, x, y float64, deltaX, deltaY, modifiers int) error {
+		gotModifiers = modifiers
+		return nil
+	}
+
+	// Shift+wheel (horizontal scroll intent): the bitmask must reach the wheel
+	// dispatch.
+	if _, err := b.Actions[ActionMouseWheel](context.Background(), ActionRequest{
+		HasXY:     true,
+		X:         10,
+		Y:         20,
+		DeltaY:    120,
+		Modifiers: 8,
+	}); err != nil {
+		t.Fatalf("mouse wheel returned error: %v", err)
+	}
+	if gotModifiers != 8 {
+		t.Fatalf("wheel modifiers = %d, want 8 (Shift)", gotModifiers)
+	}
+}
+
 func TestMouseActions_TrackCurrentPointerPosition(t *testing.T) {
 	b := New(context.TODO(), nil, &config.RuntimeConfig{})
 
@@ -177,7 +237,7 @@ func TestMouseActions_TrackCurrentPointerPosition(t *testing.T) {
 		}
 		return nil
 	}
-	mouseUpByCoordinateAction = func(ctx context.Context, x, y float64, button string) error {
+	mouseUpByCoordinateAction = func(ctx context.Context, x, y float64, button string, modifiers int) error {
 		upCalled = true
 		if x != 15 || y != 25 {
 			t.Fatalf("up coordinates = (%v, %v), want (15, 25)", x, y)
@@ -213,7 +273,7 @@ func TestMouseDownAction_UsesTrackedPointerWhenTargetMissing(t *testing.T) {
 		mouseDownByCoordinateAction = origDown
 	})
 
-	mouseDownByCoordinateAction = func(ctx context.Context, x, y float64, button string) error {
+	mouseDownByCoordinateAction = func(ctx context.Context, x, y float64, button string, modifiers int) error {
 		if x != 33 || y != 44 {
 			t.Fatalf("down coordinates = (%v, %v), want (33, 44)", x, y)
 		}
@@ -245,7 +305,7 @@ func TestMouseWheelAction_UsesViewportCenterWhenPointerMissing(t *testing.T) {
 		return 300, 200, nil
 	}
 	called := false
-	scrollByCoordinateAction = func(ctx context.Context, x, y float64, deltaX, deltaY int) error {
+	scrollByCoordinateAction = func(ctx context.Context, x, y float64, deltaX, deltaY, modifiers int) error {
 		called = true
 		if x != 300 || y != 200 {
 			t.Fatalf("wheel coordinates = (%v, %v), want (300, 200)", x, y)
@@ -660,7 +720,7 @@ func TestScrollAction_UsesCoordinateWheelPath(t *testing.T) {
 	})
 
 	called := false
-	scrollByCoordinateAction = func(ctx context.Context, x, y float64, deltaX, deltaY int) error {
+	scrollByCoordinateAction = func(ctx context.Context, x, y float64, deltaX, deltaY, modifiers int) error {
 		called = true
 		if x != 12.5 || y != 34.5 {
 			t.Fatalf("wheel coordinates = (%v, %v), want (12.5, 34.5)", x, y)
@@ -707,7 +767,7 @@ func TestScrollAction_UsesViewportCenterWhenCoordinatesMissing(t *testing.T) {
 	}
 
 	called := false
-	scrollByCoordinateAction = func(ctx context.Context, x, y float64, deltaX, deltaY int) error {
+	scrollByCoordinateAction = func(ctx context.Context, x, y float64, deltaX, deltaY, modifiers int) error {
 		called = true
 		if x != 400 || y != 300 {
 			t.Fatalf("wheel coordinates = (%v, %v), want (400, 300)", x, y)
@@ -746,7 +806,7 @@ func TestScrollAction_PropagatesViewportCenterError(t *testing.T) {
 	scrollViewportCenter = func(context.Context) (float64, float64, error) {
 		return 0, 0, context.Canceled
 	}
-	scrollByCoordinateAction = func(context.Context, float64, float64, int, int) error {
+	scrollByCoordinateAction = func(context.Context, float64, float64, int, int, int) error {
 		t.Fatal("wheel dispatch should not be called when viewport center resolution fails")
 		return nil
 	}

--- a/internal/bridge/cdp_keyboard.go
+++ b/internal/bridge/cdp_keyboard.go
@@ -14,18 +14,18 @@ var namedKeyDefs = map[string]struct {
 	virtualKey int64
 	insertText string
 }{
-	"Enter":      {"Enter", 13, "\r"},
-	"Return":     {"Enter", 13, "\r"},
-	"Tab":        {"Tab", 9, "\t"},
-	"Escape":     {"Escape", 27, ""},
+	"Enter":  {"Enter", 13, "\r"},
+	"Return": {"Enter", 13, "\r"},
+	"Tab":    {"Tab", 9, "\t"},
+	"Escape": {"Escape", 27, ""},
 	// Modifier keys must dispatch keyDown/keyUp events, never text. Without these
 	// entries they fall through to chromedp.KeyEvent and the literal name ("Shift")
 	// is typed into the focused field (issue #588). insertText is empty so the
 	// browser receives a real modifier key event with no character.
-	"Shift":   {"ShiftLeft", 16, ""},
-	"Control": {"ControlLeft", 17, ""},
-	"Alt":     {"AltLeft", 18, ""},
-	"Meta":    {"MetaLeft", 91, ""},
+	"Shift":      {"ShiftLeft", 16, ""},
+	"Control":    {"ControlLeft", 17, ""},
+	"Alt":        {"AltLeft", 18, ""},
+	"Meta":       {"MetaLeft", 91, ""},
 	"Backspace":  {"Backspace", 8, ""},
 	"Delete":     {"Delete", 46, ""},
 	"ArrowLeft":  {"ArrowLeft", 37, ""},
@@ -51,10 +51,69 @@ var namedKeyDefs = map[string]struct {
 	"F12":        {"F12", 123, ""},
 }
 
-// Unrecognised keys fall back to chromedp.KeyEvent.
-func DispatchNamedKey(ctx context.Context, key string) error {
+// printableShortcutKey returns the CDP code and Windows virtual-key code for a
+// single printable ASCII key. It is used to dispatch keyboard shortcuts such as
+// Ctrl+C / Cmd+A where the key is not in namedKeyDefs but must still carry a real
+// code/virtualKey so the page recognises the chord. ok is false for anything we
+// cannot map (the caller then falls back to typing the key).
+func printableShortcutKey(key string) (code string, vk int64, ok bool) {
+	if len(key) != 1 {
+		return "", 0, false
+	}
+	c := key[0]
+	switch {
+	case c >= 'a' && c <= 'z':
+		u := c - ('a' - 'A')
+		return "Key" + string(rune(u)), int64(u), true
+	case c >= 'A' && c <= 'Z':
+		return "Key" + string(rune(c)), int64(c), true
+	case c >= '0' && c <= '9':
+		return "Digit" + string(rune(c)), int64(c), true
+	}
+	return "", 0, false
+}
+
+// editingCommand maps a Ctrl/Cmd shortcut to the editing command CDP applies via
+// the keyDown "commands" field. On macOS the built-in editor only performs these
+// actions (select-all, copy, …) when the command name is supplied; Linux/Windows
+// derive them from the key event directly, where the empty default is harmless.
+func editingCommand(key string, modifiers int) string {
+	const ctrl, meta, shift = 2, 4, 8
+	if modifiers&(ctrl|meta) == 0 {
+		return ""
+	}
+	switch key {
+	case "a", "A":
+		return "selectAll"
+	case "c", "C":
+		return "copy"
+	case "v", "V":
+		return "paste"
+	case "x", "X":
+		return "cut"
+	case "z", "Z":
+		if modifiers&shift != 0 {
+			return "redo"
+		}
+		return "undo"
+	case "y", "Y":
+		return "redo"
+	}
+	return ""
+}
+
+// DispatchNamedKey dispatches key with the given CDP modifier bitmask
+// (Alt=1, Ctrl=2, Meta=4, Shift=8). Unrecognised keys with no modifiers fall
+// back to chromedp.KeyEvent (types the key); with modifiers they are dispatched
+// as a shortcut so chords like Ctrl+C / Cmd+A reach the page.
+func DispatchNamedKey(ctx context.Context, key string, modifiers int) error {
 	def, ok := namedKeyDefs[key]
 	if !ok {
+		if modifiers != 0 {
+			if code, vk, mapped := printableShortcutKey(key); mapped {
+				return dispatchKeyChord(ctx, key, code, vk, "", modifiers, editingCommand(key, modifiers))
+			}
+		}
 		return chromedp.Run(ctx, chromedp.KeyEvent(key))
 	}
 
@@ -63,44 +122,55 @@ func DispatchNamedKey(ctx context.Context, key string) error {
 		w3cKey = "Enter"
 	}
 
-	dispatchEvent := func(evType string) chromedp.ActionFunc {
-		return chromedp.ActionFunc(func(ctx context.Context) error {
-			return chromedp.FromContext(ctx).Target.Execute(ctx, "Input.dispatchKeyEvent", map[string]any{
-				"type":                  evType,
-				"key":                   w3cKey,
-				"code":                  def.code,
-				"windowsVirtualKeyCode": def.virtualKey,
-				"nativeVirtualKeyCode":  def.virtualKey,
-			}, nil)
-		})
+	// A named key with modifiers is a shortcut (Shift+ArrowRight selects,
+	// Ctrl+Backspace deletes a word): suppress its default text so it isn't
+	// also inserted as a character.
+	text := def.insertText
+	if modifiers != 0 {
+		text = ""
+	}
+	return dispatchKeyChord(ctx, w3cKey, def.code, def.virtualKey, text, modifiers, "")
+}
+
+// dispatchKeyChord sends a keyDown+keyUp pair via CDP, applying the modifier
+// bitmask. When text is non-empty the keyDown uses type "keyDown" and carries the
+// text (fires keypress + default actions like form submit); otherwise it uses
+// "rawKeyDown" for non-character / shortcut keys.
+func dispatchKeyChord(ctx context.Context, key, code string, vk int64, text string, modifiers int, command string) error {
+	params := func(evType string, isKeyDown bool) map[string]any {
+		p := map[string]any{
+			"type":                  evType,
+			"key":                   key,
+			"code":                  code,
+			"windowsVirtualKeyCode": vk,
+			"nativeVirtualKeyCode":  vk,
+		}
+		if modifiers != 0 {
+			p["modifiers"] = modifiers
+		}
+		if isKeyDown && text != "" {
+			p["text"] = text
+			p["unmodifiedText"] = text
+		}
+		// The editing command rides on the keyDown so macOS performs the action.
+		if isKeyDown && command != "" {
+			p["commands"] = []string{command}
+		}
+		return p
 	}
 
-	// "keyDown" + text field fires keypress and triggers default actions (form submit, tab advance).
-	// "rawKeyDown" for non-character keys — no keypress needed.
 	downType := "rawKeyDown"
-	var downText string
-	if def.insertText != "" {
+	if text != "" {
 		downType = "keyDown"
-		downText = def.insertText
 	}
-	dispatchKeyDown := chromedp.ActionFunc(func(ctx context.Context) error {
-		params := map[string]any{
-			"type":                  downType,
-			"key":                   w3cKey,
-			"code":                  def.code,
-			"windowsVirtualKeyCode": def.virtualKey,
-			"nativeVirtualKeyCode":  def.virtualKey,
-		}
-		if downText != "" {
-			params["text"] = downText
-			params["unmodifiedText"] = downText
-		}
-		return chromedp.FromContext(ctx).Target.Execute(ctx, "Input.dispatchKeyEvent", params, nil)
-	})
-	actions := chromedp.Tasks{dispatchKeyDown}
-	actions = append(actions, dispatchEvent("keyUp"))
-
-	return chromedp.Run(ctx, actions...)
+	return chromedp.Run(ctx,
+		chromedp.ActionFunc(func(c context.Context) error {
+			return chromedp.FromContext(c).Target.Execute(c, "Input.dispatchKeyEvent", params(downType, true), nil)
+		}),
+		chromedp.ActionFunc(func(c context.Context) error {
+			return chromedp.FromContext(c).Target.Execute(c, "Input.dispatchKeyEvent", params("keyUp", false), nil)
+		}),
+	)
 }
 
 func TypeByNodeID(ctx context.Context, nodeID int64, text string) error {

--- a/internal/bridge/cdp_keyboard.go
+++ b/internal/bridge/cdp_keyboard.go
@@ -18,6 +18,14 @@ var namedKeyDefs = map[string]struct {
 	"Return":     {"Enter", 13, "\r"},
 	"Tab":        {"Tab", 9, "\t"},
 	"Escape":     {"Escape", 27, ""},
+	// Modifier keys must dispatch keyDown/keyUp events, never text. Without these
+	// entries they fall through to chromedp.KeyEvent and the literal name ("Shift")
+	// is typed into the focused field (issue #588). insertText is empty so the
+	// browser receives a real modifier key event with no character.
+	"Shift":   {"ShiftLeft", 16, ""},
+	"Control": {"ControlLeft", 17, ""},
+	"Alt":     {"AltLeft", 18, ""},
+	"Meta":    {"MetaLeft", 91, ""},
 	"Backspace":  {"Backspace", 8, ""},
 	"Delete":     {"Delete", 46, ""},
 	"ArrowLeft":  {"ArrowLeft", 37, ""},

--- a/internal/bridge/cdp_keyboard_test.go
+++ b/internal/bridge/cdp_keyboard_test.go
@@ -79,6 +79,31 @@ func TestDispatchNamedKey_ModifiersNotTyped(t *testing.T) {
 	}
 }
 
+// TestPrintableShortcutKey verifies the code/virtual-key mapping used to dispatch
+// keyboard chords (Ctrl+C, Cmd+A, …) on printable keys.
+func TestPrintableShortcutKey(t *testing.T) {
+	cases := []struct {
+		key      string
+		wantCode string
+		wantVK   int64
+		wantOK   bool
+	}{
+		{"c", "KeyC", 67, true}, // Ctrl+C
+		{"a", "KeyA", 65, true}, // Cmd/Ctrl+A
+		{"C", "KeyC", 67, true}, // already-uppercase maps the same
+		{"5", "Digit5", 53, true},
+		{"Enter", "", 0, false}, // multi-char → not a printable shortcut key
+		{"-", "", 0, false},     // unmapped punctuation
+	}
+	for _, tc := range cases {
+		code, vk, ok := printableShortcutKey(tc.key)
+		if ok != tc.wantOK || code != tc.wantCode || vk != tc.wantVK {
+			t.Errorf("printableShortcutKey(%q) = (%q,%d,%v), want (%q,%d,%v)",
+				tc.key, code, vk, ok, tc.wantCode, tc.wantVK, tc.wantOK)
+		}
+	}
+}
+
 // TestDispatchNamedKey_ReturnAlias verifies that "Return" is an alias for
 // Enter and produces the same CDP parameters.
 func TestDispatchNamedKey_ReturnAlias(t *testing.T) {
@@ -97,7 +122,7 @@ func TestDispatchNamedKey_FallbackOnCancelledCtx(t *testing.T) {
 	cancel()
 
 	// "a" is not in namedKeyDefs → falls back to chromedp.KeyEvent
-	err := DispatchNamedKey(ctx, "a")
+	err := DispatchNamedKey(ctx, "a", 0)
 	if err == nil {
 		t.Error("expected error dispatching key on cancelled context")
 	}
@@ -109,7 +134,7 @@ func TestDispatchNamedKey_KnownKeyOnCancelledCtx(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	err := DispatchNamedKey(ctx, "Enter")
+	err := DispatchNamedKey(ctx, "Enter", 0)
 	if err == nil {
 		t.Error("expected error dispatching Enter on cancelled context")
 	}

--- a/internal/bridge/cdp_keyboard_test.go
+++ b/internal/bridge/cdp_keyboard_test.go
@@ -58,6 +58,27 @@ func TestDispatchNamedKey_NonPrintableNoInsertText(t *testing.T) {
 	}
 }
 
+// TestDispatchNamedKey_ModifiersNotTyped is the regression test for issue #588:
+// modifier keys (Shift/Control/Alt/Meta) must be recognised named keys with an
+// empty insertText so they dispatch keyDown/keyUp events instead of falling
+// through to chromedp.KeyEvent, which would type the literal name (e.g. "Shift")
+// into the focused field.
+func TestDispatchNamedKey_ModifiersNotTyped(t *testing.T) {
+	for _, k := range []string{"Shift", "Control", "Alt", "Meta"} {
+		def, ok := namedKeyDefs[k]
+		if !ok {
+			t.Errorf("modifier %q must be a recognised named key (else it gets typed as text)", k)
+			continue
+		}
+		if def.insertText != "" {
+			t.Errorf("modifier %q must have empty insertText, got %q (would type literal text)", k, def.insertText)
+		}
+		if def.code == "" || def.virtualKey == 0 {
+			t.Errorf("modifier %q must carry a code and virtualKey, got code=%q vk=%d", k, def.code, def.virtualKey)
+		}
+	}
+}
+
 // TestDispatchNamedKey_ReturnAlias verifies that "Return" is an alias for
 // Enter and produces the same CDP parameters.
 func TestDispatchNamedKey_ReturnAlias(t *testing.T) {

--- a/internal/bridge/cdp_pointer_test.go
+++ b/internal/bridge/cdp_pointer_test.go
@@ -9,7 +9,7 @@ func TestClickByCoordinate_ContextCancelled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	err := ClickByCoordinate(ctx, 0, 0)
+	err := ClickByCoordinate(ctx, 0, 0, 0)
 	if err == nil {
 		t.Fatal("expected error for cancelled context")
 	}
@@ -39,7 +39,7 @@ func TestMouseDownByCoordinate_ContextCancelled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	err := MouseDownByCoordinate(ctx, 10, 20, "left")
+	err := MouseDownByCoordinate(ctx, 10, 20, "left", 0)
 	if err == nil {
 		t.Fatal("expected error for cancelled context")
 	}
@@ -49,7 +49,7 @@ func TestMouseUpByCoordinate_ContextCancelled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	err := MouseUpByCoordinate(ctx, 10, 20, "left")
+	err := MouseUpByCoordinate(ctx, 10, 20, "left", 0)
 	if err == nil {
 		t.Fatal("expected error for cancelled context")
 	}
@@ -59,7 +59,7 @@ func TestMouseWheelByCoordinate_ContextCancelled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	err := MouseWheelByCoordinate(ctx, 10, 20, 0, 120)
+	err := MouseWheelByCoordinate(ctx, 10, 20, 0, 120, 0)
 	if err == nil {
 		t.Fatal("expected error for cancelled context")
 	}
@@ -90,7 +90,7 @@ func TestDoubleClickByCoordinate_RejectNegativeCoordinates(t *testing.T) {
 func TestCoordinateActions_RejectNegativeCoordinates(t *testing.T) {
 	ctx := context.Background()
 
-	if err := ClickByCoordinate(ctx, -1, 0); err == nil {
+	if err := ClickByCoordinate(ctx, -1, 0, 0); err == nil {
 		t.Fatal("expected click negative coordinate to fail")
 	}
 	if err := HoverByCoordinate(ctx, 0, -1); err == nil {
@@ -99,13 +99,13 @@ func TestCoordinateActions_RejectNegativeCoordinates(t *testing.T) {
 	if err := MouseMoveByCoordinate(ctx, -1, 0); err == nil {
 		t.Fatal("expected mouse move negative coordinate to fail")
 	}
-	if err := MouseDownByCoordinate(ctx, 0, -1, "right"); err == nil {
+	if err := MouseDownByCoordinate(ctx, 0, -1, "right", 0); err == nil {
 		t.Fatal("expected mouse down negative coordinate to fail")
 	}
-	if err := MouseUpByCoordinate(ctx, -1, 0, "middle"); err == nil {
+	if err := MouseUpByCoordinate(ctx, -1, 0, "middle", 0); err == nil {
 		t.Fatal("expected mouse up negative coordinate to fail")
 	}
-	if err := MouseWheelByCoordinate(ctx, 0, -1, 0, 100); err == nil {
+	if err := MouseWheelByCoordinate(ctx, 0, -1, 0, 100, 0); err == nil {
 		t.Fatal("expected mouse wheel negative coordinate to fail")
 	}
 }

--- a/internal/bridge/cdpops/pointer.go
+++ b/internal/bridge/cdpops/pointer.go
@@ -183,7 +183,19 @@ func MouseMoveByCoordinate(ctx context.Context, x, y float64) error {
 	return dispatchMouseMove(ctx, x, y, input.None, 0)
 }
 
-func MouseDownByCoordinate(ctx context.Context, x, y float64, button string) error {
+// Modifiers is the CDP key-modifier bitmask (Alt=1, Ctrl=2, Meta=4, Shift=8)
+// held during a pointer dispatch. Input.dispatchMouseEvent accepts this value
+// verbatim under "modifiers", enabling gestures like Shift+click and
+// Cmd/Ctrl+click. The bits below mirror that encoding for the JS WheelEvent
+// path, which needs booleans instead.
+const (
+	modAlt   = 1
+	modCtrl  = 2
+	modMeta  = 4
+	modShift = 8
+)
+
+func MouseDownByCoordinate(ctx context.Context, x, y float64, button string, modifiers int) error {
 	if err := validatePointerCoordinates(x, y); err != nil {
 		return err
 	}
@@ -191,12 +203,13 @@ func MouseDownByCoordinate(ctx context.Context, x, y float64, button string) err
 		"type":       "mousePressed",
 		"button":     normalizeMouseButton(button),
 		"clickCount": 1,
+		"modifiers":  modifiers,
 		"x":          x,
 		"y":          y,
 	})
 }
 
-func MouseUpByCoordinate(ctx context.Context, x, y float64, button string) error {
+func MouseUpByCoordinate(ctx context.Context, x, y float64, button string, modifiers int) error {
 	if err := validatePointerCoordinates(x, y); err != nil {
 		return err
 	}
@@ -204,12 +217,13 @@ func MouseUpByCoordinate(ctx context.Context, x, y float64, button string) error
 		"type":       "mouseReleased",
 		"button":     normalizeMouseButton(button),
 		"clickCount": 1,
+		"modifiers":  modifiers,
 		"x":          x,
 		"y":          y,
 	})
 }
 
-func MouseWheelByCoordinate(ctx context.Context, x, y float64, deltaX, deltaY int) error {
+func MouseWheelByCoordinate(ctx context.Context, x, y float64, deltaX, deltaY, modifiers int) error {
 	if err := validatePointerCoordinates(x, y); err != nil {
 		return err
 	}
@@ -218,30 +232,34 @@ func MouseWheelByCoordinate(ctx context.Context, x, y float64, deltaX, deltaY in
 	// longer reliably fires `wheel` JS listeners and can stall on the
 	// compositor ack chain. Dispatch a real WheelEvent at the point under
 	// the cursor so listeners run, then scroll the window if no listener
-	// called preventDefault().
+	// called preventDefault(). Held modifiers (Shift for horizontal scroll,
+	// Ctrl for zoom intent) are reflected on the event init.
 	expr := fmt.Sprintf(`(function() {
 		var dx = %d, dy = %d, cx = %f, cy = %f;
 		var target = document.elementFromPoint(cx, cy) || document.documentElement;
 		var ev = new WheelEvent('wheel', {
 			deltaX: dx, deltaY: dy,
 			clientX: cx, clientY: cy,
+			altKey: %t, ctrlKey: %t, metaKey: %t, shiftKey: %t,
 			bubbles: true, cancelable: true
 		});
 		if (target.dispatchEvent(ev)) {
 			window.scrollBy(dx, dy);
 		}
-	})()`, deltaX, deltaY, x, y)
+	})()`, deltaX, deltaY, x, y,
+		modifiers&modAlt != 0, modifiers&modCtrl != 0,
+		modifiers&modMeta != 0, modifiers&modShift != 0)
 	return chromedp.Run(ctx, chromedp.Evaluate(expr, nil))
 }
 
-func ClickByCoordinate(ctx context.Context, x, y float64) error {
+func ClickByCoordinate(ctx context.Context, x, y float64, modifiers int) error {
 	if err := validatePointerCoordinates(x, y); err != nil {
 		return err
 	}
-	if err := MouseDownByCoordinate(ctx, x, y, "left"); err != nil {
+	if err := MouseDownByCoordinate(ctx, x, y, "left", modifiers); err != nil {
 		return err
 	}
-	return MouseUpByCoordinate(ctx, x, y, "left")
+	return MouseUpByCoordinate(ctx, x, y, "left", modifiers)
 }
 
 func ClickByNodeID(ctx context.Context, nodeID int64) error {
@@ -386,8 +404,8 @@ func HoverByCoordinate(ctx context.Context, x, y float64) error {
 	return MouseMoveByCoordinate(ctx, x, y)
 }
 
-func ScrollByCoordinate(ctx context.Context, x, y float64, deltaX, deltaY int) error {
-	return MouseWheelByCoordinate(ctx, x, y, deltaX, deltaY)
+func ScrollByCoordinate(ctx context.Context, x, y float64, deltaX, deltaY, modifiers int) error {
+	return MouseWheelByCoordinate(ctx, x, y, deltaX, deltaY, modifiers)
 }
 
 func HoverByNodeID(ctx context.Context, nodeID int64) error {

--- a/internal/bridge/cdpops_facade.go
+++ b/internal/bridge/cdpops_facade.go
@@ -51,8 +51,8 @@ func PointerPointForNode(ctx context.Context, nodeID int64, requireTopMost bool)
 	return bridgecdpops.PointerPointForNode(ctx, nodeID, requireTopMost)
 }
 
-func ClickByCoordinate(ctx context.Context, x, y float64) error {
-	return bridgecdpops.ClickByCoordinate(ctx, x, y)
+func ClickByCoordinate(ctx context.Context, x, y float64, modifiers int) error {
+	return bridgecdpops.ClickByCoordinate(ctx, x, y, modifiers)
 }
 
 func ClickByNodeID(ctx context.Context, nodeID int64) error {
@@ -91,20 +91,20 @@ func MouseMoveByCoordinate(ctx context.Context, x, y float64) error {
 	return bridgecdpops.MouseMoveByCoordinate(ctx, x, y)
 }
 
-func MouseDownByCoordinate(ctx context.Context, x, y float64, button string) error {
-	return bridgecdpops.MouseDownByCoordinate(ctx, x, y, button)
+func MouseDownByCoordinate(ctx context.Context, x, y float64, button string, modifiers int) error {
+	return bridgecdpops.MouseDownByCoordinate(ctx, x, y, button, modifiers)
 }
 
-func MouseUpByCoordinate(ctx context.Context, x, y float64, button string) error {
-	return bridgecdpops.MouseUpByCoordinate(ctx, x, y, button)
+func MouseUpByCoordinate(ctx context.Context, x, y float64, button string, modifiers int) error {
+	return bridgecdpops.MouseUpByCoordinate(ctx, x, y, button, modifiers)
 }
 
-func MouseWheelByCoordinate(ctx context.Context, x, y float64, deltaX, deltaY int) error {
-	return bridgecdpops.MouseWheelByCoordinate(ctx, x, y, deltaX, deltaY)
+func MouseWheelByCoordinate(ctx context.Context, x, y float64, deltaX, deltaY, modifiers int) error {
+	return bridgecdpops.MouseWheelByCoordinate(ctx, x, y, deltaX, deltaY, modifiers)
 }
 
-func ScrollByCoordinate(ctx context.Context, x, y float64, deltaX, deltaY int) error {
-	return bridgecdpops.ScrollByCoordinate(ctx, x, y, deltaX, deltaY)
+func ScrollByCoordinate(ctx context.Context, x, y float64, deltaX, deltaY, modifiers int) error {
+	return bridgecdpops.ScrollByCoordinate(ctx, x, y, deltaX, deltaY, modifiers)
 }
 
 func HoverByNodeID(ctx context.Context, nodeID int64) error {

--- a/internal/bridge/screencast.go
+++ b/internal/bridge/screencast.go
@@ -30,9 +30,12 @@ func (b *Bridge) StartScreencast(ctx context.Context, opts ScreencastOpts) (*Scr
 }
 
 func (b *Bridge) shouldUsePollingScreencast() bool {
-	if b.Config != nil && b.Config.Headless {
-		return true
-	}
+	// Headless is NOT a reason to poll: new-headless ("--headless=new") supports
+	// event-driven Page.startScreencast, and the event-driven path starts a
+	// repaint loop that forces the compositor to keep painting so frames flow even
+	// without a foreground window. Event-driven is far more responsive than polling
+	// CaptureScreenshot per frame, which matters for interactive dashboard control.
+	// Polling remains only for providers whose CDP proxy lacks startScreencast.
 	if b.Config != nil {
 		browserID := config.NormalizeBrowser(b.Config.DefaultBrowser)
 		if browser, ok := browsers.Get(browserID); ok {
@@ -180,17 +183,33 @@ func (b *Bridge) startScreencastPolling(ctx context.Context, opts ScreencastOpts
 		ticker := time.NewTicker(frameInterval)
 		defer ticker.Stop()
 
-		var frames int
+		// A single capture failure is usually transient — the target is briefly busy
+		// navigating, painting, or handling a click. Aborting the stream on the first
+		// error drops the dashboard into a "connection lost" overlay mid-interaction.
+		// Skip the bad frame and keep streaming; only give up after many consecutive
+		// failures (or context cancellation), which indicates the target is really gone.
+		const maxConsecutiveErrors = 30
+		var frames, consecutiveErrors int
 		for {
 			select {
 			case <-ticker.C:
 				t1 := time.Now()
 				frame, err := capture(ctx)
 				if err != nil {
-					slog.Warn("screencast polling: CaptureScreenshot failed",
-						"err", err, "frame", frames, "elapsed", time.Since(t1))
-					return
+					if ctx.Err() != nil {
+						return // tab/context gone — stop cleanly
+					}
+					consecutiveErrors++
+					slog.Debug("screencast polling: capture failed, skipping frame",
+						"err", err, "consecutive", consecutiveErrors, "elapsed", time.Since(t1))
+					if consecutiveErrors >= maxConsecutiveErrors {
+						slog.Warn("screencast polling: too many consecutive capture failures, stopping",
+							"consecutive", consecutiveErrors)
+						return
+					}
+					continue
 				}
+				consecutiveErrors = 0
 				frames++
 				if frames <= 3 || frames%30 == 0 {
 					slog.Debug("screencast polling: frame captured",

--- a/internal/bridge/screencast.go
+++ b/internal/bridge/screencast.go
@@ -30,12 +30,14 @@ func (b *Bridge) StartScreencast(ctx context.Context, opts ScreencastOpts) (*Scr
 }
 
 func (b *Bridge) shouldUsePollingScreencast() bool {
-	// Headless is NOT a reason to poll: new-headless ("--headless=new") supports
-	// event-driven Page.startScreencast, and the event-driven path starts a
-	// repaint loop that forces the compositor to keep painting so frames flow even
-	// without a foreground window. Event-driven is far more responsive than polling
-	// CaptureScreenshot per frame, which matters for interactive dashboard control.
-	// Polling remains only for providers whose CDP proxy lacks startScreencast.
+	// Headless uses polling: headless Page.startScreencast does not reliably emit
+	// frames (no foreground compositor), so the polling CaptureScreenshot loop is
+	// the dependable path — and since each capture is the cost ceiling regardless,
+	// event-driven buys no throughput here. Polling is also used for providers whose
+	// CDP proxy lacks startScreencast (e.g. Cloak).
+	if b.Config != nil && b.Config.Headless {
+		return true
+	}
 	if b.Config != nil {
 		browserID := config.NormalizeBrowser(b.Config.DefaultBrowser)
 		if browser, ok := browsers.Get(browserID); ok {

--- a/internal/handlers/screencast.go
+++ b/internal/handlers/screencast.go
@@ -40,7 +40,11 @@ func (h *Handlers) HandleScreencast(w http.ResponseWriter, r *http.Request) {
 
 	quality := queryParamInt(r, "quality", 30)
 	maxWidth := queryParamInt(r, "maxWidth", 800)
-	everyNth := queryParamInt(r, "everyNthFrame", 4)
+	// everyNthFrame=1 sends every compositor frame; the requested fps still throttles
+	// the rate. A higher skip (the old default of 4) caps the live tab well below the
+	// requested fps and makes interactive control feel unresponsive (issue: dashboard
+	// Live tab too laggy to type into).
+	everyNth := queryParamInt(r, "everyNthFrame", 1)
 	fps := queryParamInt(r, "fps", 1)
 	if fps > 30 {
 		fps = 30

--- a/tests/e2e/fixtures/key-modifiers.html
+++ b/tests/e2e/fixtures/key-modifiers.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>E2E Test - Key Modifiers</title>
+  <style>
+    body { font-family: sans-serif; margin: 0; padding: 32px; line-height: 1.4; }
+    #typed { font-size: 24px; width: 600px; padding: 8px; }
+    #state-json { margin-top: 20px; padding: 12px; border-radius: 10px;
+                  background: #111827; color: #d1fae5; white-space: pre-wrap; max-width: 720px; }
+  </style>
+</head>
+<body>
+  <h1>Key Modifiers Fixture</h1>
+  <p>Verifies modifier keys are forwarded as keydown/keyup events and never typed
+     as literal text (issue #588).</p>
+
+  <input id="typed" type="text" placeholder="click me, then press keys">
+  <p style="font-size:22px">Field value: <b id="mirror" style="color:#b91c1c">(empty)</b></p>
+  <div id="state-json">[]</div>
+
+  <script>
+    // keyState records each key event as "down:<key>" / "up:<key>" so a test can
+    // assert modifiers ARE forwarded as key events. The #typed value proves they
+    // are NOT inserted as text.
+    window.keyState = [];
+    const input = document.getElementById('typed');
+    const out = document.getElementById('state-json');
+    const mirror = document.getElementById('mirror');
+    const record = (prefix) => (e) => {
+      window.keyState.push(prefix + ':' + e.key);
+      out.textContent = JSON.stringify(window.keyState);
+    };
+    document.addEventListener('keydown', record('down'));
+    document.addEventListener('keyup', record('up'));
+    input.addEventListener('input', () => {
+      mirror.textContent = input.value === '' ? '(empty)' : input.value;
+    });
+  </script>
+</body>
+</html>

--- a/tests/e2e/fixtures/screencast-click-targets.html
+++ b/tests/e2e/fixtures/screencast-click-targets.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>E2E Test - Screencast Click Targets</title>
+  <style>
+    html, body { margin: 0; padding: 0; height: 100%; width: 100%;
+                 font-family: sans-serif; background: #fafafa; overflow: hidden; }
+    .t { position: absolute; width: 120px; height: 56px; box-sizing: border-box;
+         border: 2px solid #2d6cdf; border-radius: 8px; background: #e8f0fe;
+         color: #17315f; display: flex; align-items: center; justify-content: center;
+         font-size: 16px; font-weight: 700; cursor: pointer; user-select: none; }
+    /* Targets spread across corners, edges, and centre. Right/bottom anchored
+       ones adapt to the viewport; the test reads each rect at runtime. */
+    #tl { top: 16px;  left: 16px; }
+    #tr { top: 16px;  right: 16px; }
+    #ml { top: 45%;   left: 16px; }
+    #c  { top: 45%;   left: 50%; transform: translateX(-50%); }
+    #mr { top: 45%;   right: 16px; }
+    #bl { bottom: 16px; left: 16px; }
+    #br { bottom: 16px; right: 16px; }
+    #inp { position: absolute; top: 72%; left: 50%; transform: translateX(-50%);
+           width: 240px; height: 48px; font-size: 18px; box-sizing: border-box; }
+    #status { position: absolute; top: 8px; left: 50%; transform: translateX(-50%);
+              font-size: 14px; color: #555; }
+  </style>
+</head>
+<body>
+  <button class="t" id="tl">TL</button>
+  <button class="t" id="tr">TR</button>
+  <button class="t" id="ml">ML</button>
+  <button class="t" id="c">C</button>
+  <button class="t" id="mr">MR</button>
+  <button class="t" id="bl">BL</button>
+  <button class="t" id="br">BR</button>
+  <input class="t" id="inp" placeholder="type here">
+  <div id="status">no click yet</div>
+
+  <script>
+    // Records which element a (coordinate-mapped) click actually landed on, so an
+    // e2e can verify the dashboard's frame-pixel → CSS-viewport scaling lands
+    // clicks on the intended target across different frame scales and positions.
+    window.__lastClick = "";
+    window.__lastFocus = "";
+    const status = document.getElementById("status");
+    document.querySelectorAll(".t").forEach((el) => {
+      el.addEventListener("click", () => {
+        window.__lastClick = el.id;
+        status.textContent = "clicked " + el.id;
+      });
+      el.addEventListener("focus", () => { window.__lastFocus = el.id; });
+    });
+  </script>
+</body>
+</html>

--- a/tests/e2e/scenarios/api/screencast-input-basic.sh
+++ b/tests/e2e/scenarios/api/screencast-input-basic.sh
@@ -104,6 +104,18 @@ else
   fail_assert "2x-frame click left focus on '${ACTIVE}', want 'inp'"
 fi
 
+# Close the loop: the click focused the field, so typing (as the dashboard sends
+# it — insertText for printable chars) must land in that field. This is the exact
+# end-to-end path that was broken when clicks missed their target.
+TYPED_BODY=$(jq -nc --arg t "$SC_TAB_ID" '{kind:"keyboard-inserttext", tabId:$t, text:"Hello"}')
+pt_post /action "$TYPED_BODY" >/dev/null
+VAL=$(sc_eval 'document.getElementById("inp").value')
+if [ "$VAL" = "Hello" ]; then
+  pass_assert "typing after a scaled click lands in the focused input"
+else
+  fail_assert "typed text landed as '${VAL}', want 'Hello'"
+fi
+
 end_test
 
 # ─────────────────────────────────────────────────────────────────

--- a/tests/e2e/scenarios/api/screencast-input-basic.sh
+++ b/tests/e2e/scenarios/api/screencast-input-basic.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+# screencast-input.sh — API scenarios for dashboard screencast input mapping.
+#
+# The dashboard maps a click on the screencast canvas to FRAME-pixel coordinates
+# and sends them with the frame dimensions (frameW/frameH). The server must scale
+# those into the live CSS viewport so the click lands on the intended element,
+# regardless of the frame's pixel scale (HiDPI frames are 2x+ the CSS viewport).
+# These tests exercise that mapping across multiple frame scales and target
+# positions, so it stays correct on every browser provider the suite runs against.
+
+GROUP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${GROUP_DIR}/../../helpers/api.sh"
+
+SC_TAB_ID=""
+
+sc_navigate() {
+  local url="$1"
+  local body
+  if [ -n "$SC_TAB_ID" ]; then
+    body=$(jq -nc --arg url "$url" --arg tabId "$SC_TAB_ID" '{url:$url, tabId:$tabId}')
+  else
+    body=$(jq -nc --arg url "$url" '{url:$url}')
+  fi
+  pt_post /navigate -d "$body"
+  assert_ok "navigate"
+  local tab_id
+  tab_id=$(echo "$RESULT" | jq -r '.tabId // empty')
+  [ -n "$tab_id" ] && [ "$tab_id" != "null" ] && SC_TAB_ID="$tab_id"
+}
+
+# sc_eval <expression> → echoes the evaluated .result value
+sc_eval() {
+  local body
+  body=$(jq -nc --arg tabId "$SC_TAB_ID" --arg expression "$1" '{tabId:$tabId, expression:$expression}')
+  pt_post /evaluate "$body" >/dev/null
+  echo "$RESULT" | jq -r '.result // empty'
+}
+
+# sc_click_frame <x> <y> [frameW] [frameH] — click in frame-pixel space
+sc_click_frame() {
+  local x="$1" y="$2" fw="${3:-}" fh="${4:-}"
+  local body
+  if [ -n "$fw" ]; then
+    body=$(jq -nc --arg t "$SC_TAB_ID" --argjson x "$x" --argjson y "$y" --argjson fw "$fw" --argjson fh "$fh" \
+      '{kind:"click", tabId:$t, x:$x, y:$y, hasXY:true, frameW:$fw, frameH:$fh}')
+  else
+    body=$(jq -nc --arg t "$SC_TAB_ID" --argjson x "$x" --argjson y "$y" \
+      '{kind:"click", tabId:$t, x:$x, y:$y, hasXY:true}')
+  fi
+  pt_post /action "$body" >/dev/null
+}
+
+# ─────────────────────────────────────────────────────────────────
+start_test "screencast click mapping: every target at every frame scale"
+
+sc_navigate "${FIXTURES_URL}/screencast-click-targets.html"
+
+VP=$(sc_eval 'JSON.stringify([Math.round(window.innerWidth), Math.round(window.innerHeight)])')
+CSSW=$(echo "$VP" | jq -r '.[0]')
+CSSH=$(echo "$VP" | jq -r '.[1]')
+echo "    css viewport: ${CSSW}x${CSSH}"
+
+# Frame scales to simulate: 1x (no scaling), and HiDPI/odd ratios.
+SCALES="1 1.5 2 3"
+TARGETS="tl tr ml c mr bl br"
+
+for id in $TARGETS; do
+  CENTER=$(sc_eval "var r=document.getElementById('${id}').getBoundingClientRect(); JSON.stringify([Math.round(r.left+r.width/2), Math.round(r.top+r.height/2)])")
+  CX=$(echo "$CENTER" | jq -r '.[0]')
+  CY=$(echo "$CENTER" | jq -r '.[1]')
+  for s in $SCALES; do
+    read -r FX FY FW FH < <(python3 -c "cx,cy,cw,ch,s=$CX,$CY,$CSSW,$CSSH,$s; print(round(cx*s), round(cy*s), round(cw*s), round(ch*s))")
+    sc_eval 'window.__lastClick=""; "ok"' >/dev/null
+    sc_click_frame "$FX" "$FY" "$FW" "$FH"
+    GOT=$(sc_eval 'window.__lastClick')
+    if [ "$GOT" = "$id" ]; then
+      pass_assert "scale ${s}x → click frame(${FX},${FY}) landed on '${id}'"
+    else
+      fail_assert "scale ${s}x → click frame(${FX},${FY}) landed on '${GOT}', want '${id}'"
+    fi
+  done
+done
+
+end_test
+
+# ─────────────────────────────────────────────────────────────────
+start_test "screencast click focuses an input field (HiDPI frame)"
+
+sc_navigate "${FIXTURES_URL}/screencast-click-targets.html"
+CSSW=$(sc_eval 'Math.round(window.innerWidth)')
+CSSH=$(sc_eval 'Math.round(window.innerHeight)')
+CENTER=$(sc_eval "var r=document.getElementById('inp').getBoundingClientRect(); JSON.stringify([Math.round(r.left+r.width/2), Math.round(r.top+r.height/2)])")
+CX=$(echo "$CENTER" | jq -r '.[0]')
+CY=$(echo "$CENTER" | jq -r '.[1]')
+
+# Simulate a 2x HiDPI frame.
+read -r FX FY FW FH < <(python3 -c "cx,cy,cw,ch=$CX,$CY,$CSSW,$CSSH; print(cx*2, cy*2, cw*2, ch*2)")
+sc_eval 'document.getElementById("inp").blur(); "ok"' >/dev/null
+sc_click_frame "$FX" "$FY" "$FW" "$FH"
+ACTIVE=$(sc_eval 'document.activeElement.id')
+if [ "$ACTIVE" = "inp" ]; then
+  pass_assert "2x-frame click focused the input"
+else
+  fail_assert "2x-frame click left focus on '${ACTIVE}', want 'inp'"
+fi
+
+end_test
+
+# ─────────────────────────────────────────────────────────────────
+start_test "screencast click without frameW treats coords as CSS pixels"
+
+sc_navigate "${FIXTURES_URL}/screencast-click-targets.html"
+CENTER=$(sc_eval "var r=document.getElementById('c').getBoundingClientRect(); JSON.stringify([Math.round(r.left+r.width/2), Math.round(r.top+r.height/2)])")
+CX=$(echo "$CENTER" | jq -r '.[0]')
+CY=$(echo "$CENTER" | jq -r '.[1]')
+sc_eval 'window.__lastClick=""; "ok"' >/dev/null
+sc_click_frame "$CX" "$CY"   # no frameW/frameH → coords are already CSS px
+GOT=$(sc_eval 'window.__lastClick')
+if [ "$GOT" = "c" ]; then
+  pass_assert "CSS-pixel click (no frameW) landed on centre target"
+else
+  fail_assert "CSS-pixel click landed on '${GOT}', want 'c'"
+fi
+
+end_test

--- a/tests/e2e/scenarios/api/screencast-input-basic.sh
+++ b/tests/e2e/scenarios/api/screencast-input-basic.sh
@@ -50,6 +50,15 @@ sc_click_frame() {
   pt_post /action "$body" >/dev/null
 }
 
+# sc_press <key> <modifiers> — press a key with a CDP modifier bitmask
+# (Alt=1, Ctrl=2, Meta=4, Shift=8), as the dashboard sends keyboard chords.
+sc_press() {
+  local body
+  body=$(jq -nc --arg t "$SC_TAB_ID" --arg key "$1" --argjson mods "$2" \
+    '{kind:"press", tabId:$t, key:$key, modifiers:$mods}')
+  pt_post /action "$body" >/dev/null
+}
+
 # ─────────────────────────────────────────────────────────────────
 start_test "screencast click mapping: every target at every frame scale"
 
@@ -132,6 +141,36 @@ if [ "$GOT" = "c" ]; then
   pass_assert "CSS-pixel click (no frameW) landed on centre target"
 else
   fail_assert "CSS-pixel click landed on '${GOT}', want 'c'"
+fi
+
+end_test
+
+# ─────────────────────────────────────────────────────────────────
+start_test "screencast keyboard chords (Ctrl+A, Shift+End) reach the page"
+
+sc_navigate "${FIXTURES_URL}/screencast-click-targets.html"
+# Put known text in the input and focus it with the caret mid-string.
+sc_eval 'var b=document.getElementById("inp"); b.value="hello world"; b.focus(); b.setSelectionRange(3,3); "ok"' >/dev/null
+
+# Ctrl+A (modifiers=2) → select the whole field.
+sc_press "a" 2
+SEL_START=$(sc_eval 'document.getElementById("inp").selectionStart')
+SEL_END=$(sc_eval 'document.getElementById("inp").selectionEnd')
+if [ "$SEL_START" = "0" ] && [ "$SEL_END" = "11" ]; then
+  pass_assert "Ctrl+A selected the whole field (0..11)"
+else
+  fail_assert "Ctrl+A selection was ${SEL_START}..${SEL_END}, want 0..11"
+fi
+
+# Shift+End (modifiers=8) from the start → extend selection to the end.
+sc_eval 'document.getElementById("inp").setSelectionRange(0,0); "ok"' >/dev/null
+sc_press "End" 8
+SEL_START=$(sc_eval 'document.getElementById("inp").selectionStart')
+SEL_END=$(sc_eval 'document.getElementById("inp").selectionEnd')
+if [ "$SEL_START" = "0" ] && [ "$SEL_END" = "11" ]; then
+  pass_assert "Shift+End extended the selection (0..11)"
+else
+  fail_assert "Shift+End selection was ${SEL_START}..${SEL_END}, want 0..11"
 fi
 
 end_test

--- a/tests/e2e/scenarios/api/screencast-input-basic.sh
+++ b/tests/e2e/scenarios/api/screencast-input-basic.sh
@@ -78,7 +78,8 @@ for id in $TARGETS; do
   CX=$(echo "$CENTER" | jq -r '.[0]')
   CY=$(echo "$CENTER" | jq -r '.[1]')
   for s in $SCALES; do
-    read -r FX FY FW FH < <(python3 -c "cx,cy,cw,ch,s=$CX,$CY,$CSSW,$CSSH,$s; print(round(cx*s), round(cy*s), round(cw*s), round(ch*s))")
+    read -r FX FY FW FH < <(awk -v cx="$CX" -v cy="$CY" -v cw="$CSSW" -v ch="$CSSH" -v s="$s" \
+      'BEGIN{printf "%.0f %.0f %.0f %.0f", cx*s, cy*s, cw*s, ch*s}')
     sc_eval 'window.__lastClick=""; "ok"' >/dev/null
     sc_click_frame "$FX" "$FY" "$FW" "$FH"
     GOT=$(sc_eval 'window.__lastClick')
@@ -103,7 +104,8 @@ CX=$(echo "$CENTER" | jq -r '.[0]')
 CY=$(echo "$CENTER" | jq -r '.[1]')
 
 # Simulate a 2x HiDPI frame.
-read -r FX FY FW FH < <(python3 -c "cx,cy,cw,ch=$CX,$CY,$CSSW,$CSSH; print(cx*2, cy*2, cw*2, ch*2)")
+read -r FX FY FW FH < <(awk -v cx="$CX" -v cy="$CY" -v cw="$CSSW" -v ch="$CSSH" \
+  'BEGIN{printf "%.0f %.0f %.0f %.0f", cx*2, cy*2, cw*2, ch*2}')
 sc_eval 'document.getElementById("inp").blur(); "ok"' >/dev/null
 sc_click_frame "$FX" "$FY" "$FW" "$FH"
 ACTIVE=$(sc_eval 'document.activeElement.id')

--- a/tests/e2e/scenarios/cli/actions-extended.sh
+++ b/tests/e2e/scenarios/cli/actions-extended.sh
@@ -161,6 +161,43 @@ assert_output_contains "OK" "keyup response"
 end_test
 
 # ─────────────────────────────────────────────────────────────────
+start_test "pinchtab press modifier keys are not typed as text (issue #588)"
+
+pt_ok nav "${FIXTURES_URL}/key-modifiers.html"
+pt_ok click --css "#typed"
+
+# Reset the input and the recorded key log.
+pt_ok eval "document.querySelector('#typed').value=''; window.keyState=[]; 'reset'"
+
+# Press each modifier. Before the fix these fell through to chromedp.KeyEvent and
+# the literal name (e.g. "Shift") was typed into the focused input.
+pt_ok press Shift
+pt_ok press Control
+pt_ok press Alt
+pt_ok press Meta
+
+# The focused input must remain empty — no modifier name was inserted as text.
+pt_ok eval "document.querySelector('#typed').value"
+assert_output_not_contains "Shift" "Shift must not be typed as text"
+assert_output_not_contains "Control" "Control must not be typed as text"
+assert_output_not_contains "Alt" "Alt must not be typed as text"
+assert_output_not_contains "Meta" "Meta must not be typed as text"
+
+# …but the modifiers ARE forwarded as real keydown/keyup events (issue #588 expected).
+pt_ok eval "JSON.stringify(window.keyState)"
+assert_output_contains "down:Shift" "Shift forwarded as keydown"
+assert_output_contains "up:Shift" "Shift forwarded as keyup"
+assert_output_contains "down:Control" "Control forwarded as keydown"
+
+# Control: a printable key still types into the input.
+pt_ok eval "document.querySelector('#typed').value=''; 'reset'"
+pt_ok press a
+pt_ok eval "document.querySelector('#typed').value"
+assert_output_contains "a" "printable key still types after the modifier fix"
+
+end_test
+
+# ─────────────────────────────────────────────────────────────────
 start_test "pinchtab keyboard type <text>"
 
 pt_ok nav "${FIXTURES_URL}/form.html"

--- a/tests/e2e/scenarios/manifest.json
+++ b/tests/e2e/scenarios/manifest.json
@@ -25,6 +25,9 @@
     "api/auto-switch-smoke.sh": {
       "tags": ["tabs", "actions", "auto-switch", "smoke"]
     },
+    "api/screencast-input-basic.sh": {
+      "tags": ["actions", "screencast", "input", "coordinates", "multi-browser", "pr"]
+    },
     "api/network-route-extended.sh": {
       "services": ["pinchtab", "pinchtab-full", "fixtures"],
       "ready": ["E2E_SERVER", "E2E_FULL_SERVER"],


### PR DESCRIPTION
Fixes #588.

Supersedes #597.

## What changed
- scale screencast click coordinates into the live CSS viewport
- raise live-tab screencast responsiveness and reconnect resilience
- forward modifier bitmasks through click and wheel input so Shift/Cmd/Ctrl gestures reach the page
- reset the reconnect budget on manual retry
- add focused bridge and dashboard tests for the new input and reconnect behavior

## Validation
- ./dev check dashboard
- go test ./internal/bridge
- go test ./...
- bun run test:run src/components/screencast/ScreencastTile.test.tsx src/components/screencast/useScreencastInput.test.ts