### PR TITLE
fix: improve browser discovery and recovery UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,8 @@ PinchTab's primary tested operator workflow is local macOS and Linux.
 
 Windows binaries are published, but Windows support is currently limited and best-effort because the project does not have the same level of automated and manual coverage there. On Windows, prefer running `pinchtab server` or `pinchtab bridge` directly instead of relying on the daemon workflow.
 
+On **macOS**, prefer a dedicated automation browser (Google Chrome for Testing or Chromium) over your daily Google Chrome. Driving your primary Chrome headless can prevent it from opening a normal window while PinchTab is running. PinchTab now prefers a dedicated browser automatically, and `pinchtab doctor browsers` warns if automation would fall back to your primary Chrome — install Chrome for Testing or set `browser.binary` to a separate build. See [docs/reference/config.md](docs/reference/config.md).
+
 ### Shell Completion
 
 Generate and install shell completions after `pinchtab` is on your `PATH`:

--- a/cmd/pinchtab/cmd_cli_runtime.go
+++ b/cmd/pinchtab/cmd_cli_runtime.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/pinchtab/pinchtab/internal/activity"
+	"github.com/pinchtab/pinchtab/internal/browsers"
+	"github.com/pinchtab/pinchtab/internal/browsers/runtimekit"
 	"github.com/pinchtab/pinchtab/internal/cli/output"
 	"github.com/pinchtab/pinchtab/internal/config"
 	"github.com/spf13/cobra"
