### PR TITLE
fix(npm): resolve package version from dist/src installs

### DIFF
--- a/npm/src/download.ts
+++ b/npm/src/download.ts
@@ -3,15 +3,13 @@ import * as path from 'path';
 import * as http from 'http';
 import * as https from 'https';
 import * as crypto from 'crypto';
-import { detectPlatform, getBinaryName, getBinaryPath } from './platform';
+import { detectPlatform, getBinaryName, getBinaryPath, readPackageVersion } from './platform';
 
 const GITHUB_REPO = 'pinchtab/pinchtab';
 
-// Read version from package.json at build time
+// Resolve the published package version even when compiled code lives under dist/src.
 function getVersion(): string {
-  const pkgPath = path.join(__dirname, '..', 'package.json');
-  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
-  return pkg.version;
+  return readPackageVersion(__dirname);
 }
 
 // NOTE: HTTPS_PROXY / HTTP_PROXY are NOT honored — downloads go direct. A prior

--- a/npm/tests/mcp-wrapper.test.ts
+++ b/npm/tests/mcp-wrapper.test.ts
@@ -139,3 +139,21 @@ describe('MCP wrapper integration', () => {
     assert.ok(response.result?.serverInfo, 'expected serverInfo in response');
   });
 });
+
+describe('readPackageVersion', () => {
+  test('finds the package root version from a dist/src-style compiled directory', () => {
+    const packageRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'pinchtab-pkg-layout-'));
+    try {
+      const compiledDir = path.join(packageRoot, 'dist', 'src');
+      fs.mkdirSync(compiledDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(packageRoot, 'package.json'),
+        JSON.stringify({ name: 'pinchtab', version: '0.14.0-test' })
+      );
+
+      assert.strictEqual(readPackageVersion(compiledDir), '0.14.0-test');
+    } finally {
+      fs.rmSync(packageRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/dev-smoke.sh
+++ b/scripts/dev-smoke.sh
@@ -24,10 +24,12 @@ Filters:
   browser-parity       Alias for cloakbrowser
   cdp-attach           Run CDP attach smoke
   live-detection       Run advisory live detection smoke
+  npm-install          Package + install the npm wrapper in a clean container
 
 Defaults:
   ./dev smoke          Runs Docker smoke categories for supported providers:
-                       browser parity, CDP attach, and live detection
+                       browser parity, CDP attach, and live detection, plus the
+                       provider-independent npm install e2e
 
 Special cloakbrowser flags:
   --multi-target
@@ -60,7 +62,7 @@ append_unique() {
 
 is_named_smoke_filter() {
   case "$1" in
-    cloakbrowser|browser-parity|cdp-attach|live-detection)
+    cloakbrowser|browser-parity|cdp-attach|live-detection|npm-install)
       return 0
       ;;
     *)
@@ -74,7 +76,7 @@ append_smoke_filter() {
     cloakbrowser|browser-parity)
       append_unique "browser-parity"
       ;;
-    cdp-attach|live-detection)
+    cdp-attach|live-detection|npm-install)
       append_unique "$1"
       ;;
     *)
@@ -182,7 +184,7 @@ while [ "$#" -gt 0 ]; do
     cloakbrowser|browser-parity)
       append_smoke_filter "$1"
       ;;
-    cdp-attach|live-detection)
+    cdp-attach|live-detection|npm-install)
       append_smoke_filter "$1"
       ;;
     chrome|cloak|all)
@@ -253,6 +255,11 @@ run_live_detection() {
   run_step "$2" "Live detection smoke (${selected_provider})" bash scripts/docker-live-detection-smoke.sh --browser="$selected_provider"
 }
 
+run_npm_install() {
+  # Provider-agnostic: packages + installs the npm wrapper in a clean container.
+  run_step "$1" "npm install e2e (clean container)" bash scripts/docker-npm-install-smoke.sh
+}
+
 failures=0
 
 run_or_record() {
@@ -281,6 +288,9 @@ if [ "${#filters[@]}" -eq 0 ]; then
       run_or_record run_live_detection cloak 1
       ;;
   esac
+  # Provider-independent; runs once regardless of the selected browser. Allowed
+  # to skip (exit 77) when docker/network/release prerequisites are missing.
+  run_or_record run_npm_install 1
 else
   for filter in "${filters[@]}"; do
     case "$filter" in
@@ -297,6 +307,9 @@ else
         else
           run_or_record run_live_detection "$provider" 0
         fi
+        ;;
+      npm-install)
+        run_or_record run_npm_install 0
         ;;
       *)
         echo "${ERROR}unknown smoke filter: $filter${NC}" >&2

