### PR TITLE
fix: harden new-tab navigation readiness

### DIFF
--- a/internal/bridge/cdpops/navigation.go
+++ b/internal/bridge/cdpops/navigation.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -19,14 +20,7 @@ const TargetTypePage = "page"
 
 func NavigatePage(ctx context.Context, url string) error {
 	replaceInitialBlank, _ := shouldReplaceInitialBlankNavigation(ctx)
-	err := chromedp.Run(ctx, chromedp.ActionFunc(func(ctx context.Context) error {
-		return startNavigation(ctx, url, replaceInitialBlank)
-	}))
-	if err != nil {
-		return err
-	}
-
-	return waitForReadyStateAfterNavigation(ctx)
+	return navigateAndWait(ctx, url, replaceInitialBlank)
 }
 
 // DispatchNavigation wakes a headed background renderer without activating its
@@ -54,27 +48,6 @@ func dispatchBackgroundNavigation(ctx context.Context, url string, replaceInitia
 	return startNavigation(ctx, url, replaceInitialBlank)
 }
 
-// waitForReadyStateAfterNavigation polls document.readyState every 200ms until it
-// reaches "interactive" or "complete", returning nil; it returns ctx.Err() if the
-// context ends first. readyState eval errors are ignored and retried.
-func waitForReadyStateAfterNavigation(ctx context.Context) error {
-	ticker := time.NewTicker(200 * time.Millisecond)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-ticker.C:
-			var state string
-			err := chromedp.Run(ctx, chromedp.Evaluate("document.readyState", &state))
-			if err == nil && (state == "interactive" || state == "complete") {
-				return nil
-			}
-		}
-	}
-}
-
 var ErrTooManyRedirects = fmt.Errorf("too many redirects")
 
 func NavigatePageWithRedirectLimit(ctx context.Context, url string, maxRedirects int) error {
@@ -89,6 +62,11 @@ func NavigatePageWithRedirectLimit(ctx context.Context, url string, maxRedirects
 	})); err != nil {
 		return fmt.Errorf("fetch enable: %w", err)
 	}
+	waiter, err := newNavigationLifecycleWaiter(ctx)
+	if err != nil {
+		return err
+	}
+	defer waiter.close()
 
 	var redirectCount atomic.Int32
 	var blocked atomic.Bool
@@ -112,7 +90,7 @@ func NavigatePageWithRedirectLimit(ctx context.Context, url string, maxRedirects
 		}()
 	})
 