@@ -33,11 +35,49 @@ func runCLIEnsuringServer(command string, fn func(cliRuntime)) {
 
 func runCLIWithServerCheck(cfg *config.RuntimeConfig, command string, fn func(cliRuntime)) {
 	rt := newCLIRuntime(cfg)
+	// Only preflight when this command would auto-start the local server. For a
+	// remote --server the browser lives on that host, so local discovery is moot.
+	if canAutoStartServerForCLI(cfg, rt.base) {
+		if err := preflightBrowserBinary(cfg); err != nil {
+			fmt.Fprintf(os.Stderr, "pinchtab: %v\n", err)
+			os.Exit(1)
+		}
+	}
 	if err := ensureServerForCLI(cfg, rt.base, rt.token, command); err != nil {
 		fmt.Fprintf(os.Stderr, "pinchtab: %v\n", err)
 		os.Exit(1)
 	}
 	fn(rt)
+}
+
+// preflightBrowserBinary fails fast with an actionable message when the active
+// provider has no usable browser, instead of letting the launch silently retry
+// and surface only the bridge's generic "instance not ready after 10s" timeout.
+// It mirrors the launch-time resolution in bridge/runtime.InitBrowser (explicit
+// browser.binary wins over discovery) so it can't diverge from what actually runs.
+func preflightBrowserBinary(cfg *config.RuntimeConfig) error {
+	if cfg == nil || strings.TrimSpace(cfg.CDPAttachURL) != "" {
+		return nil // attaching to an external CDP endpoint; no local binary needed
+	}
+	browserID := config.NormalizeBrowser(cfg.DefaultBrowser)
+	if _, ok := browsers.Get(browserID); !ok {
+		return nil // unknown provider — let the normal path report it
+	}
+	if override := strings.TrimSpace(cfg.BrowserBinary); override != "" {
+		if info, err := os.Stat(override); err != nil || info.IsDir() {
+			return fmt.Errorf("configured browser.binary does not point at a usable executable: %s\n"+
+				"       Point it at an existing browser binary, or unset it to use auto-discovery. "+
+				"Run `pinchtab doctor` for details", override)
+		}
+		return nil
+	}
+	if runtimekit.FindBrowserBinary(browserID) == "" {
+		return fmt.Errorf("no %s browser found on this machine.\n"+
+			"       Install one (e.g. Google Chrome for Testing, or `apt-get install -y chromium` "+
+			"on Debian/Ubuntu) or set browser.binary in your config.\n"+
+			"       Run `pinchtab doctor` for the full diagnosis", browserID)
+	}
+	return nil
 }
 
 func newCLIRuntime(cfg *config.RuntimeConfig) cliRuntime {

--- a/cmd/pinchtab/cmd_cli_runtime.go
+++ b/cmd/pinchtab/cmd_cli_runtime.go
@@ -74,22 +74,23 @@ func preflightBrowserBinary(cfg *config.RuntimeConfig) error {
 	if cfg == nil || strings.TrimSpace(cfg.CDPAttachURL) != "" {
 		return nil // attaching to an external CDP endpoint; no local binary needed
 	}
-	browserID := config.NormalizeBrowser(cfg.DefaultBrowser)
+	effective := runtimekit.ResolveEffectiveBrowser(cfg)
+	browserID := effective.ID
 	if _, ok := browsers.Get(browserID); !ok {
 		return nil // unknown provider — let the normal path report it
 	}
-	if override := strings.TrimSpace(cfg.BrowserBinary); override != "" {
+	if override := strings.TrimSpace(effective.Binary); override != "" {
 		if info, err := os.Stat(override); err != nil || info.IsDir() {
-			return fmt.Errorf("configured browser.binary does not point at a usable executable: %s\n"+
-				"       Point it at an existing browser binary, or unset it to use auto-discovery. "+
+			return fmt.Errorf("configured browser executable does not point at a usable executable: %s\n"+
+				"       Point the active browser config at an existing browser binary, or unset it to use auto-discovery. "+
 				"Run `pinchtab doctor` for details", override)
 		}
 		return nil
 	}
-	if runtimekit.FindBrowserBinary(browserID) == "" {
+	if effective.Binary == "" {
 		return fmt.Errorf("no %s browser found on this machine.\n"+
 			"       Install one (e.g. Google Chrome for Testing, or `apt-get install -y chromium` "+
-			"on Debian/Ubuntu) or set browser.binary in your config.\n"+
+			"on Debian/Ubuntu) or set a browser binary in your config.\n"+
 			"       Run `pinchtab doctor` for the full diagnosis", browserID)
 	}
 	return nil

--- a/cmd/pinchtab/cmd_cli_runtime.go
+++ b/cmd/pinchtab/cmd_cli_runtime.go
@@ -33,6 +33,21 @@ func runCLIEnsuringServer(command string, fn func(cliRuntime)) {
 	runCLIWithServerCheck(loadConfig(), command, fn)
 }
 
+// runCLIEnsuringServerNoBrowser auto-starts the local control plane if needed but
+// skips the browser preflight, for commands that need the server but not a browser
+// instance (e.g. session create). Without this, the documented "create a session
+// first" step fails cold with a raw "connection refused" on a fresh machine, since
+// only browser commands auto-start the server.
+func runCLIEnsuringServerNoBrowser(command string, fn func(cliRuntime)) {
+	cfg := loadConfig()
+	rt := newCLIRuntime(cfg)
+	if err := ensureServerForCLI(cfg, rt.base, rt.token, command); err != nil {
+		fmt.Fprintf(os.Stderr, "pinchtab: %v\n", err)
+		os.Exit(1)
+	}
+	fn(rt)
+}
+
 func runCLIWithServerCheck(cfg *config.RuntimeConfig, command string, fn func(cliRuntime)) {
 	rt := newCLIRuntime(cfg)
 	// Only preflight when this command would auto-start the local server. For a

--- a/cmd/pinchtab/cmd_cli_runtime_test.go
+++ b/cmd/pinchtab/cmd_cli_runtime_test.go
@@ -3,6 +3,9 @@ package main
 import (
 	"io"
 	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/pinchtab/pinchtab/internal/config"
@@ -185,6 +188,47 @@ func TestRunCLIWithInjectsAgentIDHeaders(t *testing.T) {
 	if got := gotRequest.Header.Get("X-Agent-Id"); got != wantAgentID {
 		t.Fatalf("X-Agent-Id = %q, want %q", got, wantAgentID)
 	}
+}
+
+// TestPreflightBrowserBinary covers the fail-fast no-browser diagnosis that
+// replaces the bridge's opaque "instance not ready after 10s" 503 on the
+// documented `pinchtab nav` cold start.
+func TestPreflightBrowserBinary(t *testing.T) {
+	existing := filepath.Join(t.TempDir(), "chrome")
+	if err := os.WriteFile(existing, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("missing override fails fast with guidance", func(t *testing.T) {
+		err := preflightBrowserBinary(&config.RuntimeConfig{
+			DefaultBrowser: "chrome",
+			BrowserBinary:  filepath.Join(t.TempDir(), "does-not-exist"),
+		})
+		if err == nil {
+			t.Fatal("expected error for a missing browser.binary override")
+		}
+		if !strings.Contains(err.Error(), "browser.binary") || !strings.Contains(err.Error(), "doctor") {
+			t.Errorf("error should name browser.binary and point at doctor; got: %v", err)
+		}
+	})
+
+	t.Run("existing override passes", func(t *testing.T) {
+		if err := preflightBrowserBinary(&config.RuntimeConfig{
+			DefaultBrowser: "chrome",
+			BrowserBinary:  existing,
+		}); err != nil {
+			t.Errorf("expected nil for an existing override binary; got %v", err)
+		}
+	})
+
+	t.Run("external CDP attach skips local binary check", func(t *testing.T) {
+		if err := preflightBrowserBinary(&config.RuntimeConfig{
+			DefaultBrowser: "chrome",
+			CDPAttachURL:   "http://127.0.0.1:9222",
+		}); err != nil {
+			t.Errorf("expected nil when attaching to external CDP; got %v", err)
+		}
+	})
 }
 
 type roundTripFunc func(*http.Request) (*http.Response, error)

--- a/cmd/pinchtab/cmd_cli_runtime_test.go
+++ b/cmd/pinchtab/cmd_cli_runtime_test.go
@@ -207,8 +207,8 @@ func TestPreflightBrowserBinary(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error for a missing browser.binary override")
 		}
-		if !strings.Contains(err.Error(), "browser.binary") || !strings.Contains(err.Error(), "doctor") {
-			t.Errorf("error should name browser.binary and point at doctor; got: %v", err)
+		if !strings.Contains(err.Error(), "browser executable") || !strings.Contains(err.Error(), "doctor") {
+			t.Errorf("error should describe the configured browser executable and point at doctor; got: %v", err)
 		}
 	})
 
@@ -218,6 +218,20 @@ func TestPreflightBrowserBinary(t *testing.T) {
 			BrowserBinary:  existing,
 		}); err != nil {
 			t.Errorf("expected nil for an existing override binary; got %v", err)
+		}
+	})
+
+	t.Run("default target binary passes", func(t *testing.T) {
+		if err := preflightBrowserBinary(&config.RuntimeConfig{
+			DefaultBrowser: config.BrowserChrome,
+			Targets: config.BrowserTargetsConfig{
+				"only": {
+					Provider: config.BrowserCloak,
+					Binary:   existing,
+				},
+			},
+		}); err != nil {
+			t.Errorf("expected nil for an existing default-target binary; got %v", err)
 		}
 	})
 

--- a/cmd/pinchtab/cmd_config_test.go
+++ b/cmd/pinchtab/cmd_config_test.go
@@ -207,6 +207,38 @@ func TestConfigShowIncludesTrustLoopbackProxy(t *testing.T) {
 	}
 }
 
+func TestConfigShowIncludesIDPIAndAllowedDomains(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("PINCHTAB_CONFIG", configPath)
+	t.Setenv("PINCHTAB_TOKEN", "")
+
+	fc := config.DefaultFileConfig()
+	if err := config.SaveFileConfig(&fc, configPath); err != nil {
+		t.Fatalf("SaveFileConfig() error = %v", err)
+	}
+
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+
+	output := captureStdout(t, func() {
+		rootCmd.SetArgs([]string{"config", "show"})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+	})
+
+	// The browsing allowlist is the most security-relevant setting a user edits;
+	// it must be visible in `config show` so an edit can be confirmed there.
+	if !strings.Contains(output, "Allowed Domains:") {
+		t.Errorf("config show output missing 'Allowed Domains:'; got %q", output)
+	}
+	if !strings.Contains(output, "IDPI:") {
+		t.Errorf("config show output missing 'IDPI:'; got %q", output)
+	}
+	if !strings.Contains(output, "localhost") {
+		t.Errorf("expected default allowlist (localhost) in output; got %q", output)
+	}
+}
+
 func TestConfigGetMasksServerToken(t *testing.T) {
 	configPath := filepath.Join(t.TempDir(), "config.json")
 	t.Setenv("PINCHTAB_CONFIG", configPath)

--- a/cmd/pinchtab/cmd_daemon.go
+++ b/cmd/pinchtab/cmd_daemon.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/pinchtab/pinchtab/internal/browsers/chrome"
 	"github.com/pinchtab/pinchtab/internal/cli"
 	"github.com/pinchtab/pinchtab/internal/config"
 	"github.com/pinchtab/pinchtab/internal/daemon"
@@ -83,7 +84,25 @@ func handleDaemonInstall(manager daemon.Manager) {
 		printDaemonActionError(manager, fmt.Sprintf("daemon install failed: %v", err))
 	}
 	fmt.Println(cli.StyleStdout(cli.SuccessStyle, "  [ok] ") + message)
+	warnPrimaryChromeMacOS(fileCfg)
 	printDaemonFollowUp()
+}
+
+// warnPrimaryChromeMacOS surfaces the issue #583 collision at install time:
+// on macOS, auto-launching the user's daily Google Chrome for headless
+// automation can stop their normal Chrome from opening a window.
+func warnPrimaryChromeMacOS(fileCfg *config.FileConfig) {
+	if fileCfg == nil || !chrome.ResolvesToPrimaryChromeMacOS(fileCfg.BrowserBinary()) {
+		return
+	}
+	fmt.Fprintln(os.Stderr, cli.StyleStderr(cli.WarningStyle,
+		"  [warn] Automation will use your primary Google Chrome on macOS."))
+	fmt.Fprintln(os.Stderr, cli.StyleStderr(cli.MutedStyle,
+		"         Launching it headless can stop your normal Chrome from opening (issue #583)."))
+	fmt.Fprintln(os.Stderr, cli.StyleStderr(cli.MutedStyle,
+		"         Install Google Chrome for Testing or Chromium, or set browser.binary in config"))
+	fmt.Fprintln(os.Stderr, cli.StyleStderr(cli.MutedStyle,
+		"         to a dedicated automation browser."))
 }
 
 func handleDaemonUninstall(manager daemon.Manager) {

--- a/cmd/pinchtab/cmd_daemon.go
+++ b/cmd/pinchtab/cmd_daemon.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/pinchtab/pinchtab/internal/browsers/chrome"
+	"github.com/pinchtab/pinchtab/internal/browsers/runtimekit"
 	"github.com/pinchtab/pinchtab/internal/cli"
 	"github.com/pinchtab/pinchtab/internal/config"
 	"github.com/pinchtab/pinchtab/internal/daemon"
@@ -84,15 +85,16 @@ func handleDaemonInstall(manager daemon.Manager) {
 		printDaemonActionError(manager, fmt.Sprintf("daemon install failed: %v", err))
 	}
 	fmt.Println(cli.StyleStdout(cli.SuccessStyle, "  [ok] ") + message)
-	warnPrimaryChromeMacOS(fileCfg)
+	warnPrimaryChromeMacOS(loadConfig())
 	printDaemonFollowUp()
 }
 
 // warnPrimaryChromeMacOS surfaces the issue #583 collision at install time:
 // on macOS, auto-launching the user's daily Google Chrome for headless
 // automation can stop their normal Chrome from opening a window.
-func warnPrimaryChromeMacOS(fileCfg *config.FileConfig) {
-	if fileCfg == nil || !chrome.ResolvesToPrimaryChromeMacOS(fileCfg.BrowserBinary()) {
+func warnPrimaryChromeMacOS(cfg *config.RuntimeConfig) {
+	effective := runtimekit.ResolveEffectiveBrowser(cfg)
+	if effective.ID != config.BrowserChrome || !chrome.IsPrimaryChromeBinaryMacOS(effective.Binary) {
 		return
 	}
 	fmt.Fprintln(os.Stderr, cli.StyleStderr(cli.WarningStyle,

--- a/cmd/pinchtab/cmd_mcp_test.go
+++ b/cmd/pinchtab/cmd_mcp_test.go
@@ -57,6 +57,21 @@ func TestIsServerHealthy_SendsAuthHeader(t *testing.T) {
 	}
 }
 
+func TestIsServerHealthy_SendsSessionAuthHeader(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Session ses_testtoken" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	if !isServerHealthy(ts.URL, "ses_testtoken") {
+		t.Fatal("expected healthy server with session token to return true")
+	}
+}
+
 func TestWaitForServer_ImmediatelyHealthy(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/cmd/pinchtab/cmd_security.go
+++ b/cmd/pinchtab/cmd_security.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/pinchtab/pinchtab/internal/cli"
 	"github.com/pinchtab/pinchtab/internal/config"
@@ -42,7 +43,31 @@ func init() {
 	rootCmd.AddCommand(securityCmd)
 }
 
+// printEnforcedDriftWarning flags when a server is running but was started with
+// a different config than what's now on disk — i.e. the posture printed below is
+// the user's intent, not necessarily what the live server enforces. The IDPI
+// guard and allowlist are snapshotted at boot, so an edit without a restart left
+// the running server enforcing stale policy with nothing signalling it; this is
+// that signal.
+func printEnforcedDriftWarning(cfg *config.RuntimeConfig) {
+	if cfg == nil {
+		return
+	}
+	snap, state := fetchHealthSnapshotWithToken(cfg.Port, resolveCLIToken(cfg))
+	if state != healthSnapshotRunning || snap == nil || !snap.RestartRequired {
+		return
+	}
+	fmt.Println(cli.StyleStdout(cli.WarningStyle,
+		"  ⚠ The running server started with a different config — the settings below are not all in effect yet."))
+	if len(snap.RestartReasons) > 0 {
+		fmt.Printf("    Pending (needs restart): %s\n", strings.Join(snap.RestartReasons, ", "))
+	}
+	fmt.Println(cli.StyleStdout(cli.MutedStyle, "    Apply with: pinchtab server restart"))
+	fmt.Println()
+}
+
 func printSecurityOverview(cfg *config.RuntimeConfig) {
+	printEnforcedDriftWarning(cfg)
 	posture := cli.AssessSecurityPosture(cfg)
 	recommended := cli.RecommendedSecurityDefaultLines(cfg)
 	warnings := cli.AssessSecurityWarnings(cfg)

--- a/cmd/pinchtab/cmd_server_background_unix.go
+++ b/cmd/pinchtab/cmd_server_background_unix.go
@@ -2,10 +2,44 @@
 
 package main
 
-import "syscall"
+import (
+	"fmt"
+	"os"
+	"strings"
+	"syscall"
+)
 
 func processAlive(pid int) bool {
-	return syscall.Kill(pid, 0) == nil
+	if syscall.Kill(pid, 0) != nil {
+		return false
+	}
+	// A zombie (defunct) process still answers kill(pid, 0) because its PID
+	// lingers in the table until the parent reaps it, but it is not running. In
+	// containers whose PID 1 doesn't reap (e.g. a bare `sleep infinity`), a
+	// SIGKILLed server stays a zombie — which would otherwise make stop/restart
+	// report a false "did not exit" failure and refuse to start over it. Treat a
+	// zombie as dead. (The official image's dumb-init reaps, so this only bites
+	// minimal/init-less containers, but the check is correct everywhere.)
+	return !processIsZombie(pid)
+}
+
+// processIsZombie reports whether pid is in the Linux zombie ("Z") state. It
+// reads /proc/<pid>/stat; where /proc is absent (e.g. macOS, where launchd
+// reaps and this case doesn't arise) it returns false and processAlive keeps
+// its plain kill(0) semantics.
+func processIsZombie(pid int) bool {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+	if err != nil {
+		return false
+	}
+	// Format: "<pid> (<comm>) <state> ...". comm may contain spaces and ')', so
+	// scan past the final ')' before reading the single-char state field.
+	s := string(data)
+	close := strings.LastIndexByte(s, ')')
+	if close < 0 || close+2 >= len(s) {
+		return false
+	}
+	return s[close+2] == 'Z'
 }
 
 func stopProcess(pid int) error {

--- a/cmd/pinchtab/cmd_server_ensure.go
+++ b/cmd/pinchtab/cmd_server_ensure.go
@@ -50,8 +50,8 @@ func ensureServerWithAutoStart(baseURL, token, command string, allowAutoStart bo
 
 func isServerHealthy(baseURL, token string) bool {
 	headers := map[string]string{}
-	if token != "" {
-		headers["Authorization"] = "Bearer " + token
+	if auth := server.AuthorizationHeaderValue(token); auth != "" {
+		headers["Authorization"] = auth
 	}
 	status, _, reachable := server.ProbeHealth(baseURL+"/health", 3*time.Second, headers)
 	return reachable && status < 500

--- a/cmd/pinchtab/cmd_session.go
+++ b/cmd/pinchtab/cmd_session.go
@@ -24,7 +24,7 @@ func init() {
 			sessionToken := os.Getenv("PINCHTAB_SESSION")
 			if sessionToken == "" {
 				fmt.Fprintln(os.Stderr, "Error: no session set")
-				output.Hint("create one: export PINCHTAB_SESSION=$(pinchtab session create --agent-id <id> --print-token)")
+				output.Hint("create one: export PINCHTAB_SESSION=$(pinchtab session create --agent-id <id>)")
 				os.Exit(1)
 			}
 			runCLI(func(rt cliRuntime) {
@@ -58,7 +58,10 @@ func init() {
 			if label != "" {
 				body["label"] = label
 			}
-			runCLI(func(rt cliRuntime) {
+			// Auto-start the control plane first: the documented "create a session
+			// before any browser command" order otherwise fails cold on a fresh
+			// machine (only browser commands start the server).
+			runCLIEnsuringServerNoBrowser("session create", func(rt cliRuntime) {
 				if jsonOutput {
 					apiclient.DoPost(rt.client, rt.base, rt.token, "/sessions", body)
 					return

--- a/cmd/pinchtab/root.go
+++ b/cmd/pinchtab/root.go
@@ -26,6 +26,17 @@ browsers, manage tabs, and perform interactive tasks.`,
 	},
 }
 
+// versionCmd mirrors --version as a subcommand, since `pinchtab version` is a
+// common first instinct and cobra only wires up the --version flag by default.
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the PinchTab version",
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("pinchtab %s\n", version)
+	},
+}
+
 // maybeRunWizard checks if the security wizard should run and triggers it.
 func maybeRunWizard() {
 	fileCfg, configPath, err := config.LoadFileConfig()
@@ -103,6 +114,8 @@ func init() {
 	configGroup := &cobra.Group{ID: "config", Title: "Configuration & Setup"}
 
 	rootCmd.AddGroup(primaryGroup, browserGroup, mgmtGroup, configGroup)
+
+	rootCmd.AddCommand(versionCmd)
 
 	cli.SetupUsage(rootCmd)
 }

--- a/cmd/pinchtab/root_health.go
+++ b/cmd/pinchtab/root_health.go
@@ -61,8 +61,8 @@ func fetchHealthSnapshot(port string) (*healthSnapshot, healthSnapshotState) {
 // /health (the unauthenticated probe would just see a protected listener).
 func fetchHealthSnapshotWithToken(port, token string) (*healthSnapshot, healthSnapshotState) {
 	var headers map[string]string
-	if strings.TrimSpace(token) != "" {
-		headers = map[string]string{"Authorization": "Bearer " + token}
+	if auth := server.AuthorizationHeaderValue(token); auth != "" {
+		headers = map[string]string{"Authorization": auth}
 	}
 	status, body, reachable := server.ProbeHealth(fmt.Sprintf("http://localhost:%s/health", port), 500*time.Millisecond, headers)
 	if !reachable {

--- a/cmd/pinchtab/root_health.go
+++ b/cmd/pinchtab/root_health.go
@@ -13,10 +13,12 @@ import (
 // healthSnapshot is the subset of the /health response the landing banner and
 // `pinchtab health` care about.
 type healthSnapshot struct {
-	Status   string `json:"status"`
-	Mode     string `json:"mode"`
-	Version  string `json:"version"`
-	Security *struct {
+	Status          string   `json:"status"`
+	Mode            string   `json:"mode"`
+	Version         string   `json:"version"`
+	RestartRequired bool     `json:"restartRequired"`
+	RestartReasons  []string `json:"restartReasons"`
+	Security        *struct {
 		Level                     string   `json:"level"`
 		AllowedDomains            []string `json:"allowedDomains"`
 		IDPIEnabled               bool     `json:"idpiEnabled"`
@@ -51,7 +53,18 @@ func formatAllowedDomains(domains []string) string {
 // It is the only function here that performs network I/O, so callers that just
 // need to print help/landing text can avoid the probe latency entirely.
 func fetchHealthSnapshot(port string) (*healthSnapshot, healthSnapshotState) {
-	status, body, reachable := server.ProbeHealth(fmt.Sprintf("http://localhost:%s/health", port), 500*time.Millisecond, nil)
+	return fetchHealthSnapshotWithToken(port, "")
+}
+
+// fetchHealthSnapshotWithToken is fetchHealthSnapshot with optional auth, so it
+// can read fields like restartRequired from a server that requires auth on
+// /health (the unauthenticated probe would just see a protected listener).
+func fetchHealthSnapshotWithToken(port, token string) (*healthSnapshot, healthSnapshotState) {
+	var headers map[string]string
+	if strings.TrimSpace(token) != "" {
+		headers = map[string]string{"Authorization": "Bearer " + token}
+	}
+	status, body, reachable := server.ProbeHealth(fmt.Sprintf("http://localhost:%s/health", port), 500*time.Millisecond, headers)
 	if !reachable {
 		return nil, healthSnapshotStopped
 	}

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -387,6 +387,17 @@ When the selected browser is `cloak`, `browser.binary` (or the target's
 `binary`) must point at the local CloakBrowser Chromium executable. PinchTab
 does not download, bundle, or redistribute the CloakBrowser binary.
 
+On **macOS**, prefer a dedicated automation browser over your daily Google
+Chrome. Launching `/Applications/Google Chrome.app` headless makes macOS treat
+Chrome as already running, so opening your normal Chrome from the Dock just
+activates the windowless automation process and no window appears (issue #583).
+PinchTab's discovery now prefers Google Chrome for Testing, Chromium, then Chrome
+Canary, and only falls back to your primary Chrome as a last resort. If only your
+daily Chrome is installed, install [Google Chrome for
+Testing](https://developer.chrome.com/blog/chrome-for-testing) or set
+`browser.binary` to a separate Chrome/Chromium build. `pinchtab doctor browsers`
+warns when automation would use your primary Chrome.
+
 `browser.cloak` maps supported CloakBrowser fingerprint settings to native launch
 flags:
 

--- a/docs/reference/sessions.md
+++ b/docs/reference/sessions.md
@@ -67,9 +67,9 @@ That default is a convenience for trusted automation, not a sandbox. If you need
 ## CLI Usage
 
 ```bash
-# Create a new session (prints token to stdout with --print-token)
-pinchtab session create --agent-id agent-1 --print-token
-export PINCHTAB_SESSION=$(pinchtab session create --agent-id agent-1 --print-token)
+# Create a new session (prints the session token to stdout; use --json for a full JSON object)
+pinchtab session create --agent-id agent-1
+export PINCHTAB_SESSION=$(pinchtab session create --agent-id agent-1)
 
 # CLI automatically uses session auth when PINCHTAB_SESSION is set
 pinchtab snap

--- a/internal/bridge/tab_manager.go
+++ b/internal/bridge/tab_manager.go
@@ -2,6 +2,7 @@ package bridge
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -13,6 +14,18 @@ import (
 	"github.com/chromedp/chromedp"
 	"github.com/pinchtab/pinchtab/internal/config"
 	"github.com/pinchtab/pinchtab/internal/ids"
+)
+
+const (
+	// tabCreateTimeout bounds the CDP target creation for a new tab. Creating a
+	// target is near-instant on a healthy browser, so a long stall means the
+	// browser is unhealthy (e.g. resource exhaustion) — fail fast instead of
+	// waiting tens of seconds.
+	tabCreateTimeout = 10 * time.Second
+	// tabCreateNavTimeout bounds the initial load of a freshly created tab. Kept
+	// well below the full navigate timeout so a wedged renderer (e.g. after an
+	// out-of-memory event) surfaces quickly rather than hanging ~60s.
+	tabCreateNavTimeout = 20 * time.Second
 )
 
 type TabSetupFunc func(ctx context.Context, tabID string)
@@ -150,7 +163,7 @@ func (tm *TabManager) CreateTab(url string) (string, context.Context, context.Ca
 
 	// target.CreateTarget works for both local and remote (CDP_URL) allocators.
 	var targetID target.ID
-	createCtx, createCancel := context.WithTimeout(tm.browserCtx, 30*time.Second)
+	createCtx, createCancel := context.WithTimeout(tm.browserCtx, tabCreateTimeout)
 	if err := chromedp.Run(createCtx,
 		chromedp.ActionFunc(func(ctx context.Context) error {
 			var err error
@@ -159,6 +172,9 @@ func (tm *TabManager) CreateTab(url string) (string, context.Context, context.Ca
 		}),
 	); err != nil {
 		createCancel()
+		if errors.Is(err, context.DeadlineExceeded) {
+			return "", nil, nil, fmt.Errorf("create tab: browser did not open a new tab within %s — it may be out of memory or overloaded (close tabs or restart the instance)", tabCreateTimeout)
+		}
 		return "", nil, nil, fmt.Errorf("create target: %w", err)
 	}
 	createCancel()
@@ -186,12 +202,15 @@ func (tm *TabManager) CreateTab(url string) (string, context.Context, context.Ca
 	}
 
 	if url != "" && url != "about:blank" {
-		navCtx, navCancel := context.WithTimeout(ctx, 30*time.Second)
+		navCtx, navCancel := context.WithTimeout(ctx, tabCreateNavTimeout)
 		if err := chromedp.Run(navCtx, chromedp.Navigate(url)); err != nil {
 			navCancel()
 			cancel()
 			if execCtx, execErr := browserExecutorContext(tm.browserCtx); execErr == nil {
 				_ = target.CloseTarget(targetID).Do(execCtx)
+			}
+			if errors.Is(err, context.DeadlineExceeded) {
+				return "", nil, nil, fmt.Errorf("navigate new tab: page did not load within %s — the browser may be out of memory or overloaded (close tabs or restart the instance)", tabCreateNavTimeout)
 			}
 			return "", nil, nil, fmt.Errorf("navigate: %w", err)
 		}

--- a/internal/browsers/chrome/chrome.go
+++ b/internal/browsers/chrome/chrome.go
@@ -14,6 +14,12 @@ import (
 	"github.com/pinchtab/pinchtab/internal/browsers"
 )
 
+// primaryChromeAppMacOS is the user's daily Google Chrome executable. On macOS,
+// launching it for headless automation collides with LaunchServices and can stop
+// the user's normal Chrome from opening (issue #583), so PinchTab prefers a
+// dedicated automation browser and only falls back to this as a last resort.
+const primaryChromeAppMacOS = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+
 var binaryNames = []string{
 	"google-chrome",
 	"google-chrome-stable",
@@ -42,10 +48,19 @@ func CommonPaths(goos string) []string {
 			"/opt/google/chrome/chrome",
 		}
 	case "darwin":
+		// Prefer a dedicated automation browser over the user's daily Google
+		// Chrome. On macOS, launching /Applications/Google Chrome.app directly
+		// with --headless=new makes LaunchServices treat Chrome as already
+		// running, so the user's next Dock/Spotlight launch just activates the
+		// windowless automation process instead of opening a real window
+		// (see issue #583). Chrome for Testing / Chromium / Canary have a
+		// distinct app identity and avoid the collision; the daily Chrome is a
+		// last resort.
 		return []string{
-			"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+			"/Applications/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing",
 			"/Applications/Chromium.app/Contents/MacOS/Chromium",
 			"/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary",
+			primaryChromeAppMacOS,
 		}
 	case "windows":
 		return []string{
@@ -99,6 +114,18 @@ func (Browser) Capabilities() browsers.CapabilitySet {
 		browsers.CapNetworkInterception,
 		browsers.CapEventScreencast,
 	)
+}
+
+// ResolvesToPrimaryChromeMacOS reports whether, absent an explicit binary
+// override, Chrome discovery would launch the user's daily Google Chrome on
+// macOS — the configuration that triggers the issue #583 LaunchServices
+// collision (automation blocks the user's normal Chrome from opening).
+func ResolvesToPrimaryChromeMacOS(binaryOverride string) bool {
+	if runtime.GOOS != "darwin" || strings.TrimSpace(binaryOverride) != "" {
+		return false
+	}
+	d := browserprobe.DiscoverBinary(BinaryNames(), CommonPaths(runtime.GOOS))
+	return d.Found == primaryChromeAppMacOS
 }
 
 func (Browser) DiscoverBinary() browsers.BinaryDiscovery {

--- a/internal/browsers/chrome/chrome.go
+++ b/internal/browsers/chrome/chrome.go
@@ -116,6 +116,10 @@ func (Browser) Capabilities() browsers.CapabilitySet {
 	)
 }
 
+func IsPrimaryChromeBinaryMacOS(binary string) bool {
+	return runtime.GOOS == "darwin" && strings.TrimSpace(binary) == primaryChromeAppMacOS
+}
+
 // ResolvesToPrimaryChromeMacOS reports whether, absent an explicit binary
 // override, Chrome discovery would launch the user's daily Google Chrome on
 // macOS — the configuration that triggers the issue #583 LaunchServices
@@ -125,7 +129,7 @@ func ResolvesToPrimaryChromeMacOS(binaryOverride string) bool {
 		return false
 	}
 	d := browserprobe.DiscoverBinary(BinaryNames(), CommonPaths(runtime.GOOS))
-	return d.Found == primaryChromeAppMacOS
+	return IsPrimaryChromeBinaryMacOS(d.Found)
 }
 
 func (Browser) DiscoverBinary() browsers.BinaryDiscovery {

--- a/internal/browsers/chrome/chrome_test.go
+++ b/internal/browsers/chrome/chrome_test.go
@@ -2,6 +2,9 @@ package chrome_test
 
 import (
 	"context"
+	"os"
+	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 	"testing"
@@ -144,6 +147,31 @@ func TestCommonPathsPerOS(t *testing.T) {
 		if !found {
 			t.Errorf("CommonPaths(%q) missing path containing %q; got %v", tt.goos, tt.want, paths)
 		}
+	}
+}
+
+func TestCommonPathsDarwinPrefersDedicatedBrowser(t *testing.T) {
+	paths := chrome.CommonPaths("darwin")
+	if len(paths) == 0 {
+		t.Fatal("darwin CommonPaths empty")
+	}
+
+	primary := "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+	cft := "/Applications/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing"
+
+	// The user's daily Chrome must be the LAST resort (issue #583): launching it
+	// for automation collides with macOS LaunchServices.
+	if got := paths[len(paths)-1]; got != primary {
+		t.Errorf("expected primary Chrome to be last; got last = %q in %v", got, paths)
+	}
+
+	primaryIdx := indexOf(paths, primary)
+	cftIdx := indexOf(paths, cft)
+	if cftIdx < 0 {
+		t.Fatalf("expected Chrome for Testing in darwin CommonPaths; got %v", paths)
+	}
+	if cftIdx >= primaryIdx {
+		t.Errorf("Chrome for Testing (%d) must be preferred over primary Chrome (%d)", cftIdx, primaryIdx)
 	}
 }
 
@@ -543,6 +571,41 @@ func TestChrome_ValidateTarget(t *testing.T) {
 	if err := b.ValidateTarget(browsers.TargetConfig{Binary: "/usr/bin/chrome"}); err != nil {
 		t.Errorf("ValidateTarget(binary) = %v, want nil", err)
 	}
+}
+
+// TestChromePresentHonorsBrowserBinaryOverride guards the issue #583 follow-up:
+// a configured browser.binary that sits off the static discovery path must PASS
+// chrome_present (it's what the runtime launches), not report a false "no
+// chrome/chromium found" FAIL while the binary_* checks pass right below it.
+func TestChromePresentHonorsBrowserBinaryOverride(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chrome_present is skipped on windows")
+	}
+	dir := t.TempDir()
+	fake := filepath.Join(dir, "fakechrome")
+	if err := os.WriteFile(fake, []byte("#!/bin/sh\necho 'Chromium 149.0.0.0'\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	check := findCheckByID(t, (&chrome.Browser{}).DoctorChecks(browsers.TargetConfig{}), "chrome_present")
+	res := check.Fn(context.Background(), &browsers.DoctorEnv{Binary: fake})
+	if res.Status != browsers.DoctorPass {
+		t.Fatalf("chrome_present with override status = %v, want DoctorPass; detail: %s", res.Status, res.Detail)
+	}
+	if !strings.Contains(res.Detail, fake) {
+		t.Errorf("expected detail to reference the override path %q; got %q", fake, res.Detail)
+	}
+}
+
+func findCheckByID(t *testing.T, checks []browsers.DoctorCheck, id string) browsers.DoctorCheck {
+	t.Helper()
+	for _, c := range checks {
+		if c.ID == id {
+			return c
+		}
+	}
+	t.Fatalf("check %q not found", id)
+	return browsers.DoctorCheck{}
 }
 
 func TestChromeHandleDecisionsCheck(t *testing.T) {

--- a/internal/browsers/chrome/doctor.go
+++ b/internal/browsers/chrome/doctor.go
@@ -52,25 +52,41 @@ func (b Browser) DoctorChecks(_ browsers.TargetConfig) []browsers.DoctorCheck {
 	}
 }
 
-func chromePresenceCheck(ctx context.Context, _ interface{}) browsers.DoctorCheckResult {
+func chromePresenceCheck(ctx context.Context, cfg interface{}) browsers.DoctorCheckResult {
+	// A configured browser.binary override governs the runtime, so resolve against
+	// it first. Honoring it here keeps chrome_present consistent with the binary_*
+	// checks (which already validate the override) — otherwise a working configured
+	// browser sitting off the static discovery path produces a false FAIL.
+	override := ""
+	if env, ok := cfg.(*browsers.DoctorEnv); ok && env != nil {
+		override = strings.TrimSpace(env.Binary)
+	}
+	overridden := override != ""
+
 	if runtime.GOOS == "windows" {
 		return browsers.DoctorCheckResult{
 			Status: browsers.DoctorSkip,
 			Detail: "chrome discovery not implemented on windows",
 		}
 	}
-	d := browserprobe.DiscoverBinary(BinaryNames(), CommonPaths(runtime.GOOS))
-	if d.Found == "" {
-		return browsers.DoctorCheckResult{
-			Status: browsers.DoctorFail,
-			Detail: "no chrome/chromium found; probed: " + strings.Join(d.Probed, ", "),
+	found := override
+	if found == "" {
+		d := browserprobe.DiscoverBinary(BinaryNames(), CommonPaths(runtime.GOOS))
+		found = d.Found
+		if found == "" {
+			return browsers.DoctorCheckResult{
+				Status: browsers.DoctorFail,
+				Detail: "no chrome/chromium found. Install Chrome/Chromium (e.g. Google Chrome " +
+					"for Testing, or `apt-get install -y chromium` on Debian/Ubuntu) or set " +
+					"browser.binary to an existing build. Probed: " + strings.Join(d.Probed, ", "),
+			}
 		}
 	}
-	line, err := browserprobe.RunVersion(ctx, d.Found)
+	line, err := browserprobe.RunVersion(ctx, found)
 	if err != nil {
 		return browsers.DoctorCheckResult{
 			Status: browsers.DoctorWarn,
-			Detail: fmt.Sprintf("%s: --version failed: %v", d.Found, err),
+			Detail: fmt.Sprintf("%s: --version failed: %v", found, err),
 			Err:    err,
 		}
 	}
@@ -78,17 +94,28 @@ func chromePresenceCheck(ctx context.Context, _ interface{}) browsers.DoctorChec
 	if token == "" {
 		return browsers.DoctorCheckResult{
 			Status: browsers.DoctorWarn,
-			Detail: fmt.Sprintf("%s: could not parse version from %q", d.Found, line),
+			Detail: fmt.Sprintf("%s: could not parse version from %q", found, line),
 		}
 	}
 	if browserprobe.CompareSemver(token, chromeMinVersion) < 0 {
 		return browsers.DoctorCheckResult{
 			Status: browsers.DoctorWarn,
-			Detail: fmt.Sprintf("%s -> %s (< required %s)", d.Found, token, chromeMinVersion),
+			Detail: fmt.Sprintf("%s -> %s (< required %s)", found, token, chromeMinVersion),
+		}
+	}
+	if !overridden && runtime.GOOS == "darwin" && found == primaryChromeAppMacOS {
+		// Works, but flag the macOS collision (issue #583) without downgrading
+		// status — the browser launches fine, it's just sub-optimal here.
+		return browsers.DoctorCheckResult{
+			Status: browsers.DoctorPass,
+			Detail: fmt.Sprintf("%s -> %s (>= %s); note: this is your primary Google Chrome — "+
+				"automating it on macOS can stop your normal Chrome from opening (issue #583). "+
+				"Install Google Chrome for Testing or Chromium, or set browser.binary.",
+				found, token, chromeMinVersion),
 		}
 	}
 	return browsers.DoctorCheckResult{
 		Status: browsers.DoctorPass,
-		Detail: fmt.Sprintf("%s -> %s (>= %s)", d.Found, token, chromeMinVersion),
+		Detail: fmt.Sprintf("%s -> %s (>= %s)", found, token, chromeMinVersion),
 	}
 }

--- a/internal/browsers/cloak/cloak_test.go
+++ b/internal/browsers/cloak/cloak_test.go
@@ -2,6 +2,9 @@ package cloak_test
 
 import (
 	"context"
+	"os"
+	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 	"testing"
@@ -758,6 +761,43 @@ func TestCloak_CanHandle_StateChanging(t *testing.T) {
 	got := b.CanHandle(browsers.RequestIntent{Shape: browsers.ShapeStaticRead, StateChanging: true})
 	if got.Decision != browsers.DecisionHandle {
 		t.Errorf("CanHandle(state-changing).Decision = %q, want %q", got.Decision, browsers.DecisionHandle)
+	}
+}
+
+// TestCloakPresentHonorsBrowserBinaryOverride is the original report: the
+// CloakBrowser installer drops its Chromium in a versioned dir that isn't on the
+// static probe list, so a configured browser.binary must PASS cloakbrowser_present
+// rather than report a false "cloakbrowser not found" FAIL.
+func TestCloakPresentHonorsBrowserBinaryOverride(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("cloakbrowser_present is skipped on windows")
+	}
+	dir := t.TempDir()
+	fake := filepath.Join(dir, "chromium-145.0.0.0", "chrome")
+	if err := os.MkdirAll(filepath.Dir(fake), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(fake, []byte("#!/bin/sh\necho 'Chromium 145.0.0.0'\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	checks := (&cloak.Browser{}).DoctorChecks(browsers.TargetConfig{})
+	var present *browsers.DoctorCheck
+	for i := range checks {
+		if checks[i].ID == "cloakbrowser_present" {
+			present = &checks[i]
+			break
+		}
+	}
+	if present == nil {
+		t.Fatal("cloakbrowser_present check not found")
+	}
+	res := present.Fn(context.Background(), &browsers.DoctorEnv{Binary: fake})
+	if res.Status != browsers.DoctorPass {
+		t.Fatalf("cloakbrowser_present with override status = %v, want DoctorPass; detail: %s", res.Status, res.Detail)
+	}
+	if !strings.Contains(res.Detail, fake) {
+		t.Errorf("expected detail to reference the override path %q; got %q", fake, res.Detail)
 	}
 }
 

--- a/internal/browsers/cloak/doctor.go
+++ b/internal/browsers/cloak/doctor.go
@@ -70,25 +70,38 @@ func (Browser) DoctorChecks(_ browsers.TargetConfig) []browsers.DoctorCheck {
 	}
 }
 
-func cloakPresenceCheck(ctx context.Context, _ interface{}) browsers.DoctorCheckResult {
+func cloakPresenceCheck(ctx context.Context, cfg interface{}) browsers.DoctorCheckResult {
 	if runtime.GOOS == "windows" {
 		return browsers.DoctorCheckResult{
 			Status: browsers.DoctorSkip,
 			Detail: "cloakbrowser discovery not implemented on windows",
 		}
 	}
-	d := browserprobe.DiscoverBinary(BinaryNames(), CommonPaths(runtime.GOOS))
-	if d.Found == "" {
-		return browsers.DoctorCheckResult{
-			Status: browsers.DoctorFail,
-			Detail: "cloakbrowser not found; set browser.binary or install CloakBrowser. probed: " + strings.Join(d.Probed, ", "),
+	// An explicit browser.binary override is what the runtime launches, so resolve
+	// against it before falling back to discovery. The CloakBrowser installer drops
+	// its Chromium in a versioned dir that isn't on the static probe list, so without
+	// this a perfectly working configured binary reports a false FAIL while the
+	// binary_* checks below it pass.
+	override := ""
+	if env, ok := cfg.(*browsers.DoctorEnv); ok && env != nil {
+		override = strings.TrimSpace(env.Binary)
+	}
+	found := override
+	if found == "" {
+		d := browserprobe.DiscoverBinary(BinaryNames(), CommonPaths(runtime.GOOS))
+		found = d.Found
+		if found == "" {
+			return browsers.DoctorCheckResult{
+				Status: browsers.DoctorFail,
+				Detail: "cloakbrowser not found; set browser.binary or install CloakBrowser. probed: " + strings.Join(d.Probed, ", "),
+			}
 		}
 	}
-	line, err := browserprobe.RunVersion(ctx, d.Found)
+	line, err := browserprobe.RunVersion(ctx, found)
 	if err != nil {
 		return browsers.DoctorCheckResult{
 			Status: browsers.DoctorWarn,
-			Detail: fmt.Sprintf("%s: --version failed: %v", d.Found, err),
+			Detail: fmt.Sprintf("%s: --version failed: %v", found, err),
 			Err:    err,
 		}
 	}
@@ -96,18 +109,18 @@ func cloakPresenceCheck(ctx context.Context, _ interface{}) browsers.DoctorCheck
 	if token == "" {
 		return browsers.DoctorCheckResult{
 			Status: browsers.DoctorWarn,
-			Detail: fmt.Sprintf("%s: could not parse version from %q", d.Found, line),
+			Detail: fmt.Sprintf("%s: could not parse version from %q", found, line),
 		}
 	}
 	if browserprobe.CompareSemver(token, cloakMinVersion) < 0 {
 		return browsers.DoctorCheckResult{
 			Status: browsers.DoctorWarn,
-			Detail: fmt.Sprintf("%s -> %s (< required %s)", d.Found, token, cloakMinVersion),
+			Detail: fmt.Sprintf("%s -> %s (< required %s)", found, token, cloakMinVersion),
 		}
 	}
 	return browsers.DoctorCheckResult{
 		Status: browsers.DoctorPass,
-		Detail: fmt.Sprintf("%s -> %s (>= %s)", d.Found, token, cloakMinVersion),
+		Detail: fmt.Sprintf("%s -> %s (>= %s)", found, token, cloakMinVersion),
 	}
 }
 

--- a/internal/browsers/runtimekit/runtimekit.go
+++ b/internal/browsers/runtimekit/runtimekit.go
@@ -17,6 +17,12 @@ type ProviderLaunchPlan struct {
 	Binary  string
 }
 
+type EffectiveBrowser struct {
+	ID     string
+	Binary string
+	Config *config.RuntimeConfig
+}
+
 func RuntimeProxyConfig(cfg *config.RuntimeConfig) browsers.ProxyConfig {
 	if cfg == nil {
 		return browsers.ProxyConfig{}
@@ -90,6 +96,26 @@ func FindBrowserBinary(browserID string) string {
 		return ""
 	}
 	return b.DiscoverBinary().Found
+}
+
+func ResolveEffectiveBrowser(cfg *config.RuntimeConfig) EffectiveBrowser {
+	if cfg == nil {
+		return EffectiveBrowser{}
+	}
+	effectiveCfg := cfg
+	if resolved, err := config.ResolveDefaultBrowserTarget(cfg); err == nil && resolved != nil && resolved.Config != nil {
+		effectiveCfg = resolved.Config
+	}
+	browserID := config.NormalizeBrowser(effectiveCfg.DefaultBrowser)
+	binary := strings.TrimSpace(effectiveCfg.BrowserBinary)
+	if binary == "" {
+		binary = FindBrowserBinary(browserID)
+	}
+	return EffectiveBrowser{
+		ID:     browserID,
+		Binary: binary,
+		Config: effectiveCfg,
+	}
 }
 
 func BaseFlagArgs(browserID string, headless bool) []string {

--- a/internal/browsers/runtimekit/runtimekit_test.go
+++ b/internal/browsers/runtimekit/runtimekit_test.go
@@ -170,6 +170,28 @@ func TestFindBrowserBinary_UnknownProvider(t *testing.T) {
 	}
 }
 
+func TestResolveEffectiveBrowser_PromotesDefaultTargetBinary(t *testing.T) {
+	cfg := &config.RuntimeConfig{
+		DefaultBrowser: config.BrowserChrome,
+		Targets: config.BrowserTargetsConfig{
+			"only": {
+				Provider: config.BrowserCloak,
+				Binary:   "/opt/cloak/chrome",
+			},
+		},
+	}
+	got := ResolveEffectiveBrowser(cfg)
+	if got.ID != config.BrowserCloak {
+		t.Fatalf("ID = %q, want %q", got.ID, config.BrowserCloak)
+	}
+	if got.Binary != "/opt/cloak/chrome" {
+		t.Fatalf("Binary = %q, want %q", got.Binary, "/opt/cloak/chrome")
+	}
+	if got.Config == nil || got.Config.BrowserBinary != "/opt/cloak/chrome" {
+		t.Fatalf("resolved config missing target binary: %+v", got.Config)
+	}
+}
+
 func TestBaseFlagArgs_Chrome(t *testing.T) {
 	args := BaseFlagArgs("chrome", false)
 	if len(args) == 0 {

--- a/internal/cli/actions/actions_navigate.go
+++ b/internal/cli/actions/actions_navigate.go
@@ -123,7 +123,7 @@ func Navigate(client *http.Client, base, token string, url string, cmd *cobra.Co
 	}
 
 	if !isIdentifiedCaller() {
-		output.Hint("no session set — this tab is shared. Create one with: export PINCHTAB_SESSION=$(pinchtab session create --agent-id <id> --print-token)")
+		output.Hint("no session set — this tab is shared. Create one with: export PINCHTAB_SESSION=$(pinchtab session create --agent-id <id>)")
 	}
 
 	snap, _ := cmd.Flags().GetBool("snap")

--- a/internal/cli/report/config_report.go
+++ b/internal/cli/report/config_report.go
@@ -27,6 +27,12 @@ func HandleConfigShow(cfg *config.RuntimeConfig) {
 	fmt.Printf("  Allowed Domains: %v\n", cfg.AllowedDomains)
 	fmt.Println()
 	fmt.Println(styleStdout(headingStyle, "Browser / Instance Defaults"))
+	fmt.Printf("  Provider:       %s\n", cfg.DefaultBrowser)
+	binary := cfg.BrowserBinary
+	if binary == "" {
+		binary = "(auto-discovered)"
+	}
+	fmt.Printf("  Binary:         %s\n", binary)
 	fmt.Printf("  Headless:       %v\n", cfg.Headless)
 	fmt.Printf("  No Restore:     %v\n", cfg.NoRestore)
 	fmt.Printf("  Profile Dir:    %s\n", cfg.ProfileDir)

--- a/internal/cli/report/config_report.go
+++ b/internal/cli/report/config_report.go
@@ -23,6 +23,8 @@ func HandleConfigShow(cfg *config.RuntimeConfig) {
 	fmt.Printf("  Cookies:        %v\n", cfg.AllowCookies)
 	fmt.Printf("  Upload:         %v\n", cfg.AllowUpload)
 	fmt.Printf("  Trust Loopback Proxy: %v\n", cfg.TrustLoopbackProxy)
+	fmt.Printf("  IDPI:           %v\n", cfg.IDPI.Enabled)
+	fmt.Printf("  Allowed Domains: %v\n", cfg.AllowedDomains)
 	fmt.Println()
 	fmt.Println(styleStdout(headingStyle, "Browser / Instance Defaults"))
 	fmt.Printf("  Headless:       %v\n", cfg.Headless)

--- a/internal/cli/styles.go
+++ b/internal/cli/styles.go
@@ -64,7 +64,8 @@ func SetupUsage(root *cobra.Command) {
 {{range .Groups}}{{$group := .ID}}
   {{.Title}}:
 {{range $.Commands}}{{if eq .GroupID $group}}{{if not .Hidden}}    %s  {{.Short}}
-{{end}}{{end}}{{end}}{{end}}
+{{end}}{{end}}{{end}}{{end}}{{range $.Commands}}{{if and (eq .GroupID "") .IsAvailableCommand}}    %s  {{.Short}}
+{{end}}{{end}}
 {{if .HasAvailableLocalFlags}}
 %s:
 {{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}
@@ -76,6 +77,7 @@ func SetupUsage(root *cobra.Command) {
 `,
 		headerStyle("Usage"),
 		headerStyle("Commands"),
+		cmdStyle("{{rpad .Name .NamePadding}}"),
 		cmdStyle("{{rpad .Name .NamePadding}}"),
 		headerStyle("Flags"),
 		headerStyle("Examples")))

--- a/internal/config/editor_parse.go
+++ b/internal/config/editor_parse.go
@@ -30,3 +30,19 @@ func parseCSVList(s string) []string {
 	}
 	return out
 }
+
+// validateAllowlistEntries rejects obviously-invalid domain entries. It exists to
+// catch a user pasting a remediation hint that contains the "…" placeholder
+// literally (the allowlist would otherwise silently accept "…" as a host) and
+// other malformed entries, rather than failing later at navigation time.
+func validateAllowlistEntries(domains []string) error {
+	for _, d := range domains {
+		if strings.ContainsRune(d, '…') || strings.Contains(d, "...") {
+			return fmt.Errorf("invalid domain %q: \"…\" is a placeholder, not a real host — replace it with an actual domain (e.g. example.com)", d)
+		}
+		if strings.ContainsAny(d, " \t/") {
+			return fmt.Errorf("invalid domain %q: a domain must not contain spaces or '/' (use a bare host like example.com or *.example.com)", d)
+		}
+	}
+	return nil
+}

--- a/internal/config/editor_set.go
+++ b/internal/config/editor_set.go
@@ -441,7 +441,11 @@ func setSecurityField(s *SecurityConfig, field, value string) error {
 		return setIDPIField(s, strings.TrimPrefix(field, "idpi."), value)
 	}
 	if field == "allowedDomains" {
-		s.AllowedDomains = parseCSVList(value)
+		domains := parseCSVList(value)
+		if err := validateAllowlistEntries(domains); err != nil {
+			return err
+		}
+		s.AllowedDomains = domains
 		return nil
 	}
 	if field == "downloadAllowedDomains" {

--- a/internal/config/editor_set_test.go
+++ b/internal/config/editor_set_test.go
@@ -2,6 +2,30 @@ package config
 
 import "testing"
 
+func TestSetConfigValue_AllowedDomainsValidation(t *testing.T) {
+	tests := []struct {
+		value   string
+		wantErr bool
+	}{
+		{"example.com", false},
+		{"localhost,127.0.0.1,example.com", false},
+		{"*.example.com", false},
+		{"…,example.com", true},        // literal placeholder pasted from a hint
+		{"127.0.0.1,…", true},          // placeholder anywhere in the list
+		{"has space.com", true},        // malformed
+		{"http://example.com/x", true}, // URL, not a host
+	}
+	for _, tt := range tests {
+		t.Run(tt.value, func(t *testing.T) {
+			fc := &FileConfig{}
+			err := SetConfigValue(fc, "security.allowedDomains", tt.value)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SetConfigValue(allowedDomains=%q) error = %v, wantErr %v", tt.value, err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestSetConfigValue_ServerFields(t *testing.T) {
 	tests := []struct {
 		path    string

--- a/internal/dashboard/config_api_test.go
+++ b/internal/dashboard/config_api_test.go
@@ -150,6 +150,22 @@ func TestRestartReasonsIncludeStealthLevel(t *testing.T) {
 	}
 }
 
+func TestRestartReasonsIncludeSecurityPolicy(t *testing.T) {
+	cfg := config.DefaultFileConfig()
+	api := NewConfigAPI(config.Load(), nil, nil, nil, nil, "test", time.Now())
+	api.boot = cfg
+
+	// Editing the allowlist changes the boot-snapshotted IDPI/security policy, so
+	// it must register as restart-required (the running guard won't pick it up).
+	next := cfg
+	next.Security.AllowedDomains = append(append([]string(nil), cfg.Security.AllowedDomains...), "example.com")
+
+	reasons := api.restartReasonsFor(next)
+	if !slices.Contains(reasons, "Security policy") {
+		t.Fatalf("restartReasonsFor() = %v, want Security policy", reasons)
+	}
+}
+
 func TestHandleGetConfigRedactsToken(t *testing.T) {
 	fc := config.DefaultFileConfig()
 	fc.Server.Token = "secret-token"

--- a/internal/dashboard/config_changes.go
+++ b/internal/dashboard/config_changes.go
@@ -77,8 +77,16 @@ func changedTargetProxyNames(current, next config.BrowserTargetsConfig) []string
 }
 
 func (c *ConfigAPI) restartReasonsFor(next config.FileConfig) []string {
-	reasons := make([]string, 0, 5)
+	reasons := make([]string, 0, 6)
 
+	// The IDPI guard, allowlist, and sensitive-endpoint policy are snapshotted
+	// from the boot config when the server starts and are not rebuilt on a config
+	// edit, so any change to the security block only takes effect after a restart.
+	// Surfacing it here is what lets `pinchtab security`/`health` warn that the
+	// running server is enforcing stale policy instead of silently diverging.
+	if !reflect.DeepEqual(c.boot.Security, next.Security) {
+		reasons = append(reasons, "Security policy")
+	}
 	if c.boot.Server.Port != next.Server.Port || c.boot.Server.Bind != next.Server.Bind {
 		reasons = append(reasons, "Server address")
 	}

--- a/internal/handlers/navigation.go
+++ b/internal/handlers/navigation.go
@@ -188,6 +188,18 @@ func (h *Handlers) resolveNavigateBrowser(w http.ResponseWriter, r *http.Request
 	return routing, true
 }
 
+// idpiAllowlistHint appends a copy-pasteable remediation to an IDPI domain-block
+// error so the user isn't left knowing only the cause. Widening the allowlist
+// reduces isolation, so the hint says so and points at the security guide.
+func idpiAllowlistHint(url string) string {
+	host, ok := navguard.ExtractHost(url)
+	if !ok || strings.TrimSpace(host) == "" {
+		return ""
+	}
+	return fmt.Sprintf(". To allow it, add the host: `pinchtab config set security.allowedDomains \"…,%s\"` "+
+		"then `pinchtab server restart` — this widens what automation may reach (see docs/guides/security.md)", host)
+}
+
 // validateNavigateTargets runs URL validation, the IDPI domain guard, and SSRF
 // target resolution, recording the navigate request on both the blocked and
 // accepted paths. On success it returns the resolved target and trusted-proxy CIDRs.
@@ -201,7 +213,7 @@ func (h *Handlers) validateNavigateTargets(w http.ResponseWriter, r *http.Reques
 	domainResult := h.IDPIGuard.CheckDomain(url)
 	if domainResult.Blocked {
 		h.recordNavigateRequest(r, tabID, url)
-		httpx.Error(w, http.StatusForbidden, fmt.Errorf("navigation blocked by IDPI: %s", domainResult.Reason))
+		httpx.Error(w, http.StatusForbidden, fmt.Errorf("navigation blocked by IDPI: %s%s", domainResult.Reason, idpiAllowlistHint(url)))
 		return navTargets{}, false
 	}
 	if domainResult.Threat {

--- a/internal/handlers/navigation.go
+++ b/internal/handlers/navigation.go
@@ -196,8 +196,18 @@ func idpiAllowlistHint(url string) string {
 	if !ok || strings.TrimSpace(host) == "" {
 		return ""
 	}
-	return fmt.Sprintf(". To allow it, add the host: `pinchtab config set security.allowedDomains \"…,%s\"` "+
-		"then `pinchtab server restart` — this widens what automation may reach (see docs/guides/security.md)", host)
+	return fmt.Sprintf(". To allow it, run: pinchtab config set security.allowedDomains "+
+		"\"$(pinchtab config get security.allowedDomains),%s\" then: pinchtab server restart "+
+		"(this widens what automation may reach — see docs/guides/security.md)", host)
+}
+
+// idpiScannerHint appends remediation to an IDPI content-scanner block, which
+// otherwise states only the cause. Unlike the domain allowlist, a scanner block
+// can be a false positive on legitimate pages, so the fix is to relax strict mode
+// (still scans and wraps, just warns instead of hard-blocking).
+func idpiScannerHint() string {
+	return ". To read pages like this, set strict mode off: `pinchtab config set security.idpi.strictMode false` " +
+		"then `pinchtab server restart` — content is still scanned and wrapped, just warned instead of blocked (see docs/guides/security.md)"
 }
 
 // validateNavigateTargets runs URL validation, the IDPI domain guard, and SSRF

--- a/internal/handlers/navigation.go
+++ b/internal/handlers/navigation.go
@@ -399,11 +399,19 @@ func (h *Handlers) executeNavigate(w http.ResponseWriter, r *http.Request, req n
 	blockPatterns := navigateBlockPatterns(req, effectiveCfg)
 
 	newTabOpts := func() navigateBrowserOptions {
+		// A brand-new tab that can't load within the ceiling is far more often a
+		// wedged/out-of-memory renderer than a genuinely slow page, so cap the
+		// default new-tab budget to fail fast instead of hanging the full navigate
+		// timeout (~60s). An explicit --timeout still wins.
+		newTabTimeout := navTimeout
+		if req.Timeout <= 0 && newTabTimeout > newTabNavCeiling {
+			newTabTimeout = newTabNavCeiling
+		}
 		return navigateBrowserOptions{
 			URL:            req.URL,
 			WaitFor:        req.WaitFor,
 			WaitSelector:   req.WaitSelector,
-			NavTimeout:     navTimeout,
+			NavTimeout:     newTabTimeout,
 			TitleWait:      titleWait,
 			Target:         targets.target,
 			TrustedCIDRs:   targets.trustedCIDRs,
@@ -509,6 +517,12 @@ func (h *Handlers) runNavigate(w http.ResponseWriter, r *http.Request, ex navExe
 				return
 			}
 		}
+		if ex.isNewTab && errors.Is(navErr, context.DeadlineExceeded) {
+			httpx.Error(w, http.StatusServiceUnavailable, fmt.Errorf(
+				"new tab did not load in time — the browser may be out of memory or overloaded; "+
+					"close tabs or restart the instance with `pinchtab server restart`"))
+			return
+		}
 		navigateErrorWithHint(w, classifyNavigateError(navErr), navErr, ex.url)
 		return
 	}
@@ -608,6 +622,11 @@ type navigateBrowserOptions struct {
 type staticFirstNavigator interface {
 	StaticFirstNavigate() bool
 }
+
+// newTabNavCeiling caps the default time a new-tab navigation will wait before
+// failing, so an out-of-memory / wedged renderer surfaces quickly instead of
+// hanging the full NavigateTimeout. Explicit per-request timeouts override it.
+const newTabNavCeiling = 30 * time.Second
 
 func (h *Handlers) navigateNewTabBrowser(w http.ResponseWriter, r *http.Request, opts navigateBrowserOptions) {
 	// Create a blank tab first so the requested URL becomes the first

--- a/internal/handlers/navigation_idpi_hint_test.go
+++ b/internal/handlers/navigation_idpi_hint_test.go
@@ -1,0 +1,24 @@
+package handlers
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestIDPIAllowlistHint(t *testing.T) {
+	hint := idpiAllowlistHint("https://example.com/some/path")
+	if !strings.Contains(hint, "example.com") {
+		t.Errorf("hint should name the blocked host; got %q", hint)
+	}
+	if !strings.Contains(hint, "security.allowedDomains") {
+		t.Errorf("hint should name the allowlist config key; got %q", hint)
+	}
+	if !strings.Contains(hint, "server restart") {
+		t.Errorf("hint should remind the user to restart; got %q", hint)
+	}
+
+	// Hostless targets (e.g. about:blank) can't be allowlisted, so no hint.
+	if got := idpiAllowlistHint("about:blank"); got != "" {
+		t.Errorf("expected empty hint for hostless url; got %q", got)
+	}
+}

--- a/internal/handlers/navigation_idpi_hint_test.go
+++ b/internal/handlers/navigation_idpi_hint_test.go
@@ -16,9 +16,27 @@ func TestIDPIAllowlistHint(t *testing.T) {
 	if !strings.Contains(hint, "server restart") {
 		t.Errorf("hint should remind the user to restart; got %q", hint)
 	}
+	// Must be copy-paste-safe: no "…" placeholder (which users paste literally),
+	// and it should preserve existing domains via a `config get` append.
+	if strings.ContainsRune(hint, '…') {
+		t.Errorf("hint must not contain the … placeholder; got %q", hint)
+	}
+	if !strings.Contains(hint, "config get security.allowedDomains") {
+		t.Errorf("hint should append to existing domains via config get; got %q", hint)
+	}
 
 	// Hostless targets (e.g. about:blank) can't be allowlisted, so no hint.
 	if got := idpiAllowlistHint("about:blank"); got != "" {
 		t.Errorf("expected empty hint for hostless url; got %q", got)
+	}
+}
+
+func TestIDPIScannerHint(t *testing.T) {
+	hint := idpiScannerHint()
+	if !strings.Contains(hint, "strictMode") {
+		t.Errorf("scanner hint should point at strictMode; got %q", hint)
+	}
+	if !strings.Contains(hint, "server restart") {
+		t.Errorf("scanner hint should remind the user to restart; got %q", hint)
 	}
 }

--- a/internal/handlers/snapshot_idpi.go
+++ b/internal/handlers/snapshot_idpi.go
@@ -44,7 +44,7 @@ func (h *Handlers) scanSnapshotIDPI(w http.ResponseWriter, flat []bridge.A11yNod
 	idpi := h.IDPIGuard.ScanContent(sb.String())
 	if idpi.Blocked {
 		httpx.Error(w, http.StatusForbidden,
-			fmt.Errorf("snapshot blocked by IDPI scanner: %s", idpi.Reason))
+			fmt.Errorf("snapshot blocked by IDPI scanner: %s%s", idpi.Reason, idpiScannerHint()))
 		out.Blocked = true
 		return out
 	}

--- a/internal/handlers/text.go
+++ b/internal/handlers/text.go
@@ -116,7 +116,7 @@ func (h *Handlers) writeTextResponse(w http.ResponseWriter, r *http.Request, tCt
 	// IDPI: scan extracted text for injection patterns and optionally wrap.
 	result := h.ContentGuard.Scan(text, url)
 	if result.Blocked {
-		httpx.Error(w, http.StatusForbidden, fmt.Errorf("content blocked by IDPI scanner: %s", result.BlockReason))
+		httpx.Error(w, http.StatusForbidden, fmt.Errorf("content blocked by IDPI scanner: %s%s", result.BlockReason, idpiScannerHint()))
 		return
 	}
 	result.SetHeaders(w)

--- a/internal/orchestrator/browser_preflight.go
+++ b/internal/orchestrator/browser_preflight.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/pinchtab/pinchtab/internal/browsers"
 	"github.com/pinchtab/pinchtab/internal/browsers/runtimekit"
-	"github.com/pinchtab/pinchtab/internal/config"
 )
 
 // BrowserUnavailableReason reports whether the request's target browser has no
@@ -18,36 +17,36 @@ import (
 // opaque-503 cold start surfaced by install-UX testing, on the API path as well
 // as the CLI.
 //
-// It deliberately speaks only to the simple default/single-provider case. An
-// explicit per-request browser, a multi-target config, or a CDP attach all fall
-// through (return false) so existing behavior and HTTP error mapping are
-// unchanged. It mirrors the launch-time resolution in bridge/runtime.InitBrowser
-// (explicit browser.binary wins over discovery) so it can't diverge from what
-// the instance would actually try to launch.
+// It deliberately avoids explicit per-request browser overrides, since those may
+// select a different target/provider than the instance's default launch path.
+// For the normal implicit path it mirrors the launch-time resolution in
+// bridge/runtime.InitBrowser, including default-target promotion, so it can't
+// diverge from what the instance would actually try to launch.
 func (o *Orchestrator) BrowserUnavailableReason(r *http.Request) (string, bool) {
 	if o == nil || o.runtimeCfg == nil {
 		return "", false
 	}
-	if ExtractRequestedBrowser(r) != "" || len(o.runtimeCfg.Targets) > 0 {
+	if ExtractRequestedBrowser(r) != "" {
 		return "", false
 	}
 	if strings.TrimSpace(o.runtimeCfg.CDPAttachURL) != "" {
 		return "", false // attaching to an external CDP endpoint; no local binary needed
 	}
-	provider := config.NormalizeBrowser(o.runtimeCfg.DefaultBrowser)
+	effective := runtimekit.ResolveEffectiveBrowser(o.runtimeCfg)
+	provider := effective.ID
 	if _, ok := browsers.Get(provider); !ok {
 		return "", false
 	}
-	if override := strings.TrimSpace(o.runtimeCfg.BrowserBinary); override != "" {
+	if override := strings.TrimSpace(effective.Binary); override != "" {
 		if info, err := os.Stat(override); err != nil || info.IsDir() {
-			return fmt.Sprintf("configured browser.binary does not point at a usable executable: %s — "+
-				"set it to a real browser or unset it for auto-discovery (run `pinchtab doctor`)", override), true
+			return fmt.Sprintf("configured browser executable does not point at a usable executable: %s — "+
+				"set the active browser config to a real browser or unset it for auto-discovery (run `pinchtab doctor`)", override), true
 		}
 		return "", false
 	}
-	if runtimekit.FindBrowserBinary(provider) == "" {
+	if effective.Binary == "" {
 		return fmt.Sprintf("no %s browser found on this host — install Chrome/Chromium "+
-			"(e.g. `apt-get install -y chromium`) or set browser.binary (run `pinchtab doctor`)", provider), true
+			"(e.g. `apt-get install -y chromium`) or set a browser binary in config (run `pinchtab doctor`)", provider), true
 	}
 	return "", false
 }

--- a/internal/orchestrator/browser_preflight.go
+++ b/internal/orchestrator/browser_preflight.go
@@ -1,0 +1,53 @@
+package orchestrator
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/pinchtab/pinchtab/internal/browsers"
+	"github.com/pinchtab/pinchtab/internal/browsers/runtimekit"
+	"github.com/pinchtab/pinchtab/internal/config"
+)
+
+// BrowserUnavailableReason reports whether the request's target browser has no
+// resolvable binary, with a user-facing reason. It lets the proxy fail fast and
+// clearly instead of polling into a generic "instance not ready after 10s"
+// timeout when the real problem is simply that no browser is installed — the
+// opaque-503 cold start surfaced by install-UX testing, on the API path as well
+// as the CLI.
+//
+// It deliberately speaks only to the simple default/single-provider case. An
+// explicit per-request browser, a multi-target config, or a CDP attach all fall
+// through (return false) so existing behavior and HTTP error mapping are
+// unchanged. It mirrors the launch-time resolution in bridge/runtime.InitBrowser
+// (explicit browser.binary wins over discovery) so it can't diverge from what
+// the instance would actually try to launch.
+func (o *Orchestrator) BrowserUnavailableReason(r *http.Request) (string, bool) {
+	if o == nil || o.runtimeCfg == nil {
+		return "", false
+	}
+	if ExtractRequestedBrowser(r) != "" || len(o.runtimeCfg.Targets) > 0 {
+		return "", false
+	}
+	if strings.TrimSpace(o.runtimeCfg.CDPAttachURL) != "" {
+		return "", false // attaching to an external CDP endpoint; no local binary needed
+	}
+	provider := config.NormalizeBrowser(o.runtimeCfg.DefaultBrowser)
+	if _, ok := browsers.Get(provider); !ok {
+		return "", false
+	}
+	if override := strings.TrimSpace(o.runtimeCfg.BrowserBinary); override != "" {
+		if info, err := os.Stat(override); err != nil || info.IsDir() {
+			return fmt.Sprintf("configured browser.binary does not point at a usable executable: %s — "+
+				"set it to a real browser or unset it for auto-discovery (run `pinchtab doctor`)", override), true
+		}
+		return "", false
+	}
+	if runtimekit.FindBrowserBinary(provider) == "" {
+		return fmt.Sprintf("no %s browser found on this host — install Chrome/Chromium "+
+			"(e.g. `apt-get install -y chromium`) or set browser.binary (run `pinchtab doctor`)", provider), true
+	}
+	return "", false
+}

--- a/internal/orchestrator/browser_preflight_test.go
+++ b/internal/orchestrator/browser_preflight_test.go
@@ -1,0 +1,74 @@
+package orchestrator
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pinchtab/pinchtab/internal/config"
+)
+
+func TestBrowserUnavailableReason(t *testing.T) {
+	req := func(target string) *http.Request {
+		return httptest.NewRequest(http.MethodGet, target, nil)
+	}
+	existing := filepath.Join(t.TempDir(), "chrome")
+	if err := os.WriteFile(existing, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("missing browser.binary override is reported", func(t *testing.T) {
+		o := &Orchestrator{runtimeCfg: &config.RuntimeConfig{
+			DefaultBrowser: "chrome",
+			BrowserBinary:  filepath.Join(t.TempDir(), "missing"),
+		}}
+		reason, unavailable := o.BrowserUnavailableReason(req("/text?url=http://x/"))
+		if !unavailable {
+			t.Fatal("expected a missing override to be reported unavailable")
+		}
+		if reason == "" {
+			t.Error("expected a non-empty reason")
+		}
+	})
+
+	t.Run("existing override is available", func(t *testing.T) {
+		o := &Orchestrator{runtimeCfg: &config.RuntimeConfig{
+			DefaultBrowser: "chrome",
+			BrowserBinary:  existing,
+		}}
+		if _, unavailable := o.BrowserUnavailableReason(req("/text?url=http://x/")); unavailable {
+			t.Error("an existing override binary should be available")
+		}
+	})
+
+	t.Run("explicit per-request browser falls through", func(t *testing.T) {
+		o := &Orchestrator{runtimeCfg: &config.RuntimeConfig{
+			DefaultBrowser: "chrome",
+			BrowserBinary:  filepath.Join(t.TempDir(), "missing"),
+		}}
+		// An explicit ?browser= override must not be short-circuited here.
+		if _, unavailable := o.BrowserUnavailableReason(req("/text?browser=chrome&url=http://x/")); unavailable {
+			t.Error("explicit per-request browser should fall through, not fast-fail")
+		}
+	})
+
+	t.Run("external CDP attach falls through", func(t *testing.T) {
+		o := &Orchestrator{runtimeCfg: &config.RuntimeConfig{
+			DefaultBrowser: "chrome",
+			BrowserBinary:  filepath.Join(t.TempDir(), "missing"),
+			CDPAttachURL:   "http://127.0.0.1:9222",
+		}}
+		if _, unavailable := o.BrowserUnavailableReason(req("/text?url=http://x/")); unavailable {
+			t.Error("CDP attach needs no local binary; should fall through")
+		}
+	})
+
+	t.Run("nil config is safe", func(t *testing.T) {
+		o := &Orchestrator{}
+		if _, unavailable := o.BrowserUnavailableReason(req("/text")); unavailable {
+			t.Error("nil runtimeCfg must not report unavailable")
+		}
+	})
+}

--- a/internal/orchestrator/browser_preflight_test.go
+++ b/internal/orchestrator/browser_preflight_test.go
@@ -43,6 +43,21 @@ func TestBrowserUnavailableReason(t *testing.T) {
 		}
 	})
 
+	t.Run("default target binary is available", func(t *testing.T) {
+		o := &Orchestrator{runtimeCfg: &config.RuntimeConfig{
+			DefaultBrowser: config.BrowserChrome,
+			Targets: config.BrowserTargetsConfig{
+				"only": {
+					Provider: config.BrowserCloak,
+					Binary:   existing,
+				},
+			},
+		}}
+		if _, unavailable := o.BrowserUnavailableReason(req("/text?url=http://x/")); unavailable {
+			t.Error("an existing default-target binary should be available")
+		}
+	})
+
 	t.Run("explicit per-request browser falls through", func(t *testing.T) {
 		o := &Orchestrator{runtimeCfg: &config.RuntimeConfig{
 			DefaultBrowser: "chrome",

--- a/internal/server/helpers.go
+++ b/internal/server/helpers.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/pinchtab/pinchtab/internal/httpx"
@@ -35,10 +36,21 @@ func ProbeHealth(url string, timeout time.Duration, headers map[string]string) (
 	return resp.StatusCode, b, true
 }
 
+func AuthorizationHeaderValue(token string) string {
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return ""
+	}
+	if strings.HasPrefix(token, "ses_") {
+		return "Session " + token
+	}
+	return "Bearer " + token
+}
+
 func CheckPinchTabRunning(port, token string) bool {
 	headers := map[string]string{}
-	if token != "" {
-		headers["Authorization"] = "Bearer " + token
+	if auth := AuthorizationHeaderValue(token); auth != "" {
+		headers["Authorization"] = auth
 	}
 	status, _, reachable := ProbeHealth(fmt.Sprintf("http://localhost:%s/health", port), 500*time.Millisecond, headers)
 	return reachable && status == 200
@@ -91,8 +103,8 @@ func ShutdownServer(port, token string) error {
 	if err != nil {
 		return fmt.Errorf("build request: %w", err)
 	}
-	if token != "" {
-		req.Header.Set("Authorization", "Bearer "+token)
+	if auth := AuthorizationHeaderValue(token); auth != "" {
+		req.Header.Set("Authorization", auth)
 	}
 	resp, err := client.Do(req)
 	if err != nil {

--- a/internal/server/helpers_test.go
+++ b/internal/server/helpers_test.go
@@ -6,6 +6,26 @@ import (
 	"github.com/pinchtab/pinchtab/internal/routes"
 )
 
+func TestAuthorizationHeaderValue(t *testing.T) {
+	tests := []struct {
+		name  string
+		token string
+		want  string
+	}{
+		{name: "empty", token: "", want: ""},
+		{name: "bearer token", token: "server-token", want: "Bearer server-token"},
+		{name: "session token", token: "ses_token123", want: "Session ses_token123"},
+		{name: "trimmed session token", token: "  ses_token123  ", want: "Session ses_token123"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := AuthorizationHeaderValue(tt.token); got != tt.want {
+				t.Fatalf("AuthorizationHeaderValue(%q) = %q, want %q", tt.token, got, tt.want)
+			}
+		})
+	}
+}
+
 // TestDefaultProxyShorthandsAreCatalogRoutes guards against the default-proxy
 // allowlist drifting from the shared route catalog: every forwarded route must
 // be a real catalog route (or the management GET /tabs handled separately), so a

--- a/internal/strategy/autorestart/handlers.go
+++ b/internal/strategy/autorestart/handlers.go
@@ -44,6 +44,19 @@ func (s *Strategy) ensureRunning(r *http.Request) (string, int, error) {
 	if s.orch == nil {
 		return "", 503, fmt.Errorf("no orchestrator configured")
 	}
+	// Fail fast when nothing is running yet *because* no browser is resolvable:
+	// return the real cause now instead of polling for 10s into a generic
+	// "instance not ready" timeout. This generalizes the CLI nav preflight to the
+	// HTTP API and any command. The browser probe only runs when the instance
+	// isn't already up, so steady-state proxied requests are untouched.
+	if t, _, err := s.orch.FirstRunningURLForRequest(r); err == nil && t != "" {
+		return t, 0, nil
+	} else if err == nil {
+		if reason, unavailable := s.orch.BrowserUnavailableReason(r); unavailable {
+			return "", http.StatusServiceUnavailable, errors.New(reason)
+		}
+	}
+
 	var lastStatus int
 	target, err := readiness.WaitUntil(context.Background(), instanceReadyWait, 200*time.Millisecond,
 		func() (string, bool, error) {

--- a/tests/install-ux/.gitignore
+++ b/tests/install-ux/.gitignore
@@ -1,0 +1,2 @@
+results/
+.bin/

--- a/tests/install-ux/Dockerfile.base
+++ b/tests/install-ux/Dockerfile.base
@@ -1,0 +1,5 @@
+# No-browser base for the install-UX personas that start on a fresh machine with
+# no browser installed (S-B, S-D). curl + ca-certificates only.
+FROM debian:stable-slim
+RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*

--- a/tests/install-ux/PERSONAS.md
+++ b/tests/install-ux/PERSONAS.md
@@ -1,0 +1,23 @@
+# Onboarding persona × condition × goal matrix
+
+Goal: pressure-test new-user onboarding. A blind agent simulates each persona reaching a
+first-step goal using only user-facing docs, in the persona's container.
+
+| ID | Container | Persona (skill) | Starting condition | First-step goal | Primarily probes |
+|----|-----------|-----------------|--------------------|-----------------|------------------|
+| S-A | `ptux-sa` | Impatient first-timer (low) | chromium present | open example.com, read title | happy path + IDPI block for a non-technical user |
+| S-B | `ptux-sb` | Backend dev (high) | **no browser** | scrape a page's heading | no-browser cold start, scraping flow |
+| S-C | `ptux-sc` | Privacy researcher (med) | chromium present | browse the **public** web | IDPI allowlist / guards journey, security legibility |
+| S-D | `ptux-sd` | DevOps / CI (high) | **no browser, minimal** | scriptable title (JSON/exit codes, restart) | scriptability, restart cleanliness |
+| S-E | `ptux-se` | Mis-set config (med) | chromium + **bogus `browser.binary`** | get nav working again | diagnosability (doctor), recovery |
+| S-F | `ptux-sf` | API integrator (high) | chromium + curl | open a page via the **HTTP API** | API discoverability, auth/token UX |
+
+## Per-scenario record (each agent returns)
+Chronological friction log → for each step: command, key output (quoted), user
+interpretation, could-proceed-from-the-messaging-alone (yes/partial/no), one-line fix.
+Then: goal achieved? top friction points; onboarding verdict for that persona.
+
+## Synthesis (after a run)
+- Cross-persona friction table (recurring vs persona-specific).
+- Ranked onboarding improvements scoped to what's fixable in this repo.
+- Validation that prior fixes still hold under persona pressure.

--- a/tests/install-ux/README.md
+++ b/tests/install-ux/README.md
@@ -1,0 +1,39 @@
+# PinchTab onboarding / install-UX persona lane
+
+Agent-driven tests of the **new-user onboarding experience**. Each scenario pairs a user
+persona (skill level + intent) with a starting condition and a first-step goal, then a
+**blind agent** simulates that user reaching the goal using ONLY the user-facing docs, in a
+fresh container. We collect friction and turn it into fixes.
+
+This is NOT a CI unit test — it needs Docker plus an LLM agent runtime (e.g. Claude
+subagents) to play the personas. The scenario definitions, container provisioning, and agent
+brief here make it repeatable.
+
+## How to run
+
+```bash
+# 1. Provision one clean container per persona (each with its starting condition)
+tests/install-ux/setup.sh
+
+# 2. For each persona, launch a blind agent with:
+#      - tests/install-ux/subagent-context.md  (shared rules + the persona's brief)
+#      - the persona's container name (e.g. ptux-sa)
+#    The agent operates the container via `docker exec <name> bash -lc '...'`,
+#    reads ONLY user-facing docs (README.md, skills/pinchtab/SKILL.md, docs/**),
+#    and returns a friction log.
+
+# 3. Tear down
+docker rm -f ptux-sa ptux-sb ptux-sc ptux-sd ptux-se ptux-sf
+```
+
+## Files
+- `PERSONAS.md` — the persona × condition × goal matrix.
+- `setup.sh` — provisions the per-persona containers with their starting conditions.
+- `subagent-context.md` — shared blind-agent rules + the per-persona briefs to hand each agent.
+
+## What good looks like
+Every persona should reach its goal, and — critically — recover from each obstacle using the
+tool's OWN output/docs (no guessing, no source-reading). The friction log scores each step
+`yes/partial/no` on "could proceed from the messaging alone." See the repo's commit history
+for fixes that came out of earlier runs (no-browser guidance, IDPI remediation, session
+auto-start, `config --help` discoverability, etc.).

--- a/tests/install-ux/setup.sh
+++ b/tests/install-ux/setup.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Provision one clean container per onboarding persona, each with its starting
+# condition. Then drive each with a blind agent using subagent-context.md.
+set -euo pipefail
+
+REPO="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+HERE="$REPO/tests/install-ux"
+cd "$REPO"
+
+case "$(uname -m)" in
+  aarch64|arm64) GOARCH=arm64 ;;
+  x86_64|amd64)  GOARCH=amd64 ;;
+  *) echo "unsupported arch $(uname -m)"; exit 1 ;;
+esac
+
+echo "[ux] building linux/$GOARCH pinchtab binary..."
+mkdir -p "$HERE/.bin"
+CGO_ENABLED=0 GOOS=linux GOARCH="$GOARCH" go build -ldflags="-s -w" -o "$HERE/.bin/pinchtab" ./cmd/pinchtab
+
+echo "[ux] building images..."
+docker build -q -f "$REPO/tests/soak/Dockerfile" -t pinchtab-ux-browser "$REPO/tests/soak" >/dev/null  # chromium + curl
+docker build -q -f "$HERE/Dockerfile.base" -t pinchtab-ux-base "$HERE" >/dev/null                       # no browser
+
+mk(){ # name image
+  docker rm -f "$1" >/dev/null 2>&1 || true
+  docker run -d --name "$1" --shm-size=512m "$2" sleep infinity >/dev/null
+  docker cp "$HERE/.bin/pinchtab" "$1:/usr/local/bin/pinchtab" >/dev/null
+  docker exec "$1" chmod +x /usr/local/bin/pinchtab
+}
+
+mk ptux-sa pinchtab-ux-browser   # impatient first-timer, browser present
+mk ptux-sb pinchtab-ux-base      # backend dev, NO browser
+mk ptux-sc pinchtab-ux-browser   # privacy researcher, browser present
+mk ptux-sd pinchtab-ux-base      # devops/CI, minimal, NO browser
+mk ptux-se pinchtab-ux-browser   # mis-set browser.binary
+mk ptux-sf pinchtab-ux-browser   # API integrator (curl present)
+
+# S-E: pre-set a bogus browser.binary in the DEFAULT config the agent will read.
+docker exec ptux-se sh -c 'pinchtab config init >/dev/null 2>&1 && pinchtab config set browser.binary /opt/not-a-real-chrome >/dev/null 2>&1'
+
+echo "[ux] persona containers ready:"
+for c in ptux-sa ptux-sb ptux-sc ptux-sd ptux-se ptux-sf; do
+  br=$(docker exec "$c" sh -c 'command -v chromium >/dev/null && echo chromium || echo NONE')
+  printf "  %-9s browser=%s\n" "$c" "$br"
+done
+echo "[ux] now launch a blind agent per persona using tests/install-ux/subagent-context.md"

--- a/tests/install-ux/subagent-context.md
+++ b/tests/install-ux/subagent-context.md
@@ -1,0 +1,59 @@
+# Blind persona agent — context
+
+Hand this (plus ONE persona brief from the table below) to an agent to simulate a new
+PinchTab user. Provision the containers first with `tests/install-ux/setup.sh`.
+
+## Shared rules (apply to every persona)
+
+You are role-playing a PERSONA using PinchTab for the first time. Stay in character and
+report friction.
+
+**Your machine** is the running container named in your brief (e.g. `ptux-sa`). Run every
+command by wrapping it:
+
+    docker exec <CONTAINER> bash -lc '<command>'
+
+Files, installed packages, and background processes persist between calls; shell env does
+NOT (re-export or use absolute values). Background a long-running server with `nohup ... &`.
+
+**What you may read** (on the host repo) — user-facing docs ONLY: `README.md`,
+`skills/pinchtab/SKILL.md`, and anything under `docs/` they point to. You MUST NOT read
+source code (`internal/`, `cmd/`, `*.go`), tests, or any scratch/tmp path. You are a user
+who has only the docs + whatever the CLI/API prints back.
+
+**Rules:** use only documented commands and what the tool tells you. On an error, consult
+the docs and the tool's own output first — do NOT read source. For each obstacle record
+whether PinchTab's OWN output/docs led you to the fix, or you had to guess. Timebox; if
+blocked after exhausting docs + CLI output, record it and stop.
+
+**Deliverable** (your final message): a chronological friction log — per step: the command,
+key output (quoted/trimmed), your interpretation AS THIS PERSONA, could-you-proceed-from-the-
+messaging-alone (yes/partial/no), one-line fix. Then: goal achieved? top friction points
+(worst first); onboarding verdict for this persona (1-2 sentences). Quote real output.
+
+## Persona briefs
+
+- **S-A — `ptux-sa` — impatient non-technical first-timer (low skill).** You paste documented
+  commands literally and lose patience fast; you don't know terms like "headless"/"allowlist".
+  Goal: open `https://example.com` and tell me its page title.
+
+- **S-B — `ptux-sb` — backend dev on a fresh headless server (high skill), no browser
+  installed.** You improvise but expect good tooling. Goal: scrape the main heading / visible
+  text of a simple web page.
+
+- **S-C — `ptux-sc` — privacy-conscious researcher (medium skill), browser present.** You want
+  to understand the security posture before loosening it. Goal: successfully browse the PUBLIC
+  web — load a real public site and read something off it — configuring whatever is required.
+
+- **S-D — `ptux-sd` — DevOps engineer wiring CI (high skill), minimal container, no browser.**
+  You value reproducibility, JSON output, stable exit codes, clean restarts. Goal: reliably
+  get a page's title in a scriptable way (prefer JSON/exit codes), and restart the server once
+  to confirm it comes back cleanly.
+
+- **S-E — `ptux-se` — developer who previously fiddled with config (medium skill).** A browser
+  is available but navigation is failing; you don't remember what you changed. Goal: get
+  navigation working again. (Does the tool DIAGNOSE the misconfig and tell you the fix?)
+
+- **S-F — `ptux-sf` — AI-tooling engineer integrating over the HTTP API (high skill),** browser
+  + curl present. Goal: using the documented HTTP API (prefer `curl` over `pinchtab nav`), bring
+  up the control plane, authenticate, open a page, and read its title via the API.

--- a/tests/soak/.gitignore
+++ b/tests/soak/.gitignore
@@ -1,0 +1,2 @@
+results/
+.bin/

--- a/tests/soak/AUTORECOVERY-DESIGN.md
+++ b/tests/soak/AUTORECOVERY-DESIGN.md
@@ -1,0 +1,35 @@
+# Design: auto-recover from renderer-OOM degradation (follow-up)
+
+Surfaced by `tests/soak/burst.sh`: under memory pressure Chrome OOM-kills a *renderer* but
+the main browser process stays alive, so the instance is **functionally degraded** (new tabs
+fail) yet the control plane never recovers it. In the burst run, 7/7 OOMs required an external
+`pinchtab server restart`. (The 60s new-tab hang itself is already fixed — new-tab creation
+now fails fast with a `503` naming OOM.)
+
+## Root cause
+The orchestrator emits crash events only at startup and process-exit, never continuously at
+runtime:
+- startup probe → `instance.error` (`internal/orchestrator/health.go`)
+- process exit → `instance.stopped` (`finalizeInstanceExit`)
+
+A running-but-degraded child (process alive, renderer dead) matches neither, so the autorestart
+strategy — which acts only on `instance.error`/`instance.stopped`
+(`internal/strategy/autorestart/restart.go`) — never triggers. Instances are child processes
+(`orchestrator/runner.go`), so the degraded signal must cross the process boundary via the
+child's `/health`.
+
+## Plan (Option A — signal degraded → reuse the existing restart path)
+1. **Child reports degraded** (low risk): a consecutive new-tab-OOM-failure counter on
+   `Handlers`, incremented on the new-tab OOM 503 path in `runNavigate` (and the `CreateTab`
+   OOM path), reset on any successful tab creation; exposed as `degraded` in the instance
+   `/health`. Useful on its own (health reflects *functional capability*, not just liveness).
+2. **Orchestrator runtime monitor** (sensitive): a goroutine that polls each running managed
+   instance's `/health`; if `degraded` for K consecutive polls, emits `instance.error`.
+   Guard against restart storms: K-consecutive requirement + the existing `MaxRestarts`/backoff
+   in `handleCrash`; only the managed instance; skip while already restarting.
+3. **Autorestart**: no change — `instance.error` already routes to `handleCrash` → restart.
+
+## Verification
+Reuse `burst.sh` but remove its own `server restart`; assert the instance self-recovers
+(instance id changes once per OOM, `degraded` clears) without external intervention, and does
+NOT restart-storm under steady light load.

--- a/tests/soak/Dockerfile
+++ b/tests/soak/Dockerfile
@@ -1,0 +1,7 @@
+# Soak/stability test image: Chromium + Python (to serve fixtures) + curl.
+# The pinchtab binary and fixtures are injected at provision time by setup.sh, so
+# this image rarely needs rebuilding.
+FROM debian:stable-slim
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      chromium ca-certificates curl python3 \
+    && rm -rf /var/lib/apt/lists/*

--- a/tests/soak/README.md
+++ b/tests/soak/README.md
@@ -1,0 +1,57 @@
+# PinchTab browser soak / stability lane
+
+Docker-based stress tests for browser **stability, responsiveness, and recoverability**
+under sustained load. Not a unit test — requires Docker, runs for minutes to an hour, and
+is meant as a manual / nightly check. Drives the `chrome` provider (Debian Chromium) by
+default.
+
+## Quick start
+
+```bash
+# 1. Provision a container (builds the binary + image, starts a guards-down server)
+tests/soak/setup.sh
+
+# 2a. Stability soak — reuse ONE browser under mixed load for an hour
+tests/soak/soak.sh 3600
+
+# 2b. OR find the breaking point — unbounded tabs under a tight cap
+MEM_CAP=1g SHM=256m MAX_TABS=200 tests/soak/setup.sh
+tests/soak/burst.sh 1200
+
+# 3. Tear down
+docker rm -f pinchtab-soak
+```
+
+Results (CSV + summary) land in `tests/soak/results/` (git-ignored).
+
+## What each measures
+
+- **soak.sh** — reuses the *same* long-lived browser across cycles of randomized light /
+  heavy / fixture loads, grows & churns tabs, periodically idles a few minutes then
+  re-probes, and on unresponsiveness restarts + records recovery. Watches for responsiveness
+  drift, memory growth/leaks, and crashes over time.
+- **burst.sh** — opens a fresh heavy tab every ~1s with no eviction relief under a tight
+  memory cap, to drive the browser to its breaking point (renderer OOM) and exercise
+  recovery. Records the first breaking point (tabs/memory/OOM) and recovery success.
+
+## Tuning (env vars on setup.sh)
+
+| Var | Default | Use |
+|-----|---------|-----|
+| `MEM_CAP` | `2g` | lower (e.g. `1g`) to reach a breaking point sooner |
+| `SHM` | `1g` | Chrome shared memory; lower (`256m`) stresses harder |
+| `MAX_TABS` | `20` | raise (e.g. `200`) so tabs grow unbounded for burst.sh |
+| `HEAVY_MB` | `5` | size of the generated `heavy.html` |
+| `CPUS` | `2` | CPU limit |
+
+## Reference baseline (what "healthy" looks like)
+
+From a 1-hour soak at `maxTabs=20`, 2 GB cap, Chromium 149, arm64:
+- responsiveness flat at **p50 ~11 ms** (no drift, even after multi-minute idles)
+- memory self-bounds (LRU eviction at `maxTabs` caps tabs → caps memory); no leak
+- **zero** unresponsive events / failed navs over 120 cycles
+
+Breaking point only appears when `maxTabs` is raised past available RAM: ~**10 heavy tabs
+per GB** → Chrome renderer OOM. The control plane + existing tabs stay responsive (~16 ms);
+only *new-tab creation* fails. Recovery via `pinchtab server restart` is reliable (~6 s).
+See the in-tree design note for the auto-recovery follow-up.

--- a/tests/soak/burst.sh
+++ b/tests/soak/burst.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Escalated burst: grow tabs UNBOUNDED with heavy pages to find the browser's
+# breaking point and exercise recovery. Provision with a tight cap and a high tab
+# limit first, e.g.:  MEM_CAP=1g SHM=256m MAX_TABS=200 tests/soak/setup.sh
+#
+# Usage:  CONTAINER=pinchtab-soak FIX_PORT=8088 tests/soak/burst.sh [DURATION_SECONDS]
+set +e
+CN="${CONTAINER:-pinchtab-soak}"
+FIX="${FIX_PORT:-8088}"
+DURATION="${1:-1200}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RESULTS="${RESULTS_DIR:-$HERE/results}"; mkdir -p "$RESULTS"
+METRICS="$RESULTS/burst_metrics.csv"; SUMMARY="$RESULTS/burst_summary.txt"
+START=$(date +%s); DEADLINE=$((START + DURATION))
+
+HEAVY=("http://localhost:$FIX/heavy.html" https://en.wikipedia.org/wiki/Operating_system "http://localhost:$FIX/ecommerce.html" "http://localhost:$FIX/dashboard.html")
+
+timed(){ docker exec "$CN" sh -c 'S=$(date +%s%3N); { '"$1"' ; } >/dev/null 2>&1; rc=$?; E=$(date +%s%3N); echo "$((E-S))|$rc"'; }
+ex(){ docker exec "$CN" sh -c "$1" 2>/dev/null; }
+tabcount(){ ex 'pinchtab tab --json' | grep -o '"id"' | wc -l | tr -d ' '; }
+cmem(){ docker stats --no-stream --format '{{.MemUsage}}' "$CN" 2>/dev/null | awk '{print $1}' | sed 's/MiB//;s/GiB/*1024/' | bc 2>/dev/null | cut -d. -f1; }
+chromemem(){ ex "ps -o rss,comm 2>/dev/null | awk '/chrom/{s+=\$1} END{print int(s/1024)}'"; }
+oomflag(){ docker inspect "$CN" --format '{{.State.OOMKilled}}' 2>/dev/null; }
+
+echo "ts,elapsed_s,cycle,tabs,cmem_mb,chrome_mb,health_ms,health_ok,probe_ms,probe_ok,nav_ms,nav_ok,event" > "$METRICS"
+cycle=0; breaks=0; recoveries=0; failed_rec=0; peakmem=0; peaktabs=0; firstbreak=""
+
+echo "[burst] $CN for ${DURATION}s; metrics -> $METRICS"
+while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+  cycle=$((cycle+1))
+  IFS='|' read -r hms hrc <<<"$(timed 'pinchtab health')"
+  IFS='|' read -r pms prc <<<"$(timed 'pinchtab title')"
+  tabs=$(tabcount); [ -z "$tabs" ] && tabs=0
+  cm=$(cmem); [ -z "$cm" ] && cm=0; chm=$(chromemem); [ -z "$chm" ] && chm=0
+  [ "${cm:-0}" -gt "$peakmem" ] 2>/dev/null && peakmem=$cm
+  [ "${tabs:-0}" -gt "$peaktabs" ] 2>/dev/null && peaktabs=$tabs
+  hok=$([ "$hrc" = 0 ] && echo 1 || echo 0); pok=$([ "$prc" = 0 ] && echo 1 || echo 0)
+
+  u=${HEAVY[$((RANDOM%${#HEAVY[@]}))]}
+  IFS='|' read -r nms nrc <<<"$(timed "pinchtab nav $u --new-tab")"
+  nok=$([ "$nrc" = 0 ] && echo 1 || echo 0)
+
+  broke=0; { [ "$hrc" != 0 ] || [ "$prc" != 0 ] || [ "${pms:-99999}" -gt 20000 ] || [ "$nrc" != 0 ]; } && broke=1
+  if [ "$broke" = 1 ]; then
+    breaks=$((breaks+1)); oom=$(oomflag)
+    [ -z "$firstbreak" ] && firstbreak="cycle $cycle @ $(($(date +%s)-START))s: tabs=$tabs mem=${cm}MB chrome=${chm}MB oom=$oom (health_rc=$hrc title_rc=$prc title_ms=$pms nav_rc=$nrc)"
+    echo "$(date +%s),$(($(date +%s)-START)),$cycle,$tabs,$cm,$chm,$hms,$hok,$pms,$pok,$nms,$nok,BREAK(oom=$oom)" >> "$METRICS"
+    IFS='|' read -r rms rrc <<<"$(timed 'pinchtab server restart')"; sleep 8
+    IFS='|' read -r r2ms r2rc <<<"$(timed "pinchtab nav http://localhost:$FIX/article.html")"
+    if [ "$r2rc" = 0 ]; then recoveries=$((recoveries+1)); ev="RECOVERED(restart ${rms}ms, nav ${r2ms}ms)"; else failed_rec=$((failed_rec+1)); ev="RECOVERY-FAILED(rc=$r2rc)"; fi
+    echo "$(date +%s),$(($(date +%s)-START)),$cycle,$(tabcount),$(cmem),$(chromemem),-,-,-,-,-,-,$ev" >> "$METRICS"
+    sleep 2; continue
+  fi
+  echo "$(date +%s),$(($(date +%s)-START)),$cycle,$tabs,$cm,$chm,$hms,$hok,$pms,$pok,$nms,$nok,grow" >> "$METRICS"
+  sleep 1
+done
+
+{
+  echo "PinchTab BURST (escalated) summary"
+  echo "duration: $(($(date +%s)-START))s   cycles: $cycle"
+  echo "break events: $breaks   recovered: $recoveries   recovery-failed: $failed_rec"
+  echo "peak mem: ${peakmem}MB   peak tabs: $peaktabs"
+  echo "FIRST BREAKING POINT: ${firstbreak:-none (survived full run)}"
+} | tee "$SUMMARY"

--- a/tests/soak/setup.sh
+++ b/tests/soak/setup.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Provision a clean PinchTab soak container: cross-compile the binary for the
+# container arch, build the image, start the container under resource limits, and
+# bring up a fixture server + a guards-down PinchTab server.
+#
+# Env (all optional):
+#   CONTAINER   container name           (default: pinchtab-soak)
+#   MEM_CAP     docker --memory          (default: 2g)
+#   SHM         docker --shm-size        (default: 1g)
+#   CPUS        docker --cpus            (default: 2)
+#   MAX_TABS    instanceDefaults.maxTabs (default: 20 — raise to find the breaking point)
+#   FIX_PORT    fixture http port        (default: 8088)
+#   HEAVY_MB    approx size of heavy.html in MB (default: 5)
+set -euo pipefail
+
+CONTAINER="${CONTAINER:-pinchtab-soak}"
+MEM_CAP="${MEM_CAP:-2g}"
+SHM="${SHM:-1g}"
+CPUS="${CPUS:-2}"
+MAX_TABS="${MAX_TABS:-20}"
+FIX_PORT="${FIX_PORT:-8088}"
+HEAVY_MB="${HEAVY_MB:-5}"
+
+REPO="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+HERE="$REPO/tests/soak"
+cd "$REPO"
+
+case "$(uname -m)" in
+  aarch64|arm64) GOARCH=arm64 ;;
+  x86_64|amd64)  GOARCH=amd64 ;;
+  *) echo "unsupported arch $(uname -m)"; exit 1 ;;
+esac
+
+echo "[soak] building linux/$GOARCH pinchtab binary..."
+mkdir -p "$HERE/.bin"
+CGO_ENABLED=0 GOOS=linux GOARCH="$GOARCH" go build -ldflags="-s -w" -o "$HERE/.bin/pinchtab" ./cmd/pinchtab
+
+echo "[soak] building image..."
+docker build -q -f "$HERE/Dockerfile" -t pinchtab-soak-img "$HERE" >/dev/null
+
+echo "[soak] starting container '$CONTAINER' (mem=$MEM_CAP shm=$SHM cpus=$CPUS maxTabs=$MAX_TABS)..."
+docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+docker run -d --name "$CONTAINER" --shm-size="$SHM" --memory="$MEM_CAP" --cpus="$CPUS" \
+  pinchtab-soak-img sleep infinity >/dev/null
+
+docker cp "$HERE/.bin/pinchtab" "$CONTAINER:/usr/local/bin/pinchtab" >/dev/null
+docker exec "$CONTAINER" chmod +x /usr/local/bin/pinchtab
+docker cp "$REPO/tests/tools/fixtures" "$CONTAINER:/fixtures" >/dev/null
+
+echo "[soak] generating heavy.html (~${HEAVY_MB}MB)..."
+docker exec "$CONTAINER" python3 -c "
+rows=int(${HEAVY_MB}*8000)
+open('/fixtures/heavy.html','w').write('<html><body><table>'+''.join(f'<tr><td>{i}</td><td>lorem ipsum dolor sit amet {i}</td></tr>' for i in range(rows))+'</table>'+'<div>filler</div>'*int(${HEAVY_MB}*4000)+'</body></html>')
+import os; print('  heavy.html', round(os.path.getsize('/fixtures/heavy.html')/1e6,1),'MB')
+"
+
+docker exec -d "$CONTAINER" sh -c "cd /fixtures && python3 -m http.server $FIX_PORT --bind 127.0.0.1"
+sleep 1
+
+# Guards-down so public + heavy pages load without the IDPI allowlist getting in the way.
+docker exec "$CONTAINER" sh -c "
+  pinchtab config init >/dev/null 2>&1
+  pinchtab security down >/dev/null 2>&1
+  pinchtab config set instanceDefaults.maxTabs $MAX_TABS >/dev/null 2>&1
+  pinchtab config set security.allowedDomains 'localhost,127.0.0.1,::1,en.wikipedia.org,example.com,news.ycombinator.com' >/dev/null 2>&1
+"
+docker exec -d "$CONTAINER" sh -c 'pinchtab server -b >/tmp/srv.log 2>&1'
+sleep 3
+
+docker exec "$CONTAINER" sh -c "
+  echo '[soak] ready:'
+  pinchtab nav http://localhost:$FIX_PORT/heavy.html >/dev/null 2>&1 && echo '  heavy nav OK'
+  echo \"  instance: \$(pinchtab instances 2>&1 | head -1)\"
+  echo \"  maxTabs=\$(pinchtab config get instanceDefaults.maxTabs)  fixtures=http://localhost:$FIX_PORT\"
+"
+echo "[soak] container '$CONTAINER' ready. Run:  CONTAINER=$CONTAINER FIX_PORT=$FIX_PORT tests/soak/soak.sh 3600"

--- a/tests/soak/soak.sh
+++ b/tests/soak/soak.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Stability soak: reuse the SAME browser across cycles under randomized mixed load
+# (light / heavy / fixture pages), grow & churn tabs, periodically idle a few
+# minutes then re-probe, and on unresponsiveness attempt a restart + record whether
+# it recovered. Provision the container first with tests/soak/setup.sh.
+#
+# Usage:  CONTAINER=pinchtab-soak FIX_PORT=8088 tests/soak/soak.sh [DURATION_SECONDS]
+set +e
+CN="${CONTAINER:-pinchtab-soak}"
+FIX="${FIX_PORT:-8088}"
+DURATION="${1:-3600}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RESULTS="${RESULTS_DIR:-$HERE/results}"; mkdir -p "$RESULTS"
+METRICS="$RESULTS/soak_metrics.csv"; SUMMARY="$RESULTS/soak_summary.txt"
+START=$(date +%s); DEADLINE=$((START + DURATION))
+
+LIGHT=(https://example.com "http://localhost:$FIX/article.html" "http://localhost:$FIX/form.html" "http://localhost:$FIX/qa.html")
+HEAVY=("http://localhost:$FIX/heavy.html" https://en.wikipedia.org/wiki/Web_browser https://en.wikipedia.org/wiki/Operating_system https://news.ycombinator.com)
+FIXP=(article.html form.html ecommerce.html dashboard.html spa.html serp.html directory.html accordion.html iframe.html editor.html autocomplete.html wizard.html)
+
+timed(){ docker exec "$CN" sh -c 'S=$(date +%s%3N); { '"$1"' ; } >/dev/null 2>&1; rc=$?; E=$(date +%s%3N); echo "$((E-S))|$rc"'; }
+ex(){ docker exec "$CN" sh -c "$1" 2>/dev/null; }
+tabcount(){ ex 'pinchtab tab --json' | grep -o '"id"' | wc -l | tr -d ' '; }
+cmem(){ docker stats --no-stream --format '{{.MemUsage}}' "$CN" 2>/dev/null | awk '{print $1}' | sed 's/MiB//;s/GiB/*1024/' | bc 2>/dev/null | cut -d. -f1; }
+chromemem(){ ex "ps -o rss,comm 2>/dev/null | awk '/chrom/{s+=\$1} END{print int(s/1024)}'"; }
+
+echo "ts,elapsed_s,cycle,phase,tabs,cmem_mb,chrome_mb,health_ms,health_ok,probe_ms,probe_ok,action,note" > "$METRICS"
+cycle=0; fails=0; recoveries=0; failed_recoveries=0; peakmem=0; peaktabs=0; firstbreak=""
+log(){ echo "$(date +%s),$(($(date +%s)-START)),$cycle,$1,$2,$3,$4,$5,$6,$7,$8,$9,${10}" >> "$METRICS"; }
+
+echo "[soak] $CN for ${DURATION}s; metrics -> $METRICS"
+while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+  cycle=$((cycle+1))
+  IFS='|' read -r hms hrc <<<"$(timed 'pinchtab health')"
+  IFS='|' read -r pms prc <<<"$(timed 'pinchtab title')"
+  tabs=$(tabcount); [ -z "$tabs" ] && tabs=0
+  cm=$(cmem); [ -z "$cm" ] && cm=0
+  chm=$(chromemem); [ -z "$chm" ] && chm=0
+  [ "${cm:-0}" -gt "$peakmem" ] 2>/dev/null && peakmem=$cm
+  [ "${tabs:-0}" -gt "$peaktabs" ] 2>/dev/null && peaktabs=$tabs
+  hok=$([ "$hrc" = 0 ] && echo 1 || echo 0); pok=$([ "$prc" = 0 ] && echo 1 || echo 0)
+  unresp=0; { [ "$hrc" != 0 ] || [ "$prc" != 0 ] || [ "${pms:-99999}" -gt 20000 ]; } && unresp=1
+
+  if [ "$unresp" = 1 ]; then
+    fails=$((fails+1)); [ -z "$firstbreak" ] && firstbreak="cycle $cycle @ $(($(date +%s)-START))s (tabs=$tabs,mem=${cm}MB)"
+    IFS='|' read -r rms rrc <<<"$(timed 'pinchtab server restart')"; sleep 6
+    IFS='|' read -r r2ms r2rc <<<"$(timed 'pinchtab title')"
+    if [ "$r2rc" = 0 ]; then recoveries=$((recoveries+1)); note="UNRESPONSIVE→RECOVERED(restart ${rms}ms,probe ${r2ms}ms)"; else failed_recoveries=$((failed_recoveries+1)); note="UNRESPONSIVE→RECOVERY-FAILED"; fi
+    log "probe" "$tabs" "$cm" "$chm" "$hms" "$hok" "$pms" "$pok" "recover" "$note"; continue
+  fi
+
+  r=$((RANDOM % 12)); action=""; note=""
+  if [ "$r" -lt 4 ]; then
+    u=${HEAVY[$((RANDOM%${#HEAVY[@]}))]}; nt=$([ $((RANDOM%2)) = 0 ] && echo --new-tab || echo ""); action="nav-heavy $nt"
+    IFS='|' read -r ams arc <<<"$(timed "pinchtab nav $u $nt")"; note="heavy ${ams}ms rc=$arc $u"
+  elif [ "$r" -lt 7 ]; then
+    u=${LIGHT[$((RANDOM%${#LIGHT[@]}))]}; action="nav-light"
+    IFS='|' read -r ams arc <<<"$(timed "pinchtab nav $u")"; note="light ${ams}ms rc=$arc"
+  elif [ "$r" -lt 9 ]; then
+    f=${FIXP[$((RANDOM%${#FIXP[@]}))]}; action="nav-fixture --new-tab"
+    IFS='|' read -r ams arc <<<"$(timed "pinchtab nav http://localhost:$FIX/$f --new-tab")"; note="fixture $f ${ams}ms rc=$arc"
+  elif [ "$r" -lt 10 ]; then
+    action="search"; IFS='|' read -r ams arc <<<"$(timed "pinchtab nav http://localhost:$FIX/serp.html && pinchtab text")"; note="search+extract ${ams}ms rc=$arc"
+  elif [ "$r" -lt 11 ]; then
+    if [ "$tabs" -gt 8 ]; then id=$(ex 'pinchtab tab --json' | grep -o '"id":"[^"]*"' | tail -1 | cut -d'"' -f4); ex "pinchtab close $id"; action="close-tab"; note="closed $id (tabs were $tabs)"; else action="extract"; IFS='|' read -r ams arc <<<"$(timed 'pinchtab snap')"; note="snap ${ams}ms rc=$arc"; fi
+  else
+    action="extract"; IFS='|' read -r ams arc <<<"$(timed 'pinchtab text')"; note="text ${ams}ms rc=$arc"
+  fi
+  log "load" "$tabs" "$cm" "$chm" "$hms" "$hok" "$pms" "$pok" "$action" "$note"
+
+  if [ $((cycle % 7)) = 0 ]; then
+    docker exec "$CN" python3 -c "import random;n=random.randint(8000,70000);open('/fixtures/heavy.html','w').write('<html><body><table>'+''.join(f'<tr><td>{i}</td><td>lorem {i}</td></tr>' for i in range(n))+'</table>'+'<div>x</div>'*random.randint(5000,30000)+'</body></html>')" 2>/dev/null
+  fi
+  if [ $((cycle % 10)) = 0 ]; then sleep $((120 + RANDOM % 120)); else sleep $((4 + RANDOM % 16)); fi
+done
+
+{
+  echo "PinchTab soak summary"
+  echo "duration: $(($(date +%s)-START))s   cycles: $cycle"
+  echo "unresponsive events: $fails   recovered: $recoveries   recovery-failed: $failed_recoveries"
+  echo "peak container mem: ${peakmem}MB   peak tabs: $peaktabs"
+  echo "first breaking point: ${firstbreak:-none (stable for full run)}"
+  echo "metrics: $METRICS"
+} | tee "$SUMMARY"


### PR DESCRIPTION
## Summary

- improve browser discovery, doctor diagnostics, and setup/onboarding UX
- make IDPI blocks and stale-security-config drift more actionable for operators
- fail fast on browser startup and new-tab hangs instead of timing out opaquely
- add install-UX and soak-lane test assets plus the follow-up fix for session-auth health probes and target-aware browser preflight

Fixes #583.

## What Changed

- improved browser discovery and `pinchtab doctor` behavior, including better CloakBrowser and Chrome checks
- added clearer CLI/setup flows:
  - `pinchtab version`
  - `pinchtab session create` auto-starts the server when needed
  - updated session/docs/help text to match the current token-print behavior
- made security/config drift visible from the CLI when the running server needs a restart to pick up changed policy
- added actionable remediation hints for IDPI domain and scanner blocks
- capped new-tab navigation waits so wedged or OOM browsers fail quickly with a useful message
- added browser-unavailable fast-fail handling on proxy/API startup paths
- warned on macOS when automation would fall back to the user's primary Google Chrome
- added install UX / soak docs and scripts for the new test lanes
- fixed the review follow-ups:
  - session-authenticated health/security probes now use `Authorization: Session ...`
  - browser preflight / unavailable checks now resolve the effective default target binary instead of ignoring `browser.targets.<name>.binary`

## Testing

- `go test ./...`
