### PR TITLE
fix: harden cli errors and windows screenshots

### DIFF
--- a/cmd/pinchtab/cmd_cli_browser_nav_test.go
+++ b/cmd/pinchtab/cmd_cli_browser_nav_test.go
@@ -4,11 +4,56 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"os/exec"
 	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
 )
+
+func TestNavPolicyDenialExitsOne(t *testing.T) {
+	if os.Getenv("PINCHTAB_NAV_POLICY_HELPER") == "1" {
+		rootCmd.SetArgs([]string{"--server", os.Getenv("PINCHTAB_NAV_POLICY_SERVER"), "nav", "https://example.com"})
+		if err := rootCmd.Execute(); err != nil {
+			os.Exit(commandExitCode(err))
+		}
+		return
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/health" {
+			_, _ = w.Write([]byte(`{"status":"ok"}`))
+			return
+		}
+		if r.URL.Path != "/navigate" {
+			t.Errorf("path = %q, want /navigate", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":"navigation blocked by IDPI","code":"idpi_domain_blocked"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	child := exec.Command(os.Args[0], "-test.run=^TestNavPolicyDenialExitsOne$", "-test.timeout=30s") // #nosec G204 -- re-executes this test binary with fixed arguments.
+	child.Env = append(os.Environ(),
+		"PINCHTAB_NAV_POLICY_HELPER=1",
+		"PINCHTAB_NAV_POLICY_SERVER="+srv.URL,
+		"HOME="+t.TempDir(),
+		"XDG_STATE_HOME="+t.TempDir(),
+	)
+	out, err := child.CombinedOutput()
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("nav policy denial exited with %v, want exit 1; output:\n%s", err, out)
+	}
+	if exitErr.ExitCode() != 1 {
+		t.Fatalf("exit code = %d, want 1; output:\n%s", exitErr.ExitCode(), out)
+	}
+	if !strings.Contains(string(out), "Error 403: navigation blocked by IDPI") {
+		t.Fatalf("output did not report the policy 403:\n%s", out)
+	}
+}
 
 func TestTabHandoffFamilyRefusesLocallyOnAnEmptyTabID(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/pinchtab/cmd_cli_register.go
+++ b/cmd/pinchtab/cmd_cli_register.go
@@ -119,7 +119,7 @@ func configureBrowserFlags() {
 	screenshotCmd.Flags().StringP("selector", "s", "", "Element selector to capture (ref/CSS/XPath/text)")
 	screenshotCmd.Flags().String("scale", "", "Rescale the output image (e.g. 0.5 = half size, 0.25 = quarter). Default 1.")
 	screenshotCmd.Flags().Bool("annotate", false, "Overlay numbered ref boxes on interactive elements (or on --selector matches). Prints a [n] ref legend to stdout.")
-	screenshotCmd.Flags().String("format", "", "Image format: 'jpeg' (default) or 'png'")
+	screenshotCmd.Flags().String("format", "", "Image format: 'jpeg' or 'png' (default: inferred from -o .png, otherwise jpeg)")
 	screenshotCmd.Flags().Bool("beyond-viewport", false, "Capture the entire scrollable document, not just the visible viewport. Ignored when --selector is set.")
 	// Back-compat: --css-1x was removed (replaced by --scale). Keep it as a
 	// deprecated no-op so old scripts get a notice instead of a hard error.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -279,7 +279,8 @@ curl -X POST "$PINCHTAB_SERVER/tabs/<tabId>/resume"
 
 ```bash
 pinchtab screenshot                     # Save a screenshot to a generated .jpg path
-pinchtab screenshot -o <path>           # Save screenshot to a chosen path
+pinchtab screenshot -o <path>           # Save to a chosen path (.png infers PNG; otherwise JPEG)
+pinchtab screenshot --format <jpeg|png>  # Override the inferred output format
 pinchtab screenshot -q <0-100>          # JPEG quality
 pinchtab screenshot -s <selector>       # Capture a specific element by selector
 pinchtab screenshot --scale 0.5         # Half-size output (quarter the pixels)

--- a/docs/reference/screenshot.md
+++ b/docs/reference/screenshot.md
@@ -1,6 +1,8 @@
 # Screenshot
 
-Capture the current page as an image. Defaults to **JPEG** format.
+Capture the current page as an image. The API defaults to **JPEG**. The CLI
+uses PNG when `-o` ends in `.png` and JPEG otherwise; an explicit `--format`
+always takes precedence.
 
 ```bash
 # Get raw PNG bytes
@@ -48,7 +50,8 @@ curl "http://localhost:9867/screenshot?output=file"
 
 ### CLI
 
-- `-o <path>`: Save to specific path.
+- `-o <path>`: Save to a specific path. A `.png` extension selects PNG when `--format` is omitted; other extensions use JPEG.
+- `--format <jpeg|png>`: Explicitly select the image format, overriding extension inference.
 - `-q <0-100>`: Set JPEG quality.
 - `-s <selector>`: Capture a specific element.
 - `--scale <f>`: Bitmap rescale (e.g. `0.5`).

--- a/internal/cdptk/screenshot.go
+++ b/internal/cdptk/screenshot.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"runtime"
 	"strings"
 
 	"github.com/chromedp/cdproto/page"
@@ -123,7 +124,9 @@ func ClipForNode(ctx context.Context, nodeID int64, css1x bool) (*ScreenshotClip
 // fresh compositor surface frame. On idle pages in headed browsers (e.g. Cloak) the
 // surface stops swapping frames, so the default fromSurface=true blocks until the action
 // deadline (~30s) — stalling one-shot screenshots and polling screencast alike. That is
-// why the nil-clip fast path matters and must be preserved.
+// why the nil-clip fast path matters and must be preserved outside Windows. Windows
+// headless Chrome with software rendering can return an unpainted white view through
+// that path, so it always requests a freshly composited surface.
 //
 // Anything that changes the captured region needs the page recomposited, which only
 // happens with fromSurface=true: capture-beyond-viewport, a render-time rescale, and the
@@ -140,7 +143,11 @@ func ClipForNode(ctx context.Context, nodeID int64, css1x bool) (*ScreenshotClip
 // The nil-clip pair matches on dimensions, which is why an unclipped browser test cannot
 // pin this choice; hence the table test beside this function.
 func CaptureFromSurface(beyondViewport bool, clip *page.Viewport) bool {
-	return beyondViewport || clip != nil
+	return captureFromSurface(runtime.GOOS, beyondViewport, clip)
+}
+
+func captureFromSurface(goos string, beyondViewport bool, clip *page.Viewport) bool {
+	return goos == "windows" || beyondViewport || clip != nil
 }
 
 // captureRefusal is the CDP error a renderer returns when it will not serve the

--- a/internal/cdptk/screenshot_fallback_test.go
+++ b/internal/cdptk/screenshot_fallback_test.go
@@ -11,6 +11,12 @@ import (
 	"github.com/pinchtab/pinchtab/internal/srccensus"
 )
 
+func TestWindowsViewportCaptureUsesSurface(t *testing.T) {
+	if !captureFromSurface("windows", false, nil) {
+		t.Fatal("Windows viewport capture used the read-the-view path")
+	}
+}
+
 // The property is that a REFUSAL of the read-the-view fast path is handled, whatever the
 // clip — not that an unclipped capture works. A browser fixture cannot pin this: the
 // refusal depends on whether the renderer's view is available, which no test can withhold

--- a/internal/cli/actions/actions_screenshot.go
+++ b/internal/cli/actions/actions_screenshot.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/pinchtab/pinchtab/internal/cli"
@@ -38,7 +40,11 @@ func Screenshot(client *http.Client, base, token string, cmd *cobra.Command) {
 	annotate, _ := cmd.Flags().GetBool("annotate")
 	format, _ := cmd.Flags().GetString("format")
 	if format == "" {
-		format = "jpeg"
+		if strings.EqualFold(filepath.Ext(outFile), ".png") {
+			format = "png"
+		} else {
+			format = "jpeg"
+		}
 	}
 	if v, _ := cmd.Flags().GetString("quality"); v != "" {
 		params.Set("quality", v)

--- a/internal/cli/actions/actions_screenshot_test.go
+++ b/internal/cli/actions/actions_screenshot_test.go
@@ -43,3 +43,19 @@ func TestScreenshot(t *testing.T) {
 		t.Errorf("unexpected content: %s", string(data))
 	}
 }
+
+func TestScreenshotInfersPNGFromOutputExtension(t *testing.T) {
+	m := newMockServer()
+	m.response = "FAKEPNGDATA"
+	defer m.close()
+
+	outFile := filepath.Join(t.TempDir(), "screenshot.png")
+	cmd := &cobra.Command{}
+	cmd.Flags().String("output", outFile, "")
+	cmd.Flags().String("format", "", "")
+	Screenshot(m.server.Client(), m.base(), "", cmd)
+
+	if !strings.Contains(m.lastQuery, "format=png") {
+		t.Fatalf("query = %q, want format=png inferred from output extension", m.lastQuery)
+	}
+}

--- a/internal/profiles/copydir.go
+++ b/internal/profiles/copydir.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 )
 
-func copyDir(src *importSource, dst string) error {
+func copyDir(src *importSource, dst *os.Root) error {
 	return fs.WalkDir(src.root.FS(), filepath.ToSlash(src.relative), func(sourcePath string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -21,22 +21,25 @@ func copyDir(src *importSource, dst string) error {
 		if err != nil {
 			return err
 		}
-		target := filepath.Join(dst, filepath.FromSlash(rel))
+		target := filepath.FromSlash(rel)
+		if !filepath.IsLocal(target) {
+			return fmt.Errorf("import path escapes destination: %s", sourcePath)
+		}
 
 		if d.IsDir() {
 			info, err := d.Info()
 			if err != nil {
 				return err
 			}
-			return os.MkdirAll(target, info.Mode().Perm())
+			return dst.MkdirAll(target, info.Mode().Perm())
 		}
 
-		return copyFile(src.root, filepath.FromSlash(sourcePath), target)
+		return copyFile(src.root, filepath.FromSlash(sourcePath), dst, target)
 	})
 }
 
-func copyFile(root *os.Root, src, dst string) error {
-	in, err := root.Open(src)
+func copyFile(srcRoot *os.Root, src string, dstRoot *os.Root, dst string) error {
+	in, err := srcRoot.Open(src)
 	if err != nil {
 		return fmt.Errorf("open %s: %w", src, err)
 	}
@@ -47,7 +50,7 @@ func copyFile(root *os.Root, src, dst string) error {
 		return err
 	}
 
-	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, info.Mode().Perm())
+	out, err := dstRoot.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, info.Mode().Perm())
 	if err != nil {
 		return fmt.Errorf("create %s: %w", dst, err)
 	}

--- a/internal/profiles/copydir_test.go
+++ b/internal/profiles/copydir_test.go
@@ -1,0 +1,40 @@
+package profiles
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCopyDirRejectsDestinationSymlinkEscape(t *testing.T) {
+	srcPath := filepath.Join(t.TempDir(), "source")
+	if err := os.MkdirAll(filepath.Join(srcPath, "Default"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcPath, "Default", "Preferences"), []byte("source"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	src, err := openImportSource(srcPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = src.root.Close() }()
+
+	dst := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(dst, "Default")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	dstRoot, err := os.OpenRoot(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = dstRoot.Close() }()
+
+	if err := copyDir(src, dstRoot); err == nil {
+		t.Fatal("copyDir followed a destination symlink outside its root")
+	}
+	if _, err := os.Stat(filepath.Join(outside, "Preferences")); !os.IsNotExist(err) {
+		t.Fatalf("copyDir wrote outside its destination root: %v", err)
+	}
+}

--- a/internal/profiles/identity.go
+++ b/internal/profiles/identity.go
@@ -101,9 +101,25 @@ func readProfileMeta(profileDir string) ProfileMeta {
 }
 
 func writeProfileMeta(profileDir string, meta ProfileMeta) error {
-	data, err := json.MarshalIndent(meta, "", "  ")
+	data, err := profileMetaJSON(meta)
 	if err != nil {
 		return err
 	}
 	return os.WriteFile(filepath.Join(profileDir, "profile.json"), data, 0644)
+}
+
+func writeProfileMetaRoot(root *os.Root, meta ProfileMeta) error {
+	data, err := profileMetaJSON(meta)
+	if err != nil {
+		return err
+	}
+	return root.WriteFile("profile.json", data, 0644)
+}
+
+func profileMetaJSON(meta ProfileMeta) ([]byte, error) {
+	data, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
 }

--- a/internal/profiles/profiles_crud.go
+++ b/internal/profiles/profiles_crud.go
@@ -34,7 +34,7 @@ func (pm *ProfileManager) Import(name, sourcePath string) error {
 	pm.mu.Lock()
 	defer pm.mu.Unlock()
 
-	_, dest, err := pm.preflightProfileDestination(name, nil)
+	id, _, err := pm.preflightProfileDestination(name, nil)
 	if err != nil {
 		return err
 	}
@@ -62,24 +62,43 @@ func (pm *ProfileManager) Import(name, sourcePath string) error {
 	}
 
 	slog.Info("importing profile", "name", name, "source", source.displayPath)
-	// Import is all-or-nothing. preflight already established that dest did not
-	// exist, so anything under it now is ours to remove — and leaving a partial
-	// copy would make every retry fail with "already exists" instead of the real
-	// cause (a live Chrome user data dir has Singleton* symlinks copyDir rejects).
-	if err := copyDir(source, dest); err != nil {
-		_ = os.RemoveAll(dest)
+	// Import is all-or-nothing. The rooted Mkdir claims the preflighted id
+	// atomically, so anything under it is ours to remove on failure.
+	baseRoot, err := os.OpenRoot(pm.baseDir)
+	if err != nil {
+		return fmt.Errorf("open profile root: %w", err)
+	}
+	defer func() { _ = baseRoot.Close() }()
+	if err := baseRoot.Mkdir(id, srcInfo.Mode().Perm()); err != nil {
+		return fmt.Errorf("create profile destination: %w", err)
+	}
+	destRoot, err := baseRoot.OpenRoot(id)
+	if err != nil {
+		_ = baseRoot.RemoveAll(id)
+		return fmt.Errorf("open profile destination: %w", err)
+	}
+	cleanup := func() {
+		_ = destRoot.Close()
+		_ = baseRoot.RemoveAll(id)
+	}
+	if err := copyDir(source, destRoot); err != nil {
+		cleanup()
 		return fmt.Errorf("copy failed: %w", err)
 	}
 
-	if err := os.WriteFile(filepath.Join(dest, ".pinchtab-imported"), []byte(source.displayPath), 0600); err != nil {
+	if err := destRoot.WriteFile(".pinchtab-imported", []byte(source.displayPath), 0600); err != nil {
 		slog.Warn("failed to write import marker", "err", err)
 	}
-	if err := writeProfileMeta(dest, ProfileMeta{
-		ID:   profileID(name),
+	if err := writeProfileMetaRoot(destRoot, ProfileMeta{
+		ID:   id,
 		Name: name,
 	}); err != nil {
-		_ = os.RemoveAll(dest)
+		cleanup()
 		return err
+	}
+	if err := destRoot.Close(); err != nil {
+		_ = baseRoot.RemoveAll(id)
+		return fmt.Errorf("close profile destination: %w", err)
 	}
 	return nil
 }

--- a/tests/e2e/scenarios/cli/files-basic.sh
+++ b/tests/e2e/scenarios/cli/files-basic.sh
@@ -5,16 +5,38 @@ GROUP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${GROUP_DIR}/../../helpers/cli.sh"
 
 start_test "pinchtab screenshot"
+
+FIRST_SCREENSHOT=/tmp/e2e-screenshot-first.png
+SECOND_SCREENSHOT=/tmp/e2e-screenshot-second.png
+rm -f "$FIRST_SCREENSHOT" "$SECOND_SCREENSHOT"
+
 pt_ok nav "${FIXTURES_URL}/index.html"
-pt_ok screenshot -o /tmp/e2e-screenshot-test.jpg
-if [ -f /tmp/e2e-screenshot-test.jpg ]; then
-  echo -e "  ${GREEN}✓${NC} screenshot file created"
-  ((ASSERTIONS_PASSED++)) || true
-  rm -f /tmp/e2e-screenshot-test.jpg
-else
-  echo -e "  ${RED}✗${NC} screenshot file not created"
-  ((ASSERTIONS_FAILED++)) || true
+pt_ok screenshot -o "$FIRST_SCREENSHOT"
+pt_ok nav "${FIXTURES_URL}/buttons.html"
+pt_ok screenshot -o "$SECOND_SCREENSHOT"
+
+assert_file_exists "$FIRST_SCREENSHOT" "first screenshot file created"
+assert_file_exists "$SECOND_SCREENSHOT" "second screenshot file created"
+
+PNG_MAGIC=""
+if [ -f "$FIRST_SCREENSHOT" ]; then
+  PNG_MAGIC=$(od -An -tx1 -N8 "$FIRST_SCREENSHOT" | tr -d ' \n')
 fi
+if [ "$PNG_MAGIC" = "89504e470d0a1a0a" ]; then
+  pass_assert ".png output contains PNG bytes"
+else
+  fail_assert ".png output contains PNG bytes"
+fi
+
+if [ ! -f "$FIRST_SCREENSHOT" ] || [ ! -f "$SECOND_SCREENSHOT" ]; then
+  fail_assert "different pages produce different viewport screenshots"
+elif cmp -s "$FIRST_SCREENSHOT" "$SECOND_SCREENSHOT"; then
+  fail_assert "different pages produce different viewport screenshots"
+else
+  pass_assert "different pages produce different viewport screenshots"
+fi
+
+rm -f "$FIRST_SCREENSHOT" "$SECOND_SCREENSHOT"
 end_test
 
 start_test "pinchtab pdf"

--- a/tests/e2e/scenarios/cli/system-extended.sh
+++ b/tests/e2e/scenarios/cli/system-extended.sh
@@ -16,6 +16,19 @@ assert_exit_code 1 "connection failure is reported to automation"
 end_test
 
 # ─────────────────────────────────────────────────────────────────
+start_test "pinchtab 403 policy denial exits non-zero"
+
+pt network route "*.png" --abort
+assert_exit_code 1 "403 policy denial is reported to automation"
+if echo "$PT_ERR" | grep -q "Error 403"; then
+  pass_assert "policy denial reports HTTP 403"
+else
+  fail_assert "policy denial reports HTTP 403"
+fi
+
+end_test
+
+# ─────────────────────────────────────────────────────────────────
 start_test "pinchtab daemon (non-interactive shows status)"
 
 pt daemon

--- a/tests/e2e/scenarios/cli/system-extended.sh
+++ b/tests/e2e/scenarios/cli/system-extended.sh
@@ -5,6 +5,17 @@ GROUP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${GROUP_DIR}/../../helpers/cli.sh"
 
 # ─────────────────────────────────────────────────────────────────
+start_test "pinchtab transport failure exits non-zero"
+
+ORIGINAL_E2E_SERVER="$E2E_SERVER"
+E2E_SERVER="http://127.0.0.1:1"
+pt health
+E2E_SERVER="$ORIGINAL_E2E_SERVER"
+assert_exit_code 1 "connection failure is reported to automation"
+
+end_test
+
+# ─────────────────────────────────────────────────────────────────
 start_test "pinchtab daemon (non-interactive shows status)"
 
 pt daemon


### PR DESCRIPTION
## Summary
- make the CLI failure coverage explicitly prove non-zero exit on both transport failures and 403 navigation policy denials
- fix Windows viewport screenshots by forcing the compositor-surface capture path where headless software rendering can otherwise return a blank white image
- infer PNG output when `pinchtab screenshot -o` targets a `.png` path, and update CLI/docs to match the new behavior
- confine profile import destinations so imports cannot escape the claimed profile root through destination path tricks

Fixes #618
Fixes #619

## Verification
- `go test ./cmd/pinchtab ./internal/cdptk ./internal/cli/actions ./internal/cli/apiclient ./internal/profiles`
- `go build ./cmd/pinchtab`

## Notes
- I did not get a completed Docker e2e run from this environment, so the CLI shell-scenario additions still need confirmation from CI or a local Docker-backed run.
- This branch also includes a small profile-import hardening commit alongside the `#618` / `#619` work; I reviewed that too and did not find a concrete issue in it.
