### PR TITLE
fix: clarify nav headless messaging

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -49,7 +49,7 @@ pinchtab find "login button"
 pinchtab network --limit 20
 ```
 
-`pinchtab nav <url>` auto-starts the local PinchTab server when it is not already running. Explicit `--server` and `PINCHTAB_SERVER` targets are used as-is and are not auto-started. To navigate and snapshot in one command after install, run:
+`pinchtab nav <url>` auto-starts the local PinchTab server when it is not already running. Explicit `--server` and `PINCHTAB_SERVER` targets are used as-is and are not auto-started. The default daemon install uses a headless browser, so `nav` may succeed without opening a visible window. To navigate and snapshot in one command after install, run:
 
 ```bash
 pinchtab nav https://pinchtab.com --snap

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -49,7 +49,7 @@ pinchtab find "login button"
 pinchtab network --limit 20
 ```
 
-`pinchtab nav <url>` auto-starts the local PinchTab server when it is not already running. Explicit `--server` and `PINCHTAB_SERVER` targets are used as-is and are not auto-started. The default daemon install uses a headless browser, so `nav` may succeed without opening a visible window. To navigate and snapshot in one command after install, run:
+`pinchtab nav <url>` auto-starts the local PinchTab server when it is not already running. Explicit `--server` and `PINCHTAB_SERVER` targets are used as-is and are not auto-started. The default config uses a headless browser, so `nav` may succeed without opening a visible window. To navigate and snapshot in one command after install, run:
 
 ```bash
 pinchtab nav https://pinchtab.com --snap

--- a/docs/reference/navigate.md
+++ b/docs/reference/navigate.md
@@ -15,6 +15,9 @@ pinchtab nav https://pinchtab.com
 ## CLI Flags
 
 `pinchtab nav <url>` auto-starts the default local server when it is not already running. When `--server` or `PINCHTAB_SERVER` targets another server, PinchTab connects to that server without auto-starting a new process.
+The default daemon install starts a headless browser, so a successful `pinchtab nav`
+may not open a visible window. Use `--snap` to inspect the result, or run PinchTab
+in headed mode when you want a visible browser.
 Hidden aliases: `goto`, `navigate`, `open`.
 
 | Flag | Description |

--- a/docs/reference/navigate.md
+++ b/docs/reference/navigate.md
@@ -15,7 +15,7 @@ pinchtab nav https://pinchtab.com
 ## CLI Flags
 
 `pinchtab nav <url>` auto-starts the default local server when it is not already running. When `--server` or `PINCHTAB_SERVER` targets another server, PinchTab connects to that server without auto-starting a new process.
-The default daemon install starts a headless browser, so a successful `pinchtab nav`
+The default config starts a headless browser, so a successful `pinchtab nav`
 may not open a visible window. Use `--snap` to inspect the result, or run PinchTab
 in headed mode when you want a visible browser.
 Hidden aliases: `goto`, `navigate`, `open`.

--- a/internal/cli/hints.go
+++ b/internal/cli/hints.go
@@ -36,6 +36,6 @@ func WriteCommandHints(out io.Writer, heading string, hints []CommandHint, width
 // shared by the root banner and `pinchtab health` so the two stay in lockstep.
 var NextStepsRunningHints = []CommandHint{
 	{"export PINCHTAB_SESSION=$(pinchtab session create --agent-id <id>)", "# start a dedicated session"},
-	{"pinchtab nav <url>", "# open a page in the current tab"},
+	{"pinchtab nav <url>", "# navigate the current tab (headless by default)"},
 	{"pinchtab snap", "# inspect interactive elements"},
 }


### PR DESCRIPTION
## Summary
- clarify the CLI hint for `pinchtab nav <url>` so it does not imply a visible browser window on the default headless install
- document in the CLI and navigate reference pages that default daemon installs run headless
- point users at `--snap` when they want to inspect a successful headless navigation

## Testing
- go test ./cmd/pinchtab ./internal/cli/...

Fixes #616