-	err := chromedp.Run(ctx, chromedp.ActionFunc(func(ctx context.Context) error {
+	err = chromedp.Run(ctx, chromedp.ActionFunc(func(ctx context.Context) error {
 		return startNavigation(ctx, url, replaceInitialBlank)
 	}))
 
@@ -127,7 +105,7 @@ func NavigatePageWithRedirectLimit(ctx context.Context, url string, maxRedirects
 		return err
 	}
 
-	return waitForReadyStateAfterNavigation(ctx)
+	return waiter.wait(ctx)
 }
 
 // ShouldReplaceBlankHistoryEntry reports whether the first navigation should replace an untouched about:blank entry.
@@ -171,13 +149,117 @@ func startNavigation(ctx context.Context, url string, replaceInitialBlank bool) 
 }
 
 func navigateAndWait(ctx context.Context, url string, replaceInitialBlank bool) error {
+	waiter, err := newNavigationLifecycleWaiter(ctx)
+	if err != nil {
+		return err
+	}
+	defer waiter.close()
+
 	if err := chromedp.Run(ctx, chromedp.ActionFunc(func(ctx context.Context) error {
 		return startNavigation(ctx, url, replaceInitialBlank)
 	})); err != nil {
 		return err
 	}
 
-	return waitForReadyStateAfterNavigation(ctx)
+	return waiter.wait(ctx)
+}
+
+type navigationLifecycleWaiter struct {
+	mu             sync.Mutex
+	mainFrame      cdp.FrameID
+	targetID       string
+	navigationSeen bool
+	lastEvent      string
+	ready          chan struct{}
+	readyOnce      sync.Once
+	cancel         context.CancelFunc
+}
+
+func newNavigationLifecycleWaiter(ctx context.Context) (*navigationLifecycleWaiter, error) {
+	var tree *page.FrameTree
+	if err := chromedp.Run(ctx, chromedp.ActionFunc(func(execCtx context.Context) error {
+		var err error
+		tree, err = page.GetFrameTree().Do(execCtx)
+		return err
+	})); err != nil {
+		return nil, fmt.Errorf("inspect navigation target: %w", err)
+	}
+	if tree == nil || tree.Frame == nil {
+		return nil, fmt.Errorf("inspect navigation target: main frame unavailable")
+	}
+
+	w := &navigationLifecycleWaiter{
+		mainFrame: tree.Frame.ID,
+		ready:     make(chan struct{}),
+	}
+	if c := chromedp.FromContext(ctx); c != nil && c.Target != nil {
+		w.targetID = string(c.Target.TargetID)
+	}
+
+	listenCtx, cancel := context.WithCancel(ctx)
+	w.cancel = cancel
+	chromedp.ListenTarget(listenCtx, w.onEvent)
+	if err := chromedp.Run(ctx, chromedp.ActionFunc(func(execCtx context.Context) error {
+		return page.SetLifecycleEventsEnabled(true).Do(execCtx)
+	})); err != nil {
+		cancel()
+		return nil, fmt.Errorf("enable navigation lifecycle events: %w", err)
+	}
+	return w, nil
+}
+
+func (w *navigationLifecycleWaiter) onEvent(event any) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	switch e := event.(type) {
+	case *page.EventFrameNavigated:
+		if e.Frame == nil || e.Frame.ParentID != "" {
+			return
+		}
+		w.mainFrame = e.Frame.ID
+		w.navigationSeen = true
+		w.lastEvent = "frameNavigated"
+	case *page.EventNavigatedWithinDocument:
+		if e.FrameID != w.mainFrame {
+			return
+		}
+		w.navigationSeen = true
+		w.lastEvent = "navigatedWithinDocument"
+		w.markReady()
+	case *page.EventLifecycleEvent:
+		if e.FrameID != w.mainFrame {
+			return
+		}
+		w.lastEvent = e.Name
+		if w.navigationSeen && (e.Name == "DOMContentLoaded" || e.Name == "load") {
+			w.markReady()
+		}
+	}
+}
+
+func (w *navigationLifecycleWaiter) markReady() {
+	w.readyOnce.Do(func() { close(w.ready) })
+}
+
+func (w *navigationLifecycleWaiter) wait(ctx context.Context) error {
+	select {
+	case <-w.ready:
+		return nil
+	case <-ctx.Done():
+		w.mu.Lock()
+		mainFrame := w.mainFrame
+		lastEvent := w.lastEvent
+		w.mu.Unlock()
+		return fmt.Errorf("navigation target %s main frame %s did not reach DOMContentLoaded (last lifecycle event %q): %w",
+			w.targetID, mainFrame, lastEvent, ctx.Err())
+	}
+}
+
+func (w *navigationLifecycleWaiter) close() {
+	if w.cancel != nil {
+		w.cancel()
+	}
 }
 
 func WaitForTitle(ctx context.Context, timeout time.Duration) (string, error) {

--- a/internal/bridge/cdpops/navigation_lifecycle_test.go
+++ b/internal/bridge/cdpops/navigation_lifecycle_test.go
@@ -1,0 +1,70 @@
+package cdpops
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/chromedp/cdproto/cdp"
+	"github.com/chromedp/cdproto/page"
+)
+
+func TestNavigationLifecycleWaiterUsesMainFrameNavigation(t *testing.T) {
+	w := &navigationLifecycleWaiter{
+		mainFrame: "main",
+		ready:     make(chan struct{}),
+	}
+
+	w.onEvent(&page.EventLifecycleEvent{FrameID: "main", Name: "DOMContentLoaded"})
+	w.onEvent(&page.EventFrameNavigated{Frame: &cdp.Frame{ID: "child", ParentID: "main"}})
+	w.onEvent(&page.EventLifecycleEvent{FrameID: "child", Name: "load"})
+	select {
+	case <-w.ready:
+		t.Fatal("child-frame lifecycle marked the navigation ready")
+	default:
+	}
+
+	w.onEvent(&page.EventFrameNavigated{Frame: &cdp.Frame{ID: "main"}})
+	w.onEvent(&page.EventLifecycleEvent{FrameID: "main", Name: "DOMContentLoaded"})
+	select {
+	case <-w.ready:
+	default:
+		t.Fatal("main-frame DOMContentLoaded did not mark the navigation ready")
+	}
+}
+
+func TestNavigationLifecycleWaiterAcceptsSameDocumentNavigation(t *testing.T) {
+	w := &navigationLifecycleWaiter{
+		mainFrame: "main",
+		ready:     make(chan struct{}),
+	}
+	w.onEvent(&page.EventNavigatedWithinDocument{FrameID: "main"})
+
+	select {
+	case <-w.ready:
+	default:
+		t.Fatal("same-document navigation did not mark the navigation ready")
+	}
+}
+
+func TestNavigationLifecycleWaiterReportsLastTargetState(t *testing.T) {
+	w := &navigationLifecycleWaiter{
+		mainFrame: "frame-1",
+		targetID:  "target-1",
+		lastEvent: "init",
+		ready:     make(chan struct{}),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := w.wait(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("wait error = %v, want context cancellation", err)
+	}
+	for _, detail := range []string{"target-1", "frame-1", `last lifecycle event "init"`} {
+		if !strings.Contains(err.Error(), detail) {
+			t.Fatalf("wait error %q does not contain %q", err, detail)
+		}
+	}
+}

--- a/internal/browsers/cloak/doctor.go
+++ b/internal/browsers/cloak/doctor.go
@@ -14,8 +14,10 @@ import (
 
 const cloakMinVersion = "120.0.0"
 const cloakIdentityPlatform = "windows"
+const cloakDoctorLaunchTimeout = 60 * time.Second
 
 var launchAndEvaluate = chrome.LaunchAndEvaluate
+var launchAndProbe = chrome.LaunchAndProbe
 
 // DoctorChecks overrides the inherited Chrome DoctorChecks method.
 func (Browser) DoctorChecks(_ browsers.TargetConfig) []browsers.DoctorCheck {
@@ -129,7 +131,7 @@ func cloakPresenceCheck(ctx context.Context, cfg interface{}) browsers.DoctorChe
 	if env, ok := cfg.(*browsers.DoctorEnv); ok && env != nil && env.NoSandbox {
 		identityArgs = append(identityArgs, "--no-sandbox")
 	}
-	_, err = launchAndEvaluate(ctx, found, identityArgs, 10*time.Second, "navigator.platform", &platform)
+	_, err = launchAndEvaluate(ctx, found, identityArgs, cloakDoctorLaunchTimeout, "navigator.platform", &platform)
 	if err != nil || platform != "Win32" {
 		reason := fmt.Sprintf("fingerprint platform probe returned %q, want Win32", platform)
 		if err != nil {
@@ -176,7 +178,7 @@ func cdpReachableCheck(ctx context.Context, cfg interface{}) browsers.DoctorChec
 	if env.NoSandbox {
 		args = append(args, "--no-sandbox")
 	}
-	res, err := chrome.LaunchAndProbe(ctx, bin, args, 10*time.Second)
+	res, err := launchAndProbe(ctx, bin, args, cloakDoctorLaunchTimeout)
 	if err != nil {
 		return browsers.DoctorCheckResult{Status: browsers.DoctorFail, Detail: err.Error(), Err: err}
 	}
@@ -219,7 +221,7 @@ func fingerprintFlagsCheck(ctx context.Context, cfg interface{}) browsers.Doctor
 	if env.NoSandbox {
 		fpFlags = append(fpFlags, "--no-sandbox")
 	}
-	res, err := chrome.LaunchAndProbe(ctx, bin, fpFlags, 10*time.Second)
+	res, err := launchAndProbe(ctx, bin, fpFlags, cloakDoctorLaunchTimeout)
 	if err != nil {
 		return browsers.DoctorCheckResult{
 			Status: browsers.DoctorFail,

--- a/internal/browsers/cloak/doctor_test.go
+++ b/internal/browsers/cloak/doctor_test.go
@@ -96,3 +96,64 @@ func TestCloakPresenceRejectsChromeEvenUnderCloakNamedDirectory(t *testing.T) {
 		})
 	}
 }
+
+func TestCloakPresenceAllowsColdStart(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("cloakbrowser_present is skipped on windows")
+	}
+	binary := filepath.Join(t.TempDir(), "cloakbrowser")
+	if err := os.WriteFile(binary, []byte("#!/bin/sh\necho 'Chromium 145.0.0.0'\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	original := launchAndEvaluate
+	launchAndEvaluate = func(_ context.Context, _ string, _ []string, timeout time.Duration, _ string, value any) (chrome.CDPProbeResult, error) {
+		if timeout < 22*time.Second {
+			return chrome.CDPProbeResult{}, context.DeadlineExceeded
+		}
+		*value.(*string) = "Win32"
+		return chrome.CDPProbeResult{Port: 9222}, nil
+	}
+	t.Cleanup(func() { launchAndEvaluate = original })
+
+	result := cloakPresenceCheck(context.Background(), &browsers.DoctorEnv{Binary: binary})
+	if result.Status != browsers.DoctorPass {
+		t.Fatalf("status = %v, want pass after cold start: %s", result.Status, result.Detail)
+	}
+}
+
+func TestCDPReachableAllowsColdStart(t *testing.T) {
+	original := launchAndProbe
+	launchAndProbe = func(_ context.Context, _ string, _ []string, timeout time.Duration) (chrome.CDPProbeResult, error) {
+		if timeout < 22*time.Second {
+			return chrome.CDPProbeResult{}, context.DeadlineExceeded
+		}
+		return chrome.CDPProbeResult{Port: 9222}, nil
+	}
+	t.Cleanup(func() { launchAndProbe = original })
+
+	result := cdpReachableCheck(context.Background(), &browsers.DoctorEnv{Binary: "/cloakbrowser"})
+	if result.Status != browsers.DoctorPass {
+		t.Fatalf("status = %v, want pass after cold start: %s", result.Status, result.Detail)
+	}
+}
+
+func TestFingerprintFlagsAllowColdStart(t *testing.T) {
+	original := launchAndProbe
+	launchAndProbe = func(_ context.Context, _ string, _ []string, timeout time.Duration) (chrome.CDPProbeResult, error) {
+		if timeout < 22*time.Second {
+			return chrome.CDPProbeResult{}, context.DeadlineExceeded
+		}
+		return chrome.CDPProbeResult{Port: 9222}, nil
+	}
+	t.Cleanup(func() { launchAndProbe = original })
+
+	env := &browsers.DoctorEnv{
+		Binary: "/cloakbrowser",
+		Cloak:  browsers.CloakFingerprint{FingerprintSeed: "test-seed"},
+	}
+	result := fingerprintFlagsCheck(context.Background(), env)
+	if result.Status != browsers.DoctorPass {
+		t.Fatalf("status = %v, want pass after cold start: %s", result.Status, result.Detail)
+	}
+}

--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -36,8 +36,10 @@ type mockBridge struct {
 	availableActions  []string
 	navigateResult    *bridge.NavigateResult
 	navigateErr       error
+	navigateFn        func(context.Context, string, bridge.NavigateParams) (*bridge.NavigateResult, error)
 	closedTabs        []string
 	runningBrowser    string
+	createTabFn       func(string) (string, context.Context, context.CancelFunc, error)
 
 	staticFirstNavigate bool
 	staticEscalate      *bridge.StaticEscalateError
@@ -82,6 +84,9 @@ func (m *mockBridge) ExecuteAction(ctx context.Context, kind string, req bridge.
 
 func (m *mockBridge) CreateTab(url string) (string, context.Context, context.CancelFunc, error) {
 	m.createTabURLs = append(m.createTabURLs, url)
+	if m.createTabFn != nil {
+		return m.createTabFn(url)
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // cancel immediately - no browser spawned
 	return "tab_abc12345", ctx, cancel, nil
@@ -135,8 +140,11 @@ func (m *mockBridge) GetRefCache(tabID string) *bridge.RefCache        { return 
 func (m *mockBridge) SetRefCache(tabID string, cache *bridge.RefCache) {}
 func (m *mockBridge) DeleteRefCache(tabID string)                      {}
 
-func (m *mockBridge) Navigate(_ context.Context, url string, params bridge.NavigateParams) (*bridge.NavigateResult, error) {
+func (m *mockBridge) Navigate(ctx context.Context, url string, params bridge.NavigateParams) (*bridge.NavigateResult, error) {
 	m.navigateParams = append(m.navigateParams, params)
+	if m.navigateFn != nil {
+		return m.navigateFn(ctx, url, params)
+	}
 	if params.NoEscalate && m.staticEscalate != nil {
 		return nil, m.staticEscalate
 	}

--- a/internal/handlers/navigation.go
+++ b/internal/handlers/navigation.go
@@ -511,8 +511,8 @@ func (h *Handlers) runNavigate(w http.ResponseWriter, r *http.Request, ex navExe
 		}
 		if ex.isNewTab && errors.Is(navErr, context.DeadlineExceeded) {
 			httpx.Error(w, http.StatusServiceUnavailable, fmt.Errorf(
-				"new tab did not load in time — the browser may be out of memory or overloaded; "+
-					"close tabs or restart the instance with `pinchtab server restart`"))
+				"new tab did not load in time: %v; the browser may be out of memory or overloaded; "+
+					"close tabs or restart the instance with `pinchtab server restart`", navErr))
 			return
 		}
 		navigateErrorWithHint(w, classifyNavigateError(navErr), navErr, ex.url)

--- a/internal/handlers/navigation_browser_test.go
+++ b/internal/handlers/navigation_browser_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/pinchtab/pinchtab/internal/activity"
 	"github.com/pinchtab/pinchtab/internal/bridge"
@@ -508,6 +509,70 @@ func TestHandleNavigate_AdapterServedTab_NewTab_ClosesUnusedBlankTab(t *testing.
 	}
 	if got := w.Header().Get(activity.HeaderPTTabCreated); got != "true" {
 		t.Fatalf("created marker header = %q, want true", got)
+	}
+}
+
+func TestRunNavigate_NewTabTimeoutPreservesReadinessDiagnostics(t *testing.T) {
+	m := &mockBridge{navigateErr: fmt.Errorf(
+		"navigation target target-1 main frame frame-1 did not reach DOMContentLoaded (last lifecycle event %q): %w",
+		"init", context.DeadlineExceeded,
+	)}
+	h := New(m, &config.RuntimeConfig{}, nil, nil, nil)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/navigate", nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	h.runNavigate(w, r, navExec{
+		tabID:    "tab-1",
+		ctx:      ctx,
+		cancel:   cancel,
+		url:      "https://example.com",
+		isNewTab: true,
+	})
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d; body=%s", w.Code, http.StatusServiceUnavailable, w.Body.String())
+	}
+	for _, detail := range []string{"target-1", "frame-1", `last lifecycle event \"init\"`} {
+		if !strings.Contains(w.Body.String(), detail) {
+			t.Fatalf("response %q does not contain %q", w.Body.String(), detail)
+		}
+	}
+}
+
+func TestNavigateNewTabBrowserStartsNavigationBudgetAfterTabCreation(t *testing.T) {
+	var createdAt time.Time
+	var budgetAfterCreation time.Duration
+	m := &mockBridge{}
+	m.createTabFn = func(string) (string, context.Context, context.CancelFunc, error) {
+		time.Sleep(25 * time.Millisecond)
+		createdAt = time.Now()
+		ctx, cancel := context.WithCancel(context.Background())
+		return "tab-1", ctx, cancel, nil
+	}
+	m.navigateFn = func(ctx context.Context, url string, params bridge.NavigateParams) (*bridge.NavigateResult, error) {
+		deadline, ok := ctx.Deadline()
+		if !ok {
+			return nil, fmt.Errorf("navigation context has no deadline")
+		}
+		budgetAfterCreation = deadline.Sub(createdAt)
+		return &bridge.NavigateResult{URL: url, Title: "ready"}, nil
+	}
+	h := New(m, &config.RuntimeConfig{}, nil, nil, nil)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/navigate", nil)
+
+	h.navigateNewTabBrowser(w, r, navigateBrowserOptions{
+		URL:        "https://example.com",
+		NavTimeout: 100 * time.Millisecond,
+	})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", w.Code, http.StatusOK, w.Body.String())
+	}
+	if budgetAfterCreation < 95*time.Millisecond {
+		t.Fatalf("navigation budget after tab creation = %v, want at least 95ms", budgetAfterCreation)
 	}
 }
 

--- a/internal/profiles/copydir.go
+++ b/internal/profiles/copydir.go
@@ -8,20 +8,20 @@ import (
 	"path/filepath"
 )
 
-func copyDir(src, dst string) error {
-	return filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
+func copyDir(src *importSource, dst string) error {
+	return fs.WalkDir(src.root.FS(), filepath.ToSlash(src.relative), func(sourcePath string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 		if d.Type()&os.ModeSymlink != 0 {
-			return fmt.Errorf("symlinks are not allowed in imported profiles: %s", path)
+			return fmt.Errorf("symlinks are not allowed in imported profiles: %s", sourcePath)
 		}
 
-		rel, err := filepath.Rel(src, path)
+		rel, err := filepath.Rel(filepath.FromSlash(src.relative), filepath.FromSlash(sourcePath))
 		if err != nil {
 			return err
 		}
-		target := filepath.Join(dst, rel)
+		target := filepath.Join(dst, filepath.FromSlash(rel))
 
 		if d.IsDir() {
 			info, err := d.Info()
@@ -31,12 +31,12 @@ func copyDir(src, dst string) error {
 			return os.MkdirAll(target, info.Mode().Perm())
 		}
 
-		return copyFile(path, target)
+		return copyFile(src.root, filepath.FromSlash(sourcePath), target)
 	})
 }
 
-func copyFile(src, dst string) error {
-	in, err := os.Open(src) // #nosec G304 — src is validated by caller
+func copyFile(root *os.Root, src, dst string) error {
+	in, err := root.Open(src)
 	if err != nil {
 		return fmt.Errorf("open %s: %w", src, err)
 	}

--- a/internal/profiles/profiles_crud.go
+++ b/internal/profiles/profiles_crud.go
@@ -39,18 +39,13 @@ func (pm *ProfileManager) Import(name, sourcePath string) error {
 		return err
 	}
 
-	resolvedSourcePath, err := resolveImportSourcePath(sourcePath)
+	source, err := openImportSource(sourcePath)
 	if err != nil {
 		return err
 	}
+	defer func() { _ = source.root.Close() }()
 
-	if _, err := os.Stat(filepath.Join(resolvedSourcePath, "Default")); err != nil {
-		if _, err2 := os.Stat(filepath.Join(resolvedSourcePath, "Preferences")); err2 != nil {
-			return fmt.Errorf("source doesn't look like a Chrome user data dir (no Default/ or Preferences found)")
-		}
-	}
-
-	srcInfo, err := os.Lstat(resolvedSourcePath)
+	srcInfo, err := source.root.Lstat(source.relative)
 	if err != nil {
 		return fmt.Errorf("source path invalid: %w", err)
 	}
@@ -60,18 +55,23 @@ func (pm *ProfileManager) Import(name, sourcePath string) error {
 	if !srcInfo.IsDir() {
 		return fmt.Errorf("source path must be a directory")
 	}
+	if _, err := source.root.Stat(source.child("Default")); err != nil {
+		if _, err2 := source.root.Stat(source.child("Preferences")); err2 != nil {
+			return fmt.Errorf("source doesn't look like a Chrome user data dir (no Default/ or Preferences found)")
+		}
+	}
 
-	slog.Info("importing profile", "name", name, "source", resolvedSourcePath)
+	slog.Info("importing profile", "name", name, "source", source.displayPath)
 	// Import is all-or-nothing. preflight already established that dest did not
 	// exist, so anything under it now is ours to remove — and leaving a partial
 	// copy would make every retry fail with "already exists" instead of the real
 	// cause (a live Chrome user data dir has Singleton* symlinks copyDir rejects).
-	if err := copyDir(resolvedSourcePath, dest); err != nil {
+	if err := copyDir(source, dest); err != nil {
 		_ = os.RemoveAll(dest)
 		return fmt.Errorf("copy failed: %w", err)
 	}
 
-	if err := os.WriteFile(filepath.Join(dest, ".pinchtab-imported"), []byte(resolvedSourcePath), 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(dest, ".pinchtab-imported"), []byte(source.displayPath), 0600); err != nil {
 		slog.Warn("failed to write import marker", "err", err)
 	}
 	if err := writeProfileMeta(dest, ProfileMeta{

--- a/internal/profiles/profiles_import.go
+++ b/internal/profiles/profiles_import.go
@@ -7,30 +7,49 @@ import (
 	"strings"
 )
 
-func resolveImportSourcePath(sourcePath string) (string, error) {
+type importSource struct {
+	root        *os.Root
+	relative    string
+	displayPath string
+}
+
+func openImportSource(sourcePath string) (*importSource, error) {
 	if sourcePath == "" {
-		return "", fmt.Errorf("source path required")
+		return nil, fmt.Errorf("source path required")
 	}
 
 	cleaned := filepath.Clean(sourcePath)
 	if !filepath.IsAbs(cleaned) {
 		abs, err := filepath.Abs(cleaned)
 		if err != nil {
-			return "", fmt.Errorf("source path invalid: %w", err)
+			return nil, fmt.Errorf("source path invalid: %w", err)
 		}
 		cleaned = abs
 	}
 
 	roots, err := allowedImportRoots()
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	for _, root := range roots {
-		if pathWithinRoot(cleaned, root) {
-			return cleaned, nil
+	for _, rootPath := range roots {
+		relative, err := filepath.Rel(rootPath, cleaned)
+		if err != nil || !pathWithinRoot(cleaned, rootPath) {
+			continue
 		}
+		root, err := os.OpenRoot(rootPath)
+		if err != nil {
+			return nil, fmt.Errorf("open import root: %w", err)
+		}
+		return &importSource{root: root, relative: relative, displayPath: cleaned}, nil
 	}
-	return "", fmt.Errorf("source path must be within %s", strings.Join(roots, " or "))
+	return nil, fmt.Errorf("source path must be within %s", strings.Join(roots, " or "))
+}
+
+func (s *importSource) child(name string) string {
+	if s.relative == "." {
+		return name
+	}
+	return filepath.Join(s.relative, name)
 }
 
 func allowedImportRoots() ([]string, error) {

--- a/internal/profiles/profiles_test.go
+++ b/internal/profiles/profiles_test.go
@@ -169,6 +169,27 @@ func TestProfileManagerImportRejectsSymlinkSource(t *testing.T) {
 	}
 }
 
+func TestProfileManagerImportRejectsIntermediateSymlinkOutsideRoot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("rooted symlink test requires Unix symlink semantics")
+	}
+
+	dir := t.TempDir()
+	pm := NewProfileManager(dir)
+	link := filepath.Join(t.TempDir(), "escape")
+	if err := os.Symlink(string(os.PathSeparator), link); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	err := pm.Import("escaped-source", filepath.Join(link, "etc"))
+	if err == nil || !strings.Contains(err.Error(), "source path invalid") {
+		t.Fatalf("expected rooted source validation to reject the escaping symlink, got %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, profileID("escaped-source"))); !os.IsNotExist(statErr) {
+		t.Fatalf("rejected import created a destination: %v", statErr)
+	}
+}
+
 func TestProfileManagerImportRejectsSymlinkEntry(t *testing.T) {
 	dir := t.TempDir()
 	pm := NewProfileManager(dir)

--- a/tests/e2e/fixtures/navigation-extra-target.html
+++ b/tests/e2e/fixtures/navigation-extra-target.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Navigation Target Owner</title>
+</head>
+<body>
+  <main id="ready">owner-ready</main>
+  <script>
+    window.open('/navigation-loading-target.html', '_blank')
+    window.addEventListener('DOMContentLoaded', () => {
+      setTimeout(() => {
+        document.open()
+        document.write('<title>Navigation Target Owner</title><main id="ready">owner-ready</main>')
+      }, 0)
+    })
+  </script>
+</body>
+</html>

--- a/tests/e2e/fixtures/navigation-loading-target.html
+++ b/tests/e2e/fixtures/navigation-loading-target.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Loading Side Target</title>
+</head>
+<body>
+  <main>side-target-loading</main>
+  <script>
+    document.open()
+    document.write('<main>side-target-loading</main>')
+  </script>
+</body>
+</html>

--- a/tests/e2e/scenarios/api/browser-basic.sh
+++ b/tests/e2e/scenarios/api/browser-basic.sh
@@ -40,6 +40,15 @@ assert_json_contains "$RESULT" '.title' 'Table'
 end_test
 
 # ─────────────────────────────────────────────────────────────────
+start_test "pinchtab nav --new-tab follows the created target lifecycle"
+
+pt_post /navigate -d "{\"url\":\"${FIXTURES_URL}/navigation-extra-target.html\",\"newTab\":true,\"timeout\":3}"
+assert_ok "navigate owner target while the page spawns a loading side target"
+assert_json_contains "$RESULT" '.title' 'Navigation Target Owner'
+
+end_test
+
+# ────────────────────────────────────────────────────────────────
 start_test "pinchtab tabs"
 
 assert_tab_count_gte 2


### PR DESCRIPTION
## Summary
- replace readyState polling with lifecycle-based readiness that follows the main navigation target
- start new-tab navigation timeouts after tab creation and preserve lifecycle diagnostics on timeout
- add focused unit and e2e coverage for pages that spawn extra targets during new-tab navigation
- harden profile import path handling against intermediate symlink escapes

Fixes #620
Fixes #621
Fixes #622

## Verification
- `go test ./internal/bridge/cdpops ./internal/handlers ./internal/httpx ./internal/instance ./internal/orchestrator ./internal/profiles ./internal/proxy ./internal/server ./cmd/pinchtab`
- `go test ./internal/browsers/cloak ./internal/doctor ./cmd/pinchtab`
- `go build ./cmd/pinchtab`

## Notes
- I attempted `./dev e2e api browser-basic` in this environment, but it did not complete, so Docker e2e still needs confirmation from CI or a local Docker-backed run.
