### PR TITLE
fix: build stock pinchtab image for keep-stock services in cloak e2e lane

### DIFF
--- a/tests/tools/runner/internal/e2e/e2e_test.go
+++ b/tests/tools/runner/internal/e2e/e2e_test.go
@@ -620,6 +620,36 @@ func TestBringUpSharedStackCloakBuildsSupportImagesOnly(t *testing.T) {
 	}
 }
 
+func TestBringUpSharedStackCloakBuildsStockImageForGhostChrome(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	r := &Runner{
+		args:     Args{DryRun: true},
+		stdout:   &stdout,
+		stderr:   &stderr,
+		compose:  []string{"docker", "compose"},
+		logsMode: "hide",
+		overrides: &providerOverrides{
+			provider:     "cloak",
+			image:        defaultCloakImage,
+			composeFiles: []string{"/tmp/docker-compose.cloak.yml"},
+		},
+	}
+
+	// pinchtab-ghostchrome is keepStockProvider: it stays on e2e-pinchtab:latest
+	// even under cloak, so the stock pinchtab image must be built or the
+	// `up --no-build` fails with "No such image: e2e-pinchtab:latest".
+	services := []string{"pinchtab", "pinchtab-ghostchrome", "fixtures"}
+	if code := r.bringUpSharedStack("compose.yml", services); code != 0 {
+		t.Fatalf("bringUpSharedStack returned %d, stderr: %s", code, stderr.String())
+	}
+
+	out := stdout.String()
+	want := "docker compose -f compose.yml -f /tmp/docker-compose.cloak.yml build fixtures runner-api runner-cli pinchtab"
+	if !strings.Contains(out, want) {
+		t.Fatalf("cloak build must include stock pinchtab when ghostchrome is present, missing %q:\n%s", want, out)
+	}
+}
+
 func TestDryRunCloakProviderDoesNotRequireImage(t *testing.T) {
 	t.Setenv("E2E_LOGS", "")
 	var stdout, stderr bytes.Buffer

--- a/tests/tools/runner/internal/e2e/runner.go
+++ b/tests/tools/runner/internal/e2e/runner.go
@@ -615,7 +615,15 @@ func (r *Runner) bringUpSharedStack(composeFile string, services []string) int {
 	// rebuilding the overridden pinchtab services.
 	skipPinchtabBuild := r.overrides != nil && r.overrides.provider == "cloak"
 	if skipPinchtabBuild {
-		if code := r.buildSharedStack(composeFile, cloakSupportBuildServices()...); code != 0 {
+		buildServices := cloakSupportBuildServices()
+		// keepStockProvider services (e.g. pinchtab-ghostchrome) stay pinned to
+		// the stock e2e-pinchtab:latest image even in the cloak lane. If the
+		// suite brings any of them up, that image must exist or `up --no-build`
+		// fails with "No such image", so build the stock pinchtab service too.
+		if needsStockPinchtabImage(services) {
+			buildServices = append(buildServices, "pinchtab")
+		}
+		if code := r.buildSharedStack(composeFile, buildServices...); code != 0 {
 			return code
 		}
 	} else {
@@ -654,6 +662,20 @@ func (r *Runner) buildSharedStack(composeFile string, services ...string) int {
 
 func cloakSupportBuildServices() []string {
 	return []string{"fixtures", "runner-api", "runner-cli"}
+}
+
+// needsStockPinchtabImage reports whether any service being brought up is a
+// keepStockProvider service that stays pinned to e2e-pinchtab:latest. Such
+// services require the stock pinchtab image even in the cloak lane.
+func needsStockPinchtabImage(services []string) bool {
+	for _, svc := range services {
+		for _, def := range pinchtabServiceTable {
+			if def.name == svc && def.keepStockProvider {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func (r *Runner) stackOutputHasBuildKitCacheFailure() bool {


### PR DESCRIPTION
## Summary
- build the stock `pinchtab` image before cloak runs when a selected service keeps the stock provider image, such as `pinchtab-ghostchrome`
- keep the existing cloak support-image-only build path for scenarios that do not need the stock image
- add dry-run coverage for both cloak build paths

## Testing
- `go test ./tests/tools/runner/internal/e2e -run 'TestBringUpSharedStackCloakBuildsSupportImagesOnly|TestBringUpSharedStackCloakBuildsStockImageForGhostChrome|TestDryRunCloakProviderDoesNotRequireImage'`
