### PR TITLE
test: stabilize orchestrator attach harness

### DIFF
--- a/internal/orchestrator/handlers_instances_test.go
+++ b/internal/orchestrator/handlers_instances_test.go
@@ -534,6 +534,9 @@ func setupAttachTargetsOrchestrator(t *testing.T, runner *mockRunner) *Orchestra
 	old := processAliveFunc
 	processAliveFunc = func(pid int) bool { return pid > 0 }
 	t.Cleanup(func() { processAliveFunc = old })
+	if runner.newCmd == nil {
+		runner.newCmd = newBlockingMockCmdFactory(t)
+	}
 
 	o := NewOrchestratorWithRunner(t.TempDir(), runner)
 	o.ApplyRuntimeConfig(&config.RuntimeConfig{

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -454,7 +454,7 @@ func stubAttachBridgeHealthy(t *testing.T) {
 
 func TestOrchestrator_Attach(t *testing.T) {
 	stubAttachBridgeHealthy(t)
-	runner := &mockRunner{portAvail: true}
+	runner := &mockRunner{portAvail: true, newCmd: newBlockingMockCmdFactory(t)}
 	o := NewOrchestratorWithRunner(t.TempDir(), runner)
 	allowAttachForTest(o, []string{"ws"}, []string{"localhost"})
 	o.attachHealthCheckTimeout = 50 * time.Millisecond
@@ -495,7 +495,7 @@ func TestOrchestrator_Attach(t *testing.T) {
 
 func TestOrchestrator_Attach_SpawnsChildBridgeWithCDPFlags(t *testing.T) {
 	stubAttachBridgeHealthy(t)
-	runner := &mockRunner{portAvail: true}
+	runner := &mockRunner{portAvail: true, newCmd: newBlockingMockCmdFactory(t)}
 	o := NewOrchestratorWithRunner(t.TempDir(), runner)
 	allowAttachForTest(o, []string{"ws"}, []string{"127.0.0.1"})
 	o.attachHealthCheckTimeout = 30 * time.Millisecond
@@ -541,7 +541,7 @@ func TestOrchestrator_AttachWithProviderRejectsUnknownProvider(t *testing.T) {
 
 func TestOrchestrator_Attach_PreservesCdpURLMetadata(t *testing.T) {
 	stubAttachBridgeHealthy(t)
-	runner := &mockRunner{portAvail: true}
+	runner := &mockRunner{portAvail: true, newCmd: newBlockingMockCmdFactory(t)}
 	o := NewOrchestratorWithRunner(t.TempDir(), runner)
 	allowAttachForTest(o, []string{"ws"}, []string{"127.0.0.1"})
 	o.attachHealthCheckTimeout = 30 * time.Millisecond
@@ -568,7 +568,7 @@ func TestOrchestrator_Attach_DuplicateName(t *testing.T) {
 	processAliveFunc = func(pid int) bool { return pid > 0 }
 	defer func() { processAliveFunc = old }()
 
-	runner := &mockRunner{portAvail: true}
+	runner := &mockRunner{portAvail: true, newCmd: newBlockingMockCmdFactory(t)}
 	o := NewOrchestratorWithRunner(t.TempDir(), runner)
 	allowAttachForTest(o, []string{"ws"}, []string{"localhost"})
 	o.attachHealthCheckTimeout = 50 * time.Millisecond
@@ -1274,7 +1274,7 @@ func TestAttach_FailedSpawnReleasesNameReservation(t *testing.T) {
 		t.Fatalf("failed attach left %d residual instances (stale reservation)", n)
 	}
 
-	o.runner = &mockRunner{portAvail: true}
+	o.runner = &mockRunner{portAvail: true, newCmd: newBlockingMockCmdFactory(t)}
 	if _, err := o.Attach("ext", "ws://localhost:9222/devtools/browser/a"); err != nil {
 		t.Fatalf("retry after failed attach should succeed: %v", err)
 	}
@@ -1297,7 +1297,10 @@ func (r *slowAttachRunner) Run(ctx context.Context, binary string, args []string
 // M9 regression: concurrent same-name attaches spawn at most one child.
 func TestAttach_ConcurrentDuplicateNameSpawnsOneChild(t *testing.T) {
 	stubAttachBridgeHealthy(t)
-	runner := &slowAttachRunner{mockRunner: mockRunner{portAvail: true}, delay: 50 * time.Millisecond}
+	runner := &slowAttachRunner{
+		mockRunner: mockRunner{portAvail: true, newCmd: newBlockingMockCmdFactory(t)},
+		delay:      50 * time.Millisecond,
+	}
 	o := NewOrchestratorWithRunner(t.TempDir(), runner)
 	allowAttachForTest(o, []string{"ws"}, []string{"localhost"})
 	o.attachHealthCheckTimeout = 50 * time.Millisecond

--- a/internal/orchestrator/process_test.go
+++ b/internal/orchestrator/process_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/pinchtab/pinchtab/internal/bridge"
@@ -18,6 +19,7 @@ type mockRunner struct {
 	args      []string
 	env       []string
 	runErr    error
+	newCmd    func() Cmd
 }
 
 type mockCmd struct {
@@ -29,12 +31,67 @@ func (m *mockCmd) Wait() error { return nil }
 func (m *mockCmd) PID() int    { return m.pid }
 func (m *mockCmd) Cancel()     {}
 
+type blockingMockCmd struct {
+	pid  int
+	done chan struct{}
+	once sync.Once
+	err  error
+}
+
+func newBlockingMockCmd() *blockingMockCmd {
+	return &blockingMockCmd{
+		pid:  1234,
+		done: make(chan struct{}),
+	}
+}
+
+func (m *blockingMockCmd) Wait() error {
+	<-m.done
+	return m.err
+}
+
+func (m *blockingMockCmd) PID() int { return m.pid }
+
+func (m *blockingMockCmd) Cancel() { m.release() }
+
+func (m *blockingMockCmd) release() {
+	m.once.Do(func() {
+		close(m.done)
+	})
+}
+
+func newBlockingMockCmdFactory(t *testing.T) func() Cmd {
+	t.Helper()
+
+	var (
+		mu   sync.Mutex
+		cmds []*blockingMockCmd
+	)
+	t.Cleanup(func() {
+		mu.Lock()
+		defer mu.Unlock()
+		for _, cmd := range cmds {
+			cmd.release()
+		}
+	})
+	return func() Cmd {
+		cmd := newBlockingMockCmd()
+		mu.Lock()
+		cmds = append(cmds, cmd)
+		mu.Unlock()
+		return cmd
+	}
+}
+
 func (m *mockRunner) Run(ctx context.Context, binary string, args []string, env []string, stdout, stderr io.Writer) (Cmd, error) {
 	m.runCalled = true
 	m.args = append([]string(nil), args...)
 	m.env = append([]string(nil), env...)
 	if m.runErr != nil {
 		return nil, m.runErr
+	}
+	if m.newCmd != nil {
+		return m.newCmd(), nil
 	}
 	return &mockCmd{pid: 1234, isAlive: true}, nil
 }


### PR DESCRIPTION
## Summary
- add a blocking mock child command for orchestrator attach tests
- use the blocking mock in attach-focused tests so monitor does not mark instances exited before assertions run
- keep the immediate-exit mock behavior available for tests that intentionally exercise failure paths

## Testing
- go test ./internal/orchestrator
- go test ./internal/orchestrator -run 'TestHandleAttachInstanceUsesDefaultBrowserTargetWhenOmitted|TestHandleAttachInstanceExplicitBrowserTargetRoutes|TestOrchestrator_Attach|TestOrchestrator_Attach_SpawnsChildBridgeWithCDPFlags|TestOrchestrator_Attach_PreservesCdpURLMetadata|TestOrchestrator_Attach_DuplicateName|TestAttach_FailedSpawnReleasesNameReservation|TestAttach_ConcurrentDuplicateNameSpawnsOneChild' -count=50