--- a/scripts/docker-npm-install-smoke.sh
+++ b/scripts/docker-npm-install-smoke.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# docker-npm-install-smoke.sh — Clean-room smoke for the published npm install path.
+#
+# Packages the npm wrapper and runs the real `npm install -g <tarball>` flow
+# inside a fresh node container, then boots the CLI and authenticates against
+# /health (npm/scripts/npm-cli-e2e.sh). This is the path that a published
+# `npm install -g pinchtab` actually takes — postinstall detects it is NOT a
+# source checkout, so it resolves the package version and downloads the matching
+# release binary. That version-resolution step (readPackageVersion over the
+# compiled dist/src layout) is what regressed in #602 and is only exercised on a
+# true published install, never in a source checkout, so unit tests alone miss
+# it.
+#
+# Why a container: it is a clean environment — no host node_modules, no host npm
+# global prefix, no host HOME state. The wrapper is packed and installed exactly
+# as an end user would get it. The host repo is never mutated (the version bump
+# for the binary download happens on a throwaway copy inside the container).
+#
+# The local source tree ships version 0.0.0, which has no release binary, so we
+# pack against the latest published release tag purely so postinstall has a real
+# binary to fetch. The wrapper CODE under test is still the local working tree.
+#
+# Skips (exit 77) — never a hard failure — when the environment cannot run it:
+#   - docker unavailable / daemon down
+#   - no vX.Y.Z release tag to pin the binary to
+#   - release assets unreachable (offline / release not published yet)
+#
+# Usage:
+#   ./dev smoke                       # runs as part of the default smoke group
+#   bash scripts/docker-npm-install-smoke.sh   # standalone
+#
+# Env overrides:
+#   PINCHTAB_NPM_SMOKE_NODE_IMAGE   Node image to pack/install in (default: node:22-bookworm)
+#   PINCHTAB_NPM_SMOKE_VERSION      Override the release version to pin/download
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+NODE_IMAGE="${PINCHTAB_NPM_SMOKE_NODE_IMAGE:-node:22-bookworm}"
+GITHUB_REPO="pinchtab/pinchtab"
+
+CONTAINER="pinchtab-npm-smoke-${RANDOM}${RANDOM}"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/pinchtab-npm-smoke.XXXXXX")"
+CONTAINER_STARTED=0
+
+cleanup() {
+  set +e
+  if [ "${CONTAINER_STARTED}" -eq 1 ]; then
+    docker rm -f "${CONTAINER}" >/dev/null 2>&1 || true
+  fi
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+skip() {
+  echo "SKIP: $*"
+  exit 77
+}
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || fail "$1 not found in PATH"
+}
+
+require_cmd git
+require_cmd tar
+require_cmd curl
+
+command -v docker >/dev/null 2>&1 || skip "docker not found in PATH"
+docker info >/dev/null 2>&1 || skip "docker daemon not available"
+
+# Pin the binary download to a real published release. The working-tree version
+# (0.0.0) has no release asset, so postinstall would 404 on the download for a
+# reason unrelated to the wrapper code we are testing.
+VERSION="${PINCHTAB_NPM_SMOKE_VERSION:-}"
+if [ -z "${VERSION}" ]; then
+  VERSION="$(git -C "${ROOT}" tag --list 'v*' --sort=-v:refname | head -1 | sed 's/^v//')"
+fi
+if [ -z "${VERSION}" ]; then
+  skip "no vX.Y.Z release tag found to resolve a download binary"
+fi
+
+# Preflight: are the release assets actually reachable? A clean skip when offline
+# or when the release has not been published yet keeps this out of the failure
+# column for environmental reasons.
+CHECKSUMS_URL="https://github.com/${GITHUB_REPO}/releases/download/v${VERSION}/checksums.txt"
+if ! curl -fsIL --max-time 20 -o /dev/null "${CHECKSUMS_URL}"; then
+  skip "release assets for v${VERSION} unreachable (offline or not yet published)"
+fi
+
+echo "Packaging npm wrapper (working tree) against release v${VERSION} in ${NODE_IMAGE}"
+
+# Clean export of the wrapper: tracked working-tree state minus build artifacts.
+# Nothing from the host node_modules/dist/tarballs comes along, so the container
+# rebuilds from a pristine state via `npm ci`. The repo layout is preserved (npm/
+# alongside skills/) because prepack's stage-skills.js copies the SKILL source
+# from the repo-root skills/ dir two levels above npm/scripts.
+tar -C "${ROOT}" \
+  --exclude='npm/node_modules' \
+  --exclude='npm/dist' \
+  --exclude='npm/pinchtab-*.tgz' \
+  -cf "${TMP_DIR}/pkg.tar" npm skills
+
+# The in-container recipe: extract, install deps from the lockfile, bump the
+# version to the pinned release, pack, then run the real global-install e2e.
+cat > "${TMP_DIR}/run.sh" <<'RECIPE'
+set -euo pipefail
+mkdir -p /work
+tar -xf /tmp/pkg.tar -C /work
+cd /work/npm
+
+echo "==> npm ci"
+npm ci
+
+echo "==> pin version to v${TARGET_VERSION} for the binary download"
+npm version "${TARGET_VERSION}" --no-git-tag-version --allow-same-version >/dev/null
+
+echo "==> npm pack"
+npm pack >/dev/null
+TARBALL="/work/npm/$(ls -t pinchtab-*.tgz | head -1)"
+echo "    packed ${TARBALL}"
+
+echo "==> npm install -g + CLI auth e2e"
+bash scripts/npm-cli-e2e.sh "${TARBALL}"
+RECIPE
+
+docker run -d --name "${CONTAINER}" "${NODE_IMAGE}" sleep 900 >/dev/null
+CONTAINER_STARTED=1
+
+docker cp "${TMP_DIR}/pkg.tar" "${CONTAINER}:/tmp/pkg.tar" >/dev/null
+docker cp "${TMP_DIR}/run.sh" "${CONTAINER}:/tmp/run.sh" >/dev/null
+
+if ! docker exec -e TARGET_VERSION="${VERSION}" "${CONTAINER}" bash /tmp/run.sh; then
+  fail "npm install e2e failed inside ${NODE_IMAGE}"
+fi
+
+echo ""
+echo "npm install e2e passed (packaged + installed v${VERSION} in a clean ${NODE_IMAGE} container)"


### PR DESCRIPTION
## Summary

- resolve npm package version by walking up from `dist/src` to the package root
- add a regression test covering the published tarball layout

## Testing

- npm run build
- npm test
- npm pack smoke check on `dist/src/download.js`

Fixes #602
