### PR TITLE
fix: build stock e2e image outside cloak override

### DIFF
--- a/tests/tools/runner/internal/e2e/e2e_test.go
+++ b/tests/tools/runner/internal/e2e/e2e_test.go
@@ -644,9 +644,18 @@ func TestBringUpSharedStackCloakBuildsStockImageForGhostChrome(t *testing.T) {
 	}
 
 	out := stdout.String()
-	want := "docker compose -f compose.yml -f /tmp/docker-compose.cloak.yml build fixtures runner-api runner-cli pinchtab"
-	if !strings.Contains(out, want) {
-		t.Fatalf("cloak build must include stock pinchtab when ghostchrome is present, missing %q:\n%s", want, out)
+	for _, want := range []string{
+		"docker compose -f compose.yml build pinchtab",
+		"docker compose -f compose.yml -f /tmp/docker-compose.cloak.yml build fixtures runner-api runner-cli",
+		"docker compose -f compose.yml -f /tmp/docker-compose.cloak.yml up -d --no-build --force-recreate pinchtab pinchtab-ghostchrome fixtures",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("cloak ghostchrome flow missing %q:\n%s", want, out)
+		}
+	}
+	bad := "docker compose -f compose.yml -f /tmp/docker-compose.cloak.yml build fixtures runner-api runner-cli pinchtab"
+	if strings.Contains(out, bad) {
+		t.Fatalf("stock pinchtab image must be built without cloak override:\n%s", out)
 	}
 }
 

--- a/tests/tools/runner/internal/e2e/runner.go
+++ b/tests/tools/runner/internal/e2e/runner.go
@@ -615,15 +615,17 @@ func (r *Runner) bringUpSharedStack(composeFile string, services []string) int {
 	// rebuilding the overridden pinchtab services.
 	skipPinchtabBuild := r.overrides != nil && r.overrides.provider == "cloak"
 	if skipPinchtabBuild {
-		buildServices := cloakSupportBuildServices()
 		// keepStockProvider services (e.g. pinchtab-ghostchrome) stay pinned to
 		// the stock e2e-pinchtab:latest image even in the cloak lane. If the
 		// suite brings any of them up, that image must exist or `up --no-build`
-		// fails with "No such image", so build the stock pinchtab service too.
+		// fails with "No such image". Build that stock image via the base compose
+		// only so the cloak override cannot retag it to the provider image.
 		if needsStockPinchtabImage(services) {
-			buildServices = append(buildServices, "pinchtab")
+			if code := r.buildSharedStackWithOverrides(composeFile, false, "pinchtab"); code != 0 {
+				return code
+			}
 		}
-		if code := r.buildSharedStack(composeFile, buildServices...); code != 0 {
+		if code := r.buildSharedStack(composeFile, cloakSupportBuildServices()...); code != 0 {
 			return code
 		}
 	} else {
@@ -647,8 +649,12 @@ func (r *Runner) bringUpSharedStack(composeFile string, services []string) int {
 }
 
 func (r *Runner) buildSharedStack(composeFile string, services ...string) int {
+	return r.buildSharedStackWithOverrides(composeFile, true, services...)
+}
+
+func (r *Runner) buildSharedStackWithOverrides(composeFile string, includeOverrides bool, services ...string) int {
 	args := append([]string{"build"}, services...)
-	code := r.runLoggedCommand("building shared-stack images", stackOutput, r.composeArgs(composeFile, args...))
+	code := r.runLoggedCommand("building shared-stack images", stackOutput, r.composeArgsWithOverrides(composeFile, includeOverrides, args...))
 	if code == 0 {
 		return 0
 	}
@@ -657,7 +663,7 @@ func (r *Runner) buildSharedStack(composeFile string, services ...string) int {
 	}
 	_, _ = fmt.Fprintln(r.stdout, "  build cache looked stale; retrying shared-stack build with --no-cache...")
 	retryArgs := append([]string{"build", "--no-cache"}, services...)
-	return r.runLoggedCommand("rebuilding shared-stack images without cache", stackOutput, r.composeArgs(composeFile, retryArgs...))
+	return r.runLoggedCommand("rebuilding shared-stack images without cache", stackOutput, r.composeArgsWithOverrides(composeFile, includeOverrides, retryArgs...))
 }
 
 func cloakSupportBuildServices() []string {
@@ -751,9 +757,13 @@ func suiteReportTitle(def suiteDef) string {
 }
 
 func (r *Runner) composeArgs(composeFile string, args ...string) []string {
+	return r.composeArgsWithOverrides(composeFile, true, args...)
+}
+
+func (r *Runner) composeArgsWithOverrides(composeFile string, includeOverrides bool, args ...string) []string {
 	out := append([]string{}, r.compose...)
 	out = append(out, "-f", composeFile)
-	if r.overrides != nil {
+	if includeOverrides && r.overrides != nil {
 		for _, override := range r.overrides.composeFiles {
 			out = append(out, "-f", override)
 		}


### PR DESCRIPTION
## Summary
- build the stock `e2e-pinchtab:latest` image from the base compose file when the cloak lane needs a keep-stock service such as `pinchtab-ghostchrome`
- keep the cloak override limited to the cloak support-image build and the later `up --no-build` path
- tighten the dry-run regression test so it proves the stock image is built without the cloak override

## Context
This follows up `#599`.

That change correctly detected when the cloak lane needed the stock image, but it still built `pinchtab` with the cloak override active. That meant the service was built under the override image path instead of materializing the `e2e-pinchtab:latest` tag that `pinchtab-ghostchrome` expects.

## Testing
- `go test ./tests/tools/runner/internal/e2e -run 'TestBuildSharedStackRetriesWithoutCacheOnBuildKitSnapshotFailure|TestBuildSharedStackDoesNotRetryNonCacheFailure|TestBringUpSharedStackCloakBuildsSupportImagesOnly|TestBringUpSharedStackCloakBuildsStockImageForGhostChrome|TestDryRunCloakProviderDoesNotRequireImage'`
- `go test ./tests/tools/runner/...`
