### PR TITLE
fix: enforce tab cap against Chrome reality; make new profiles self-identifying

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,8 @@ RUN apk add --no-cache \
     harfbuzz \
     ca-certificates \
     ttf-freefont \
-    dumb-init
+    dumb-init \
+    curl
 
 # Non-root user; /data is the persistent volume mount point
 RUN adduser -D -h /data -g '' pinchtab && \

--- a/TESTING.md
+++ b/TESTING.md
@@ -40,6 +40,17 @@ go test ./...
 
 Unit tests are standard Go tests that validate individual packages and functions without launching a full server.
 
+### Transaction-policy browser proof
+
+The MV3 transaction-policy browser test is deliberately environment-gated because it needs an unpacked-extension-capable Chromium or Chrome for Testing binary; it is not claimed as a CI check. Run it explicitly with:
+
+```bash
+PINCHTAB_TEST_TRANSACTION_POLICY_CHROME=/path/to/chrome \
+  go test -tags=integration ./internal/bridge/runtime -run TestTransactionPolicyDNRIntegration -count=1
+```
+
+The fixture asserts HTTP and WebSocket evidence with server counters. Its TLS/WSS variant is not run against the self-signed local fixture because production launch flags intentionally reject certificate-bypass flags; WSS URL coverage remains unit-tested in the generated DNR rules.
+
 ## E2E Tests
 
 End-to-end tests launch a real pinchtab server with Chrome and run e2e-level tests against it.

--- a/cmd/pinchtab/cmd_cli_register.go
+++ b/cmd/pinchtab/cmd_cli_register.go
@@ -223,6 +223,7 @@ func configureManagementFlags() {
 	startInstanceCmd.Flags().String("profile", "", "Profile to use")
 	startInstanceCmd.Flags().String("mode", "", "Instance mode")
 	startInstanceCmd.Flags().String("port", "", "Port number")
+	startInstanceCmd.Flags().String("stealth-level", "", "Stealth level for this instance: light, medium, or full")
 	startInstanceCmd.Flags().StringArray("extension", nil, "Load browser extension (repeatable)")
 
 	activityCmd.PersistentFlags().Int("limit", 200, "Maximum number of events to return")

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -157,6 +157,7 @@ pinchtab instance start                 # Start an instance
 pinchtab instance start --profile <id-or-name>
 pinchtab instance start --mode headed
 pinchtab instance start --port <n>
+pinchtab instance start --stealth-level full
 pinchtab instance start --extension /path/to/ext
 pinchtab instance stop <id>             # Stop an instance
 pinchtab instance logs <id>             # Show instance logs

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -176,6 +176,12 @@ Current nested file-config shape:
     "uploadMaxFileBytes": 5242880,
     "uploadMaxTotalBytes": 10485760,
     "maxRedirects": -1,
+    "transactionPolicy": {
+      "enabled": false,
+      "hosts": [],
+      "denyRules": [],
+      "allowRules": []
+    },
     "attach": {
       "enabled": false,
       "allowHosts": ["127.0.0.1", "localhost", "::1"],
@@ -262,12 +268,47 @@ For Linux container compatibility, use the runtime-managed path instead of `brow
 | `server` | HTTP server settings, engine selection, proxy trust, and network buffer defaults |
 | `browser` | Chrome executable, version pin, extra flags, and extension paths |
 | `instanceDefaults` | Default behavior for managed instances |
-| `security` | Sensitive feature gates, transfer limits, attach policy, and IDPI |
+| `security` | Sensitive feature gates, transfer limits, transaction policy, attach policy, and IDPI |
 | `profiles` | Profile storage defaults |
 | `multiInstance` | Orchestrator strategy, allocation, port range, and restart policy |
 | `timeouts` | Action, navigation, shutdown, and navigation wait delays |
 | `scheduler` | Optional task queue |
 | `observability` | Activity logging and retention |
+
+## Transaction policy
+
+`security.transactionPolicy` is an operator-configured, restart-only browser network policy for supplier hosts. On each managed PinchTab launch, PinchTab compiles it into an unpacked Manifest V3 `declarativeNetRequest` extension under `server.stateDir` before Chrome starts. The extension permits GET/HEAD/OPTIONS reads by default (including existing order history, status, and invoices), permits explicit `allowRules` such as cart mutations and login POSTs, and blocks all other methods on listed hosts. `denyRules` take precedence over allows and the default block, and are required for enabled policies; a `method: "*"` deny can block GET navigation too. It covers managed pages, popups, workers, redirects, and WebSocket handshakes at the browser network layer.
+
+Hosts are exact (no subdomain expansion), with the DNS-equivalent trailing-dot spelling covered too. Paths, segments, and query pairs are case-insensitive but deliberately limited to unescaped unreserved ASCII so DNR's raw-URL matching cannot broaden a decoded allow rule. Unsafe query allows match the **entire** query exactly (`?key=value`, with an optional fragment): extra, duplicate, conflicting, or empty parameters do not inherit the allow. A deny query condition matches its exact pair anywhere in the query, including one single percent-encoded unreserved byte per request; extra or conflicting parameters cannot bypass the deny. Deny paths likewise cover one single percent-encoded unreserved byte per request plus encoded separators, which can only broaden a block. The policy is not raw-HTTP protection and does not terminate messages on an already-open allowed WebSocket. Policy changes are saved but take effect only after a full PinchTab restart. Enabled policy requires a PinchTab-managed launch with an explicitly configured Chromium or Chrome for Testing `browser.binary`; attached browsers and Google Chrome Stable are rejected. It also rejects `browser.extensionPaths`: policy mode loads only its generated extension.
+
+Example suitable for a mounted lue-kube `config.json`:
+
+```json
+{
+  "security": {
+    "transactionPolicy": {
+      "enabled": true,
+      "hosts": ["supplier.example"],
+      "denyRules": [
+        {"method": "*", "pathPrefix": "/", "pathSegment": "checkout"},
+        {"method": "*", "pathPrefix": "/", "pathSegment": "payment"},
+        {"method": "*", "pathPrefix": "/", "pathSegment": "cancel"},
+        {"method": "*", "pathPrefix": "/checkout"},
+        {"method": "*", "pathPrefix": "/payment"},
+        {"method": "POST", "pathPrefix": "/orders/place"},
+        {"method": "POST", "pathPrefix": "/orders/confirm"},
+        {"method": "POST", "pathPrefix": "/orders/reorder"},
+        {"method": "POST", "pathPrefix": "/orders/amend"},
+        {"method": "POST", "pathPrefix": "/orders/cancel"}
+      ],
+      "allowRules": [
+        {"method": "*", "pathPrefix": "/cart"},
+        {"method": "POST", "pathPrefix": "/", "queryParam": "wc-ajax", "queryValue": "add_to_cart"}
+      ]
+    }
+  }
+}
+```
 
 ## `config get` And `config set` Support
 

--- a/docs/reference/instances.md
+++ b/docs/reference/instances.md
@@ -127,10 +127,10 @@ You can also start an instance from a profile-oriented route:
 ```bash
 curl -X POST http://localhost:9867/profiles/prof_278be873/start \
   -H "Content-Type: application/json" \
-  -d '{"headless":false,"port":"9999"}'
+  -d '{"headless":false,"port":"9999","stealthLevel":"full"}'
 ```
 
-This route accepts a profile ID or profile name in the path. Unlike `/instances/start` and `/instances/launch`, its request body uses `headless` instead of `mode`.
+This route accepts a profile ID or profile name in the path. Unlike `/instances/start` and `/instances/launch`, its request body uses `headless` instead of `mode`. Pass `stealthLevel` (`light`, `medium`, or `full`) to override the configured default for this launch.
 
 ## Open A Tab In An Instance
 

--- a/docs/reference/profiles.md
+++ b/docs/reference/profiles.md
@@ -129,7 +129,7 @@ Start the active instance for a profile:
 ```bash
 curl -X POST http://localhost:9867/profiles/prof_278be873/start \
   -H "Content-Type: application/json" \
-  -d '{"headless":true}'
+  -d '{"headless":true,"stealthLevel":"full"}'
 # Response
 {
   "id": "inst_ea2e747f",
@@ -153,7 +153,7 @@ curl -X POST http://localhost:9867/profiles/prof_278be873/stop
 }
 ```
 
-For these orchestrator routes, the path can be a profile ID or profile name.
+For these orchestrator routes, the path can be a profile ID or profile name. `stealthLevel` is optional and overrides `instanceDefaults.stealthLevel` for this launch only; valid values are `light`, `medium`, and `full`.
 
 ## Check Whether A Profile Has A Running Instance
 

--- a/internal/bridge/action_text.go
+++ b/internal/bridge/action_text.go
@@ -7,28 +7,52 @@ import (
 	"github.com/chromedp/chromedp"
 )
 
+// concealedReply returns the safe response shape for an action that
+// successfully wrote text. When req.Concealed is set, the plaintext is
+// replaced with the literal string "[REDACTED]" and a length plus
+// `concealed: true` flag is added so callers can confirm redaction was
+// applied. When not concealed, the original echo behavior is preserved
+// for debugging form fills.
+//
+// Use this everywhere a handler would otherwise return
+// map[string]any{"<verb>": req.Text}.
+func concealedReply(verb string, req ActionRequest, extras map[string]any) map[string]any {
+	out := make(map[string]any, len(extras)+3)
+	for k, v := range extras {
+		out[k] = v
+	}
+	if req.Concealed {
+		out[verb] = "[REDACTED]"
+		out["len"] = len(req.Text)
+		out["concealed"] = true
+	} else {
+		out[verb] = req.Text
+	}
+	return out
+}
+
 func (b *Bridge) actionType(ctx context.Context, req ActionRequest) (map[string]any, error) {
 	if req.Text == "" {
 		return nil, fmt.Errorf("text required for type")
 	}
 	if req.Selector != "" {
-		return map[string]any{"typed": req.Text}, chromedp.Run(ctx,
+		return concealedReply("typed", req, nil), chromedp.Run(ctx,
 			chromedp.Click(req.Selector, chromedp.ByQuery),
 			chromedp.SendKeys(req.Selector, req.Text, chromedp.ByQuery),
 		)
 	}
 	if req.NodeID > 0 {
-		return map[string]any{"typed": req.Text}, TypeByNodeID(ctx, req.NodeID, req.Text)
+		return concealedReply("typed", req, nil), TypeByNodeID(ctx, req.NodeID, req.Text)
 	}
 	return nil, fmt.Errorf("need selector or ref")
 }
 
 func (b *Bridge) actionFill(ctx context.Context, req ActionRequest) (map[string]any, error) {
 	if req.Selector != "" {
-		return map[string]any{"filled": req.Text}, chromedp.Run(ctx, chromedp.SetValue(req.Selector, req.Text, chromedp.ByQuery))
+		return concealedReply("filled", req, nil), chromedp.Run(ctx, chromedp.SetValue(req.Selector, req.Text, chromedp.ByQuery))
 	}
 	if req.NodeID > 0 {
-		return map[string]any{"filled": req.Text}, FillByNodeID(ctx, req.NodeID, req.Text)
+		return concealedReply("filled", req, nil), FillByNodeID(ctx, req.NodeID, req.Text)
 	}
 	return nil, fmt.Errorf("need selector or ref")
 }
@@ -66,7 +90,7 @@ func (b *Bridge) actionHumanType(ctx context.Context, req ActionRequest) (map[st
 		return nil, err
 	}
 
-	return map[string]any{"typed": req.Text, "human": true}, nil
+	return concealedReply("typed", req, map[string]any{"human": true}), nil
 }
 
 func (b *Bridge) actionKeyboardType(ctx context.Context, req ActionRequest) (map[string]any, error) {
@@ -102,7 +126,7 @@ func (b *Bridge) actionKeyboardType(ctx context.Context, req ActionRequest) (map
 	if err != nil {
 		return nil, err
 	}
-	return map[string]any{"typed": req.Text}, nil
+	return concealedReply("typed", req, nil), nil
 }
 
 func (b *Bridge) actionKeyboardInsert(ctx context.Context, req ActionRequest) (map[string]any, error) {
@@ -117,7 +141,7 @@ func (b *Bridge) actionKeyboardInsert(ctx context.Context, req ActionRequest) (m
 	if err != nil {
 		return nil, err
 	}
-	return map[string]any{"inserted": req.Text}, nil
+	return concealedReply("inserted", req, nil), nil
 }
 
 func (b *Bridge) actionKeyDown(ctx context.Context, req ActionRequest) (map[string]any, error) {

--- a/internal/bridge/action_text_concealed_test.go
+++ b/internal/bridge/action_text_concealed_test.go
@@ -1,0 +1,107 @@
+package bridge
+
+import (
+	"strings"
+	"testing"
+)
+
+// Tests for concealedReply — the F4 redaction helper that prevents the
+// fill/type action handlers from echoing plaintext credentials in their
+// response bodies. See valkyriweb/pinchtab smilerite/v0.8.6-hardening
+// branch (origin: SMI-81 retro Finding 4).
+
+func TestConcealedReply_NotConcealed_EchoesPlaintext(t *testing.T) {
+	req := ActionRequest{Text: "hello", Concealed: false}
+	out := concealedReply("filled", req, nil)
+
+	if got, want := out["filled"], "hello"; got != want {
+		t.Fatalf("expected echoed plaintext %q, got %v", want, got)
+	}
+	if _, has := out["concealed"]; has {
+		t.Errorf("did not expect concealed flag on non-concealed reply, got %v", out)
+	}
+	if _, has := out["len"]; has {
+		t.Errorf("did not expect len field on non-concealed reply, got %v", out)
+	}
+}
+
+func TestConcealedReply_Concealed_Redacts(t *testing.T) {
+	req := ActionRequest{Text: "hunter2", Concealed: true}
+	out := concealedReply("filled", req, nil)
+
+	if got, want := out["filled"], "[REDACTED]"; got != want {
+		t.Fatalf("expected redacted marker %q, got %v", want, got)
+	}
+	if got, want := out["len"], 7; got != want {
+		t.Errorf("expected len=%d, got %v", want, got)
+	}
+	if got, want := out["concealed"], true; got != want {
+		t.Errorf("expected concealed=true, got %v", got)
+	}
+
+	// Critical correctness: the plaintext value MUST NOT appear anywhere
+	// in the reply. Walk every value (string-typed) and fail if it
+	// matches the original text. This catches future regressions like
+	// "extras shadow concealed" or "verb mistyped".
+	for k, v := range out {
+		if s, ok := v.(string); ok && strings.Contains(s, req.Text) {
+			t.Fatalf("plaintext %q leaked into reply key %q (value %q)", req.Text, k, s)
+		}
+	}
+}
+
+func TestConcealedReply_Concealed_PreservesExtras(t *testing.T) {
+	// actionHumanType returns {"typed": req.Text, "human": true} — the
+	// "human" flag must survive the redaction path.
+	req := ActionRequest{Text: "secret", Concealed: true}
+	out := concealedReply("typed", req, map[string]any{"human": true})
+
+	if got, want := out["human"], true; got != want {
+		t.Errorf("expected extras.human=true to survive, got %v", got)
+	}
+	if got, want := out["typed"], "[REDACTED]"; got != want {
+		t.Errorf("expected typed redacted, got %v", got)
+	}
+}
+
+func TestConcealedReply_Concealed_EmptyText(t *testing.T) {
+	// Edge: caller passes Concealed:true with empty Text. Still redact
+	// (don't leak the fact that the field was empty by echoing "" vs
+	// "[REDACTED]" — uniform shape).
+	req := ActionRequest{Text: "", Concealed: true}
+	out := concealedReply("filled", req, nil)
+
+	if got, want := out["filled"], "[REDACTED]"; got != want {
+		t.Errorf("expected redacted for empty concealed text, got %v", got)
+	}
+	if got, want := out["len"], 0; got != want {
+		t.Errorf("expected len=0, got %v", got)
+	}
+	if got, want := out["concealed"], true; got != want {
+		t.Errorf("expected concealed=true, got %v", got)
+	}
+}
+
+func TestConcealedReply_Concealed_UnicodeLen(t *testing.T) {
+	// len() returns byte length, not rune count. That's intentional:
+	// "did pinchtab type the whole thing?" is a byte-level question
+	// once chromedp hands the string to chromium. Document the choice
+	// via a test so a future "switch to utf8.RuneCountInString" doesn't
+	// land without re-thinking the contract.
+	req := ActionRequest{Text: "héllo", Concealed: true} // 6 bytes, 5 runes
+	out := concealedReply("filled", req, nil)
+
+	if got, want := out["len"], len(req.Text); got != want {
+		t.Errorf("expected len=%d bytes, got %v", want, got)
+	}
+}
+
+func TestActionRequest_JSON_ConcealedOmitemptyDefault(t *testing.T) {
+	// Concealed is an opt-in flag. The struct tag is `json:"concealed,omitempty"`
+	// so callers that don't know about it (e.g. older Smiles instructions)
+	// continue to work unchanged — zero value = false = echo behavior.
+	req := ActionRequest{Text: "hello"}
+	if req.Concealed {
+		t.Fatalf("default Concealed must be false (opt-in)")
+	}
+}

--- a/internal/bridge/bridge.go
+++ b/internal/bridge/bridge.go
@@ -484,6 +484,14 @@ type ActionRequest struct {
 	WaitNav bool   `json:"waitNav"`
 	Fast    bool   `json:"fast"`
 	Owner   string `json:"owner"`
+
+	// Concealed signals that req.Text holds a credential/secret
+	// (password, OTP, API key). When true, action handlers redact
+	// the value from their response body and return only metadata
+	// ({"filled":"[REDACTED]","len":N,"concealed":true}). Callers
+	// that capture the response into logs / agent transcripts /
+	// OTel spans no longer leak the secret.
+	Concealed bool `json:"concealed,omitempty"`
 }
 
 // NormalizeSelector merges legacy Ref and Selector (CSS) fields into the

--- a/internal/bridge/bridge.go
+++ b/internal/bridge/bridge.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/chromedp/cdproto/page"
 	"github.com/chromedp/chromedp"
+	bridgeruntime "github.com/pinchtab/pinchtab/internal/bridge/runtime"
 	"github.com/pinchtab/pinchtab/internal/config"
 	"github.com/pinchtab/pinchtab/internal/ids"
 	"github.com/pinchtab/pinchtab/internal/stealth"
@@ -137,7 +138,7 @@ func (b *Bridge) tabSetup(ctx context.Context) {
 	b.applyTargetStealth(ctx)
 	b.installWorkerStealthParity(ctx)
 	b.injectStealth(ctx)
-	if b.Config.NoAnimations {
+	if b.Config != nil && b.Config.NoAnimations {
 		if err := b.InjectNoAnimations(ctx); err != nil {
 			slog.Warn("no-animations injection failed", "err", err)
 		}
@@ -253,9 +254,14 @@ func (b *Bridge) EnsureChrome(cfg *config.RuntimeConfig) error {
 		}
 	}
 
-	slog.Info("starting chrome with confirmed profile", "headless", cfg.Headless, "profile", cfg.ProfileDir)
+	launchCfg, err := bridgeruntime.PrepareTransactionPolicyExtension(cfg)
+	if err != nil {
+		return fmt.Errorf("prepare transaction policy: %w", err)
+	}
+
+	slog.Info("starting chrome with confirmed profile", "headless", launchCfg.Headless, "profile", launchCfg.ProfileDir)
 	b.ensureStealthBundle()
-	allocCtx, allocCancel, browserCtx, browserCancel, launchMode, err := InitChrome(cfg, b.StealthBundle)
+	allocCtx, allocCancel, browserCtx, browserCancel, launchMode, err := InitChrome(launchCfg, b.StealthBundle)
 	if err != nil {
 		return fmt.Errorf("failed to initialize chrome: %w", err)
 	}
@@ -351,7 +357,10 @@ func (b *Bridge) Cleanup() {
 	}
 }
 
-func (b *Bridge) SetBrowserContexts(allocCtx context.Context, allocCancel context.CancelFunc, browserCtx context.Context, browserCancel context.CancelFunc) {
+func (b *Bridge) SetBrowserContexts(allocCtx context.Context, allocCancel context.CancelFunc, browserCtx context.Context, browserCancel context.CancelFunc) error {
+	if b.Config != nil && b.Config.TransactionPolicy.Enabled {
+		return fmt.Errorf("transaction policy requires a PinchTab-managed browser launch; attached browsers cannot load the required extension")
+	}
 	b.initMu.Lock()
 	defer b.initMu.Unlock()
 
@@ -373,6 +382,7 @@ func (b *Bridge) SetBrowserContexts(allocCtx context.Context, allocCancel contex
 		b.TabManager = NewTabManager(browserCtx, b.Config, b.IdMgr, b.LogStore, b.tabSetup)
 		b.SetDialogManager(b.Dialogs)
 	}
+	return nil
 }
 
 func (b *Bridge) ensureStealthBundle() {

--- a/internal/bridge/runtime/init.go
+++ b/internal/bridge/runtime/init.go
@@ -14,11 +14,13 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	goruntime "runtime"
 	"strconv"
 	"strings"
 	"time"
 
+	cdpruntime "github.com/chromedp/cdproto/runtime"
 	"github.com/chromedp/chromedp"
 	"github.com/pinchtab/pinchtab/internal/config"
 	"github.com/pinchtab/pinchtab/internal/stealth"
@@ -39,10 +41,16 @@ type Hooks struct {
 
 // InitChrome initializes a Chrome browser for a Bridge instance.
 func InitChrome(cfg *config.RuntimeConfig, bundle *stealth.Bundle, hooks Hooks) (context.Context, context.CancelFunc, context.Context, context.CancelFunc, stealth.LaunchMode, error) {
+	if err := validateTransactionPolicyLaunch(cfg); err != nil {
+		return nil, nil, nil, nil, stealth.LaunchModeUninitialized, err
+	}
 	slog.Info("starting chrome initialization", "headless", cfg.Headless, "profile", cfg.ProfileDir, "binary", cfg.ChromeBinary)
 
 	bundle = ensureStealthBundle(cfg, bundle)
-	allocCtx, allocCancel, opts, debugPort := setupAllocator(cfg, bundle, hooks)
+	allocCtx, allocCancel, opts, debugPort, err := setupAllocator(cfg, bundle, hooks)
+	if err != nil {
+		return nil, nil, nil, nil, stealth.LaunchModeUninitialized, err
+	}
 	browserCtx, browserCancel, launchMode, err := startChrome(allocCtx, cfg, bundle, opts, debugPort, hooks)
 	if err != nil {
 		allocCancel()
@@ -52,6 +60,52 @@ func InitChrome(cfg *config.RuntimeConfig, bundle *stealth.Bundle, hooks Hooks) 
 
 	slog.Info("chrome initialized successfully", "headless", cfg.Headless, "profile", cfg.ProfileDir)
 	return allocCtx, allocCancel, browserCtx, browserCancel, launchMode, nil
+}
+
+func validateTransactionPolicyLaunch(cfg *config.RuntimeConfig) error {
+	if cfg == nil || !cfg.TransactionPolicy.Enabled {
+		return nil
+	}
+	if strings.TrimSpace(cfg.ChromeBinary) == "" {
+		return fmt.Errorf("transaction policy requires browser.binary to name an unpacked-extension-capable Chromium or Chrome for Testing executable")
+	}
+	binary := strings.ToLower(strings.TrimSpace(cfg.ChromeBinary))
+	base := filepath.Base(binary)
+	// Chrome for Testing on macOS is named "Google Chrome for Testing" and is
+	// supported. Reject Stable by its app/path identity rather than matching the
+	// generic words "google chrome".
+	if (strings.Contains(binary, "google chrome") && !strings.Contains(binary, "for testing")) || base == "google-chrome" || base == "google-chrome-stable" || strings.Contains(binary, "program files/google/chrome/application") {
+		return fmt.Errorf("transaction policy does not support Google Chrome Stable; configure a compatible Chromium or Chrome for Testing executable")
+	}
+	// Policy activation is meaningful only when this generated extension is the
+	// sole extension Chrome can load. Do not accept a path merely because it has
+	// a familiar prefix: it must be a validated content-addressed generation.
+	if len(cfg.ExtensionPaths) != 1 {
+		return fmt.Errorf("transaction policy requires exactly one generated extension and rejects browser.extensionPaths")
+	}
+	if !isTransactionPolicyExtensionPath(cfg.StateDir, cfg.ExtensionPaths[0]) {
+		return fmt.Errorf("transaction policy extension is not a managed generated extension")
+	}
+	manifest, rules, err := compileTransactionPolicy(cfg.TransactionPolicy)
+	if err != nil {
+		return fmt.Errorf("recompile transaction policy for launch validation: %w", err)
+	}
+	if err := checkTransactionPolicyGenerationContent(cfg.ExtensionPaths[0], manifest, rules); err != nil {
+		return fmt.Errorf("transaction policy extension is unavailable, unsafe, or does not match policy: %w", err)
+	}
+	return nil
+}
+
+func isTransactionPolicyExtensionPath(stateDir, extensionPath string) bool {
+	stateRoot, err := filepath.Abs(stateDir)
+	if err != nil {
+		return false
+	}
+	path, err := filepath.Abs(extensionPath)
+	if err != nil || filepath.Dir(path) != filepath.Join(stateRoot, transactionPolicyStateRoot) {
+		return false
+	}
+	return transactionPolicyGenerationName.MatchString(filepath.Base(path))
 }
 
 func findChromeBinary() string {
@@ -106,7 +160,13 @@ func appendExecAllocatorFlags(opts []chromedp.ExecAllocatorOption, flags []strin
 	return opts
 }
 
-func setupAllocator(cfg *config.RuntimeConfig, bundle *stealth.Bundle, hooks Hooks) (context.Context, context.CancelFunc, []chromedp.ExecAllocatorOption, int) {
+func setupAllocator(cfg *config.RuntimeConfig, bundle *stealth.Bundle, hooks Hooks) (context.Context, context.CancelFunc, []chromedp.ExecAllocatorOption, int, error) {
+	// Recheck immediately before building allocator arguments. If the generated
+	// directory vanished after InitChrome's first check, do not silently launch
+	// with profile extensions or an unprotected browser.
+	if err := validateTransactionPolicyLaunch(cfg); err != nil {
+		return nil, nil, nil, 0, err
+	}
 	opts := []chromedp.ExecAllocatorOption{
 		chromedp.NoFirstRun,
 		chromedp.NoDefaultBrowserCheck,
@@ -183,7 +243,7 @@ func setupAllocator(cfg *config.RuntimeConfig, bundle *stealth.Bundle, hooks Hoo
 	}))
 
 	ctx, cancel := context.WithCancel(context.Background())
-	return ctx, cancel, opts, debugPort
+	return ctx, cancel, opts, debugPort, nil
 }
 
 func startChrome(parentCtx context.Context, cfg *config.RuntimeConfig, bundle *stealth.Bundle, opts []chromedp.ExecAllocatorOption, debugPort int, hooks Hooks) (context.Context, context.CancelFunc, stealth.LaunchMode, error) {
@@ -239,6 +299,14 @@ func startChromeWithRecovery(parentCtx context.Context, cfg *config.RuntimeConfi
 		return nil, nil, stealth.LaunchModeUninitialized, fmt.Errorf("failed to connect to chrome: %w", err)
 	}
 
+	if cfg.TransactionPolicy.Enabled {
+		if err := verifyTransactionPolicyExtension(browserCtx); err != nil {
+			browserCancel()
+			allocCancel()
+			return nil, nil, stealth.LaunchModeUninitialized, fmt.Errorf("transaction policy extension did not activate: %w", err)
+		}
+	}
+
 	if err := chromedp.Run(browserCtx, chromedp.ActionFunc(func(ctx context.Context) error {
 		if err := stealth.ApplyTargetEmulation(ctx, cfg, bundle.LaunchUserAgent()); err != nil {
 			return err
@@ -256,6 +324,53 @@ func startChromeWithRecovery(parentCtx context.Context, cfg *config.RuntimeConfi
 	}, stealth.LaunchModeAllocator, nil
 }
 
+func hasExactTransactionPolicyRulesets(enabled []string) bool {
+	return len(enabled) == 1 && enabled[0] == transactionPolicyRulesetID
+}
+
+func verifyTransactionPolicyExtension(browserCtx context.Context) error {
+	// The fixed manifest key makes this exact extension URL an identity-bound
+	// probe. Evaluate DNR directly in that extension page; MV3 workers need not
+	// be separately visible or attachable through Target.getTargets.
+	if err := chromedp.Run(browserCtx, chromedp.Navigate("chrome-extension://"+transactionPolicyExtensionID+"/probe.html")); err != nil {
+		return fmt.Errorf("open generated extension activation probe: %w", err)
+	}
+	var state struct {
+		Enabled     []string `json:"enabled"`
+		Unsupported []int    `json:"unsupported"`
+		Disabled    []int    `json:"disabled"`
+		RuleCount   int      `json:"ruleCount"`
+	}
+	const probe = `(async () => {
+		const rules = await (await fetch(chrome.runtime.getURL('rules.json'), {cache: 'no-store'})).json();
+		const support = await Promise.all(rules.map(async rule => ({
+			id: rule.id,
+			result: await chrome.declarativeNetRequest.isRegexSupported({
+				regex: rule.condition.regexFilter,
+				isCaseSensitive: rule.condition.isUrlFilterCaseSensitive
+			})
+		})));
+		return {
+			enabled: Array.from(await chrome.declarativeNetRequest.getEnabledRulesets()),
+			unsupported: support.filter(item => !item.result.isSupported).map(item => item.id),
+			disabled: Array.from(await chrome.declarativeNetRequest.getDisabledRuleIds({rulesetId: 'pinchtab_transaction_policy'})),
+			ruleCount: rules.length
+		};
+	})()`
+	if err := chromedp.Run(browserCtx, chromedp.Evaluate(probe, &state, func(p *cdpruntime.EvaluateParams) *cdpruntime.EvaluateParams {
+		return p.WithAwaitPromise(true)
+	})); err != nil {
+		return fmt.Errorf("inspect generated extension rules: %w", err)
+	}
+	if !hasExactTransactionPolicyRulesets(state.Enabled) {
+		return fmt.Errorf("generated ruleset %q was not exclusively enabled (enabled rulesets=%v)", transactionPolicyRulesetID, state.Enabled)
+	}
+	if state.RuleCount == 0 || len(state.Unsupported) != 0 || len(state.Disabled) != 0 {
+		return fmt.Errorf("generated ruleset is incomplete (rules=%d unsupported=%v disabled=%v)", state.RuleCount, state.Unsupported, state.Disabled)
+	}
+	return nil
+}
+
 func isStartupTimeout(err error) bool {
 	if errors.Is(err, context.DeadlineExceeded) {
 		return true
@@ -265,6 +380,12 @@ func isStartupTimeout(err error) bool {
 }
 
 func startChromeWithRemoteAllocator(parentCtx context.Context, cfg *config.RuntimeConfig, bundle *stealth.Bundle, debugPort int, injectedStealthScript string) (context.Context, context.CancelFunc, stealth.LaunchMode, error) {
+	// This path can be reached after allocator startup has timed out. Keep its
+	// guard independent so a future direct caller cannot bypass policy launch
+	// validation before starting a process.
+	if err := validateTransactionPolicyLaunch(cfg); err != nil {
+		return nil, nil, stealth.LaunchModeUninitialized, err
+	}
 	chromeBinary := cfg.ChromeBinary
 	if chromeBinary == "" {
 		chromeBinary = findChromeBinary()
@@ -290,6 +411,18 @@ func startChromeWithRemoteAllocator(parentCtx context.Context, cfg *config.Runti
 
 	remoteAllocCtx, remoteAllocCancel := chromedp.NewRemoteAllocator(parentCtx, wsURL)
 	browserCtx, browserCancel := chromedp.NewContext(remoteAllocCtx)
+
+	// The direct-launch recovery path must prove the extension activated too;
+	// otherwise a startup workaround could turn an enabled policy into an
+	// unprotected managed browser.
+	if cfg.TransactionPolicy.Enabled {
+		if err := verifyTransactionPolicyExtension(browserCtx); err != nil {
+			browserCancel()
+			remoteAllocCancel()
+			_ = cmd.Process.Kill()
+			return nil, nil, stealth.LaunchModeUninitialized, fmt.Errorf("transaction policy extension did not activate: %w", err)
+		}
+	}
 
 	if err := chromedp.Run(browserCtx, chromedp.ActionFunc(func(ctx context.Context) error {
 		if err := stealth.ApplyTargetEmulation(ctx, cfg, bundle.LaunchUserAgent()); err != nil {
@@ -395,6 +528,9 @@ func chromeNeedsNoSandbox() bool {
 }
 
 func BuildChromeArgs(cfg *config.RuntimeConfig, port int) []string {
+	// InitChrome and the direct fallback both validate before process launch.
+	// This helper is retained for argument inspection by callers and must never
+	// be used as a launch authorization boundary.
 	return buildChromeArgsWithBundle(cfg, nil, port)
 }
 

--- a/internal/bridge/runtime/transaction_policy.go
+++ b/internal/bridge/runtime/transaction_policy.go
@@ -1,0 +1,266 @@
+package runtime
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/pinchtab/pinchtab/internal/config"
+)
+
+const (
+	transactionPolicyRulesetID   = "pinchtab_transaction_policy"
+	transactionPolicyExtensionID = "amadgaedoaaekpjejecafmbdhacgmlig"
+	transactionPolicyManifestKey = "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuinfEBuVQwc6FKF/tVRTn6rfITooe1jQaIMYk/rTRwYg4Pe1GqvFafjT7ghbL58Tjf55M+VhVhvEMSIzCPzjRfp7m8cUgm8/Qz7b86DRkyBzz+ovEMvtZLtN8f8xLIaR1dWVt++Lti1QOMBDNB6DVdGIDGUJm5xXVWhQTh1pRRBY2Fcbg5BgH4SG8/VAOXbVnXuXvniKf1skZlO3lUZeTVBlF8Rly4Drgep/B5wQEVhIiiomm+LV6saes6nKHbMysFlgfAOxL7wiEt6oqtFvGfh+QiVe8pazpA1N6Xf8Q47ljG2oTEtdGaPouHdOcnNwC0WtZ8p8LfhL7zqVqpCkpQIDAQAB"
+	maxTransactionPolicyRules    = 25000
+)
+
+type transactionPolicyManifest struct {
+	ManifestVersion       int           `json:"manifest_version"`
+	Name                  string        `json:"name"`
+	Version               string        `json:"version"`
+	Key                   string        `json:"key"`
+	Permissions           []string      `json:"permissions"`
+	HostPermissions       []string      `json:"host_permissions"`
+	DeclarativeNetRequest dnrSpec       `json:"declarative_net_request"`
+	Background            dnrBackground `json:"background"`
+}
+
+type dnrBackground struct {
+	ServiceWorker string `json:"service_worker"`
+}
+type dnrSpec struct {
+	RuleResources []dnrResource `json:"rule_resources"`
+}
+type dnrResource struct {
+	ID      string `json:"id"`
+	Enabled bool   `json:"enabled"`
+	Path    string `json:"path"`
+}
+type dnrRule struct {
+	ID        int          `json:"id"`
+	Priority  int          `json:"priority"`
+	Action    dnrAction    `json:"action"`
+	Condition dnrCondition `json:"condition"`
+}
+type dnrAction struct {
+	Type string `json:"type"`
+}
+type dnrCondition struct {
+	RegexFilter              string   `json:"regexFilter"`
+	IsURLFilterCaseSensitive bool     `json:"isUrlFilterCaseSensitive"`
+	RequestMethods           []string `json:"requestMethods,omitempty"`
+	ExcludedRequestMethods   []string `json:"excludedRequestMethods,omitempty"`
+}
+
+// PrepareTransactionPolicyExtension compiles the configured policy into an
+// unpacked MV3 extension. Policy mode deliberately loads no operator supplied
+// extensions: an additional extension could spoof activation or change DNR.
+func PrepareTransactionPolicyExtension(cfg *config.RuntimeConfig) (*config.RuntimeConfig, error) {
+	if cfg == nil || !cfg.TransactionPolicy.Enabled {
+		return cfg, nil
+	}
+	if strings.TrimSpace(cfg.StateDir) == "" {
+		return nil, fmt.Errorf("transaction policy requires server.stateDir")
+	}
+	if len(cfg.ExtensionPaths) != 0 {
+		return nil, fmt.Errorf("transaction policy cannot be used with browser.extensionPaths")
+	}
+	manifest, rules, err := compileTransactionPolicy(cfg.TransactionPolicy)
+	if err != nil {
+		return nil, fmt.Errorf("compile transaction policy: %w", err)
+	}
+	path, err := writeTransactionPolicyExtension(cfg.StateDir, manifest, rules)
+	if err != nil {
+		return nil, fmt.Errorf("write transaction policy extension: %w", err)
+	}
+	launch := *cfg
+	launch.ExtensionPaths = []string{path}
+	return &launch, nil
+}
+
+func compileTransactionPolicy(policy config.TransactionPolicyConfig) (transactionPolicyManifest, []dnrRule, error) {
+	if !policy.Enabled {
+		return transactionPolicyManifest{}, nil, nil
+	}
+	if errs := config.ValidateFileConfig(&config.FileConfig{Security: config.SecurityConfig{TransactionPolicy: policy}}); len(errs) != 0 {
+		return transactionPolicyManifest{}, nil, fmt.Errorf("invalid policy: %v", errs[0])
+	}
+	hosts := append([]string(nil), policy.Hosts...)
+	for i := range hosts {
+		hosts[i] = strings.ToLower(strings.TrimSuffix(strings.TrimSpace(hosts[i]), "."))
+	}
+	sort.Strings(hosts)
+	hosts = compactStrings(hosts)
+	manifest := transactionPolicyManifest{ManifestVersion: 3, Name: "PinchTab Transaction Policy", Version: "1.0", Key: transactionPolicyManifestKey, Permissions: []string{"declarativeNetRequest"}, HostPermissions: transactionHostPermissions(hosts), DeclarativeNetRequest: dnrSpec{RuleResources: []dnrResource{{ID: transactionPolicyRulesetID, Enabled: true, Path: "rules.json"}}}, Background: dnrBackground{ServiceWorker: "background.js"}}
+	rules := make([]dnrRule, 0, len(hosts)*(len(policy.DenyRules)+len(policy.AllowRules)+1))
+	id := 1
+	appendRules := func(source []config.TransactionPolicyRule, priority int, action string, encodePath bool) error {
+		for _, rule := range source {
+			for _, host := range hosts {
+				regexes, err := transactionRuleRegexes(host, rule, encodePath)
+				if err != nil {
+					return err
+				}
+				for _, regex := range regexes {
+					if err := validateDNRRegex(regex); err != nil {
+						return err
+					}
+					condition := dnrCondition{RegexFilter: regex, IsURLFilterCaseSensitive: false}
+					if method := strings.ToLower(strings.TrimSpace(rule.Method)); method != "*" {
+						condition.RequestMethods = []string{method}
+					}
+					rules = append(rules, dnrRule{ID: id, Priority: priority, Action: dnrAction{Type: action}, Condition: condition})
+					id++
+				}
+			}
+		}
+		return nil
+	}
+	// Denies use an encoding-tolerant path representation. This only broadens a
+	// block, never an allow, so URL serialization ambiguities fail closed.
+	if err := appendRules(policy.DenyRules, 3, "block", true); err != nil {
+		return transactionPolicyManifest{}, nil, err
+	}
+	if err := appendRules(policy.AllowRules, 2, "allow", false); err != nil {
+		return transactionPolicyManifest{}, nil, err
+	}
+	for _, host := range hosts {
+		regex := "^(https?|wss?)://([^/?#@]*@)?" + regexp.QuoteMeta(host) + "(\\.)?(:[0-9]+)?(/|$)"
+		if err := validateDNRRegex(regex); err != nil {
+			return transactionPolicyManifest{}, nil, err
+		}
+		rules = append(rules, dnrRule{ID: id, Priority: 1, Action: dnrAction{Type: "block"}, Condition: dnrCondition{RegexFilter: regex, IsURLFilterCaseSensitive: false, ExcludedRequestMethods: []string{"get", "head", "options"}}})
+		id++
+	}
+	if len(rules) > maxTransactionPolicyRules {
+		return transactionPolicyManifest{}, nil, fmt.Errorf("policy produces %d rules, maximum is %d", len(rules), maxTransactionPolicyRules)
+	}
+	return manifest, rules, nil
+}
+
+func validateDNRRegex(regex string) error {
+	if len(regex) > 2000 {
+		return fmt.Errorf("DNR regex exceeds the 2000 byte limit")
+	}
+	if _, err := regexp.Compile(regex); err != nil {
+		return fmt.Errorf("invalid DNR regex: %w", err)
+	}
+	return nil
+}
+func transactionHostPermissions(hosts []string) []string {
+	permissions := make([]string, 0, len(hosts)*4)
+	for _, host := range hosts {
+		for _, name := range []string{host, host + "."} {
+			permissions = append(permissions, "http://"+name+"/*", "https://"+name+"/*")
+		}
+	}
+	return permissions
+}
+
+// transactionRuleRegexes describes the raw network URL. Denies get one raw
+// regex plus one variant for each single percent-encoded unreserved byte.
+// Separate simple regexes stay within Chrome DNR's RE2 memory limit; a single
+// regex with an alternation at every byte is rejected for ordinary route names.
+func transactionRuleRegexes(host string, rule config.TransactionPolicyRule, encodePath bool) ([]string, error) {
+	base, positions, err := transactionRuleRegexVariant(host, rule, encodePath, -1)
+	if err != nil {
+		return nil, err
+	}
+	regexes := []string{base}
+	if !encodePath {
+		return regexes, nil
+	}
+	for position := 0; position < positions; position++ {
+		variant, _, err := transactionRuleRegexVariant(host, rule, true, position)
+		if err != nil {
+			return nil, err
+		}
+		regexes = append(regexes, variant)
+	}
+	return regexes, nil
+}
+
+func transactionRuleRegexVariant(host string, rule config.TransactionPolicyRule, encodePath bool, encodeAt int) (string, int, error) {
+	prefix := strings.TrimSuffix(strings.TrimSpace(rule.PathPrefix), "/")
+	if prefix == "" {
+		prefix = "/"
+	}
+	segment := strings.TrimSpace(rule.PathSegment)
+	position := 0
+	literal := func(value string) string {
+		if !encodePath {
+			return regexp.QuoteMeta(value)
+		}
+		var b strings.Builder
+		for i := 0; i < len(value); i++ {
+			c := value[i]
+			if c == '/' {
+				// A run covers the serialized root slash followed by an encoded
+				// separator without adding per-byte regex alternations.
+				b.WriteString("(/|%2F)+")
+				continue
+			}
+			if position == encodeAt {
+				fmt.Fprintf(&b, "%%%02X", c)
+			} else {
+				b.WriteString(regexp.QuoteMeta(string(c)))
+			}
+			position++
+		}
+		return b.String()
+	}
+	separator := "/"
+	if encodePath {
+		separator = "(/|%2F)"
+	}
+	var pathPart string
+	switch {
+	case segment == "" && prefix == "/":
+		pathPart = "/[^?]*"
+	case segment == "":
+		pathPart = literal(prefix) + "(" + separator + "[^?]*)?"
+	case prefix == "/":
+		pathPart = separator + "([^?]*" + separator + ")?" + literal(segment) + "(" + separator + "[^?]*)?"
+	case pathPrefixHasSegment(prefix, segment):
+		pathPart = literal(prefix) + "(" + separator + "[^?]*)?"
+	default:
+		pathPart = literal(prefix) + "(" + separator + "[^?]*)?" + separator + literal(segment) + "(" + separator + "[^?]*)?"
+	}
+	query := "(\\?[^#]*)?(#.*)?$"
+	if rule.QueryParam != "" {
+		if encodePath {
+			// Denies match the configured pair anywhere in the query. Extra or
+			// conflicting parameters cannot turn a forbidden action into an allow.
+			pair := literal(rule.QueryParam) + "=" + literal(rule.QueryValue)
+			query = "\\?([^#&]*&)*" + pair + "(&[^#]*)?(#.*)?$"
+		} else {
+			// Allows must have exactly this whole query. A query condition is not a
+			// permission to add another action, duplicate, or empty value.
+			query = "\\?" + regexp.QuoteMeta(rule.QueryParam) + "=" + regexp.QuoteMeta(rule.QueryValue) + "(#.*)?$"
+		}
+	}
+	regex := "^(https?|wss?)://([^/?#@]*@)?" + regexp.QuoteMeta(host) + "(\\.)?(:[0-9]+)?" + pathPart + query
+	return regex, position, nil
+}
+func pathPrefixHasSegment(prefix, segment string) bool {
+	for _, part := range strings.Split(strings.Trim(prefix, "/"), "/") {
+		if strings.EqualFold(part, segment) {
+			return true
+		}
+	}
+	return false
+}
+func compactStrings(values []string) []string {
+	if len(values) == 0 {
+		return values
+	}
+	out := values[:1]
+	for _, value := range values[1:] {
+		if value != out[len(out)-1] {
+			out = append(out, value)
+		}
+	}
+	return out
+}

--- a/internal/bridge/runtime/transaction_policy_integration_test.go
+++ b/internal/bridge/runtime/transaction_policy_integration_test.go
@@ -1,0 +1,140 @@
+//go:build integration
+
+package runtime
+
+import (
+	"crypto/sha1"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/chromedp/chromedp"
+	"github.com/pinchtab/pinchtab/internal/config"
+)
+
+// Run manually with an unpacked-extension-capable Chrome for Testing or Chromium:
+//
+//	PINCHTAB_TEST_TRANSACTION_POLICY_CHROME=/path/to/chrome \
+//	  go test -tags=integration ./internal/bridge/runtime -run TestTransactionPolicyDNRIntegration -count=1
+//
+// This is environment-gated and is not asserted to run in CI. The fixture uses
+// server-side counters only; a blocked request has no JavaScript "attempt" flag
+// that could turn a browser failure into a passing policy proof.
+func TestTransactionPolicyDNRIntegration(t *testing.T) {
+	binary := os.Getenv("PINCHTAB_TEST_TRANSACTION_POLICY_CHROME")
+	if binary == "" {
+		t.Skip("set PINCHTAB_TEST_TRANSACTION_POLICY_CHROME to a Chrome for Testing or Chromium binary")
+	}
+	var mu sync.Mutex
+	counts := map[string]int{}
+	count := func(path string) int { mu.Lock(); defer mu.Unlock(); return counts[path] }
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		counts[r.URL.Path]++
+		mu.Unlock()
+		switch r.URL.Path {
+		case "/worker.js":
+			w.Header().Set("Content-Type", "application/javascript")
+			_, _ = w.Write([]byte(`fetch('/worker-forbidden',{method:'POST'}).catch(()=>{}).then(()=>fetch('/worker-ran'));`))
+		case "/shared-worker.js":
+			w.Header().Set("Content-Type", "application/javascript")
+			_, _ = w.Write([]byte(`fetch('/shared-worker-forbidden',{method:'POST'}).catch(()=>{}).then(()=>fetch('/shared-worker-ran'));`))
+		case "/service-worker.js":
+			w.Header().Set("Content-Type", "application/javascript")
+			_, _ = w.Write([]byte(`self.addEventListener('install', e => e.waitUntil(fetch('/service-worker-forbidden',{method:'POST'}).catch(()=>{}).then(()=>fetch('/service-worker-ran'))));`))
+		case "/redirect":
+			http.Redirect(w, r, "/redirect-forbidden", http.StatusTemporaryRedirect)
+		case "/ws-allowed":
+			// A real 101 response makes the counter evidence an actual WebSocket
+			// handshake rather than merely a JavaScript construction attempt.
+			h, ok := w.(http.Hijacker)
+			if !ok {
+				http.Error(w, "hijacking unavailable", http.StatusInternalServerError)
+				return
+			}
+			conn, rw, err := h.Hijack()
+			if err != nil {
+				return
+			}
+			defer conn.Close()
+			sum := sha1.Sum([]byte(r.Header.Get("Sec-WebSocket-Key") + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"))
+			_, _ = rw.WriteString("HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: " + base64.StdEncoding.EncodeToString(sum[:]) + "\r\n\r\n")
+			_ = rw.Flush()
+		default:
+			w.Header().Set("Content-Type", "text/html")
+			_, _ = w.Write([]byte(`<!doctype html><iframe name=normal hidden></iframe>
+<form action=/form-forbidden method=POST target=normal><input name=x value=1></form>
+<form action=/popup-initial-forbidden method=POST target=policyPopup><input name=x value=1></form>
+<script>
+fetch('/page-forbidden',{method:'POST'}).catch(()=>{}).then(()=>fetch('/page-ran'));
+document.forms[0].submit(); fetch('/form-ran'); document.forms[1].submit();
+new Worker('/worker.js'); new SharedWorker('/shared-worker.js'); navigator.serviceWorker && navigator.serviceWorker.register('/service-worker.js');
+fetch('/redirect',{method:'POST'}).catch(()=>{});
+new WebSocket(location.origin.replace(/^http/,'ws')+'/ws-forbidden'); new WebSocket(location.origin.replace(/^http/,'ws')+'/ws-allowed');
+fetch('/cart/add',{method:'POST'}); fetch('/cart/update',{method:'POST'}); fetch('/cart/remove',{method:'POST'});
+fetch('/checkout',{method:'POST'}); fetch('/chec%6bout',{method:'POST'});
+const trailing = location.origin.replace('//127.0.0.1:', '//127.0.0.1.:'); fetch(trailing+'/trailing-read'); fetch(trailing+'/trailing-forbidden',{method:'POST'});
+fetch('/?wc-ajax=add_to_cart',{method:'POST'}); fetch('/?wc-ajax=add_to_cart&action=checkout',{method:'POST'});
+fetch('/?action=checkout'); fetch('/?%61ction=checkout'); fetch('/?action=%63heckout'); fetch('/?action=cart');
+fetch('/read'); fetch('/read',{method:'HEAD'});
+</script>`))
+		}
+	}))
+	defer server.Close()
+	cfg := &config.RuntimeConfig{StateDir: t.TempDir(), ProfileDir: t.TempDir(), ChromeBinary: binary, Headless: true, TransactionPolicy: config.TransactionPolicyConfig{Enabled: true, Hosts: []string{"127.0.0.1"}, DenyRules: []config.TransactionPolicyRule{{Method: "*", PathPrefix: "/page-forbidden"}, {Method: "*", PathPrefix: "/form-forbidden"}, {Method: "*", PathPrefix: "/popup-initial-forbidden"}, {Method: "*", PathPrefix: "/worker-forbidden"}, {Method: "*", PathPrefix: "/shared-worker-forbidden"}, {Method: "*", PathPrefix: "/service-worker-forbidden"}, {Method: "*", PathPrefix: "/redirect-forbidden"}, {Method: "*", PathPrefix: "/ws-forbidden"}, {Method: "*", PathPrefix: "/checkout"}, {Method: "*", PathPrefix: "/trailing-forbidden"}, {Method: "*", PathPrefix: "/", QueryParam: "action", QueryValue: "checkout"}}, AllowRules: []config.TransactionPolicyRule{{Method: "POST", PathPrefix: "/cart"}, {Method: "POST", PathPrefix: "/redirect"}, {Method: "*", PathPrefix: "/ws-allowed"}, {Method: "POST", PathPrefix: "/checkout"}, {Method: "POST", PathPrefix: "/", QueryParam: "wc-ajax", QueryValue: "add_to_cart"}}}}
+	launch, err := PrepareTransactionPolicyExtension(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, allocCancel, browserCtx, browserCancel, _, err := InitChrome(launch, nil, Hooks{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer allocCancel()
+	defer browserCancel()
+	if err := chromedp.Run(browserCtx, chromedp.Navigate(server.URL)); err != nil {
+		t.Fatal(err)
+	}
+	need := []string{"/", "/trailing-read", "/cart/add", "/cart/update", "/cart/remove", "/redirect", "/worker.js", "/worker-ran", "/shared-worker.js", "/shared-worker-ran", "/service-worker.js", "/service-worker-ran", "/page-ran", "/form-ran", "/ws-allowed"}
+	deadline := time.Now().Add(8 * time.Second)
+	for time.Now().Before(deadline) {
+		ready := true
+		for _, path := range need {
+			if count(path) == 0 {
+				ready = false
+				break
+			}
+		}
+		if ready && count("/") >= 3 && count("/read") >= 2 {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	for _, path := range []string{"/page-forbidden", "/form-forbidden", "/popup-initial-forbidden", "/worker-forbidden", "/shared-worker-forbidden", "/service-worker-forbidden", "/redirect-forbidden", "/ws-forbidden", "/checkout", "/trailing-forbidden"} {
+		if got := count(path); got != 0 {
+			t.Errorf("forbidden request %s reached fixture %d times", path, got)
+		}
+	}
+	for _, path := range need {
+		if got := count(path); got == 0 {
+			t.Errorf("allowed request %s did not reach fixture", path)
+		}
+	}
+	if got := count("/"); got != 3 {
+		t.Errorf("query deny bypass/broadening or missing exact query allow: root count = %d", got)
+	}
+	if got := count("/read"); got < 2 {
+		t.Errorf("allowed GET/HEAD reads did not reach fixture twice: %d", got)
+	}
+	if t.Failed() {
+		mu.Lock()
+		snapshot := fmt.Sprint(counts)
+		mu.Unlock()
+		t.Logf("fixture counters: %s", snapshot)
+	}
+}

--- a/internal/bridge/runtime/transaction_policy_state.go
+++ b/internal/bridge/runtime/transaction_policy_state.go
@@ -1,0 +1,297 @@
+package runtime
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"sort"
+	"time"
+)
+
+const (
+	transactionPolicyStateRoot      = "transaction-policy"
+	transactionPolicyCurrentFile    = "current"
+	maxTransactionPolicyGenerations = 4
+)
+
+var transactionPolicyGenerationName = regexp.MustCompile(`^generation-[a-f0-9]{64}$`)
+
+func writeTransactionPolicyExtension(stateDir string, manifest transactionPolicyManifest, rules []dnrRule) (string, error) {
+	stateRoot, err := filepath.Abs(stateDir)
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(stateRoot, 0700); err != nil {
+		return "", err
+	} // never chmod StateDir
+	// StateDir may be shared with other application state and may intentionally
+	// have broader permissions. Only our dedicated child is policy-owned.
+	if err := checkStateDirectory(stateRoot); err != nil {
+		return "", fmt.Errorf("unsafe stateDir: %w", err)
+	}
+	root := filepath.Join(stateRoot, transactionPolicyStateRoot)
+	if err := os.Mkdir(root, 0700); err != nil && !os.IsExist(err) {
+		return "", err
+	}
+	if err := checkPolicyDirectory(root); err != nil {
+		return "", fmt.Errorf("unsafe transaction policy state root: %w", err)
+	}
+	unlock, err := lockTransactionPolicyRoot(root)
+	if err != nil {
+		return "", err
+	}
+	defer unlock()
+	manifestData, err := jsonData(manifest)
+	if err != nil {
+		return "", err
+	}
+	rulesData, err := jsonData(rules)
+	if err != nil {
+		return "", err
+	}
+	background := []byte("chrome.runtime.onMessage.addListener((_, __, reply) => { chrome.declarativeNetRequest.getEnabledRulesets().then(reply); return true; });\n")
+	probe := []byte("<script>chrome.runtime.sendMessage({pinchTabPolicyProbe: true});</script>\n")
+	digest := policyDigest(manifestData, rulesData, background, probe)
+	name := "generation-" + digest
+	target := filepath.Join(root, name)
+	if _, err := os.Lstat(target); err == nil {
+		if err := checkTransactionPolicyGenerationContent(target, manifest, rules); err != nil {
+			return "", err
+		}
+	} else if !os.IsNotExist(err) {
+		return "", err
+	} else {
+		staging, err := os.MkdirTemp(root, ".staging-")
+		if err != nil {
+			return "", err
+		}
+		defer os.RemoveAll(staging)
+		if err := os.Chmod(staging, 0700); err != nil {
+			return "", err
+		}
+		for _, file := range []struct {
+			name string
+			data []byte
+		}{{"manifest.json", manifestData}, {"rules.json", rulesData}, {"background.js", background}, {"probe.html", probe}} {
+			if err := os.WriteFile(filepath.Join(staging, file.name), file.data, 0600); err != nil {
+				return "", err
+			}
+		}
+		if err := os.Rename(staging, target); err != nil {
+			return "", err
+		}
+	}
+	if err := publishTransactionPolicyCurrent(root, name); err != nil {
+		return "", err
+	}
+	if err := retainTransactionPolicyGenerations(root, name); err != nil {
+		return "", err
+	}
+	return target, nil
+}
+
+func jsonData(value any) ([]byte, error) {
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(data, '\n'), nil
+}
+func policyDigest(parts ...[]byte) string {
+	h := sha256.New()
+	for _, part := range parts {
+		_, _ = h.Write([]byte(fmt.Sprintf("%d:", len(part))))
+		_, _ = h.Write(part)
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func checkStateDirectory(path string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&fs.ModeSymlink != 0 || !info.IsDir() {
+		return fmt.Errorf("not a real directory")
+	}
+	return nil
+}
+
+func checkPolicyDirectory(path string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&fs.ModeSymlink != 0 || !info.IsDir() {
+		return fmt.Errorf("not a real directory")
+	}
+	if info.Mode().Perm()&0077 != 0 {
+		return fmt.Errorf("permissions %o are not private", info.Mode().Perm())
+	}
+	return checkPolicyOwner(info)
+}
+func checkPolicyOwner(info fs.FileInfo) error {
+	if runtimeGOOS == "windows" {
+		return nil
+	}
+	v := reflect.ValueOf(info.Sys())
+	if v.Kind() == reflect.Pointer {
+		v = v.Elem()
+	}
+	uid := v.FieldByName("Uid")
+	if uid.IsValid() && uid.CanUint() && int(uid.Uint()) != osGeteuid() {
+		return fmt.Errorf("not owned by current user")
+	}
+	return nil
+}
+func checkTransactionPolicyGeneration(path string) error {
+	if err := checkPolicyDirectory(path); err != nil {
+		return err
+	}
+	for _, name := range []string{"manifest.json", "rules.json", "background.js", "probe.html"} {
+		info, err := os.Lstat(filepath.Join(path, name))
+		if err != nil {
+			return err
+		}
+		if info.Mode()&fs.ModeSymlink != 0 || !info.Mode().IsRegular() || info.Mode().Perm() != 0600 {
+			return fmt.Errorf("unsafe generated file %s", name)
+		}
+		if err := checkPolicyOwner(info); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// checkTransactionPolicyGenerationContent binds the content-addressed name to
+// the exact bytes compiled from this launch configuration. Ownership alone is
+// insufficient: a same-user accidental or compromised replacement must fail
+// before Chrome starts.
+func checkTransactionPolicyGenerationContent(path string, manifest transactionPolicyManifest, rules []dnrRule) error {
+	if err := checkTransactionPolicyGeneration(path); err != nil {
+		return err
+	}
+	manifestData, err := jsonData(manifest)
+	if err != nil {
+		return err
+	}
+	rulesData, err := jsonData(rules)
+	if err != nil {
+		return err
+	}
+	background := []byte("chrome.runtime.onMessage.addListener((_, __, reply) => { chrome.declarativeNetRequest.getEnabledRulesets().then(reply); return true; });\n")
+	probe := []byte("<script>chrome.runtime.sendMessage({pinchTabPolicyProbe: true});</script>\n")
+	expected := "generation-" + policyDigest(manifestData, rulesData, background, probe)
+	if filepath.Base(path) != expected {
+		return fmt.Errorf("generation name does not authenticate policy content")
+	}
+	for _, file := range []struct {
+		name string
+		data []byte
+	}{{"manifest.json", manifestData}, {"rules.json", rulesData}, {"background.js", background}, {"probe.html", probe}} {
+		actual, err := os.ReadFile(filepath.Join(path, file.name))
+		if err != nil {
+			return err
+		}
+		if string(actual) != string(file.data) {
+			return fmt.Errorf("generated %s does not match compiled policy", file.name)
+		}
+	}
+	return nil
+}
+func lockTransactionPolicyRoot(root string) (func(), error) {
+	path := filepath.Join(root, ".lock")
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		err := os.Mkdir(path, 0700)
+		if err == nil {
+			return func() { _ = os.Remove(path) }, nil
+		}
+		if !os.IsExist(err) {
+			return nil, err
+		}
+		info, statErr := os.Lstat(path)
+		if statErr != nil {
+			return nil, statErr
+		}
+		if info.Mode()&fs.ModeSymlink != 0 || !info.Mode().IsDir() {
+			return nil, fmt.Errorf("unsafe transaction policy lock")
+		}
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("timed out waiting for transaction policy state lock")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+func publishTransactionPolicyCurrent(root, name string) error {
+	current := filepath.Join(root, transactionPolicyCurrentFile)
+	if info, err := os.Lstat(current); err == nil {
+		if info.Mode()&fs.ModeSymlink != 0 || !info.Mode().IsRegular() {
+			return fmt.Errorf("unsafe transaction policy current pointer")
+		}
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	temp, err := os.CreateTemp(root, ".current-")
+	if err != nil {
+		return err
+	}
+	tempName := temp.Name()
+	defer os.Remove(tempName)
+	if err := temp.Chmod(0600); err == nil {
+		_, err = temp.WriteString(name + "\n")
+	}
+	if closeErr := temp.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		return err
+	}
+	return os.Rename(tempName, current)
+}
+func retainTransactionPolicyGenerations(root, current string) error {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return err
+	}
+	type generation struct {
+		name string
+		mod  time.Time
+	}
+	var gens []generation
+	for _, entry := range entries {
+		if !transactionPolicyGenerationName.MatchString(entry.Name()) {
+			continue
+		}
+		path := filepath.Join(root, entry.Name())
+		if err := checkTransactionPolicyGeneration(path); err != nil {
+			return err
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		gens = append(gens, generation{entry.Name(), info.ModTime()})
+	}
+	sort.Slice(gens, func(i, j int) bool { return gens[i].mod.After(gens[j].mod) })
+	kept := 0
+	for _, gen := range gens {
+		if gen.name == current {
+			continue // current is always retained, even if timestamps are skewed.
+		}
+		if kept < maxTransactionPolicyGenerations-1 {
+			kept++
+			continue
+		}
+		if err := os.RemoveAll(filepath.Join(root, gen.name)); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/bridge/runtime/transaction_policy_test.go
+++ b/internal/bridge/runtime/transaction_policy_test.go
@@ -1,0 +1,255 @@
+package runtime
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/pinchtab/pinchtab/internal/config"
+)
+
+func testTransactionPolicy() config.TransactionPolicyConfig {
+	return config.TransactionPolicyConfig{Enabled: true, Hosts: []string{"supplier.example"}, DenyRules: []config.TransactionPolicyRule{{Method: "*", PathPrefix: "/checkout"}}, AllowRules: []config.TransactionPolicyRule{{Method: "POST", PathPrefix: "/cart"}, {Method: "POST", PathPrefix: "/", QueryParam: "wc-ajax", QueryValue: "add_to_cart"}}}
+}
+
+func TestCompileTransactionPolicyPriorityMethodsAndTrailingDot(t *testing.T) {
+	manifest, rules, err := compileTransactionPolicy(testTransactionPolicy())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if manifest.ManifestVersion != 3 || len(manifest.HostPermissions) != 4 {
+		t.Fatalf("manifest = %#v", manifest)
+	}
+	if len(rules) != 12 {
+		t.Fatalf("rule count = %d", len(rules))
+	}
+	denies, allows, defaults := rulesAtPriority(rules, 3), rulesAtPriority(rules, 2), rulesAtPriority(rules, 1)
+	if len(denies) != 9 || len(allows) != 2 || len(defaults) != 1 || denies[0].Action.Type != "block" || allows[0].Action.Type != "allow" {
+		t.Fatalf("priorities/actions = %#v", rules)
+	}
+	if got := strings.Join(defaults[0].Condition.ExcludedRequestMethods, ","); got != "get,head,options" {
+		t.Fatalf("default methods = %v", got)
+	}
+	for _, group := range [][]dnrRule{denies, defaults} {
+		if !anyRuleMatches(group, "https://supplier.example./checkout") {
+			t.Fatalf("trailing-dot URL bypasses priority %d rules", group[0].Priority)
+		}
+	}
+}
+
+func TestDenyRegexCoversChromeEncodedPathForms(t *testing.T) {
+	_, rules, err := compileTransactionPolicy(testTransactionPolicy())
+	if err != nil {
+		t.Fatal(err)
+	}
+	denies := rulesAtPriority(rules, 3)
+	for _, url := range []string{"https://supplier.example/checkout", "https://user:password@supplier.example/checkout", "https://supplier.example/chec%6bout", "https://supplier.example/%2Fcheckout", "https://supplier.example./chec%6bout"} {
+		if !anyRuleMatches(denies, url) {
+			t.Errorf("encoded deny bypass: %s", url)
+		}
+	}
+	allows := rulesAtPriority(rules, 2)
+	allow := regexp.MustCompile(allows[1].Condition.RegexFilter)
+	for _, url := range []string{"https://supplier.example/?wc-ajax=add_to_cart", "https://supplier.example/?wc-ajax=add_to_cart#cart"} {
+		if !allow.MatchString(url) {
+			t.Errorf("exact query allow did not match %s", url)
+		}
+	}
+	for _, url := range []string{"https://supplier.example/?x=1&wc-ajax=add_to_cart", "https://supplier.example/?wc-ajax=add_to_cart&x=1", "https://supplier.example/?wc-ajax=add_to_cart&wc-ajax=add_to_cart", "https://supplier.example/?wc-ajax=add_to_cart&wc-ajax=checkout", "https://supplier.example/?action=checkout&wc-ajax=add_to_cart", "https://supplier.example/?wc-ajax="} {
+		if allow.MatchString(url) {
+			t.Errorf("polluted query allowed: %s", url)
+		}
+	}
+}
+
+func TestDenyQueryMatchesExactPairWithoutBroadeningPath(t *testing.T) {
+	policy := testTransactionPolicy()
+	policy.DenyRules = []config.TransactionPolicyRule{{Method: "*", PathPrefix: "/", QueryParam: "action", QueryValue: "checkout"}}
+	_, rules, err := compileTransactionPolicy(policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	denies := rulesAtPriority(rules, 3)
+	for _, url := range []string{
+		"https://supplier.example/?action=checkout",
+		"https://supplier.example/?x=1&action=checkout",
+		"https://supplier.example/?action=checkout&x=1",
+		"https://supplier.example/?action=cancel&action=checkout",
+		"https://supplier.example/?%61ction=checkout",
+		"https://supplier.example/?action=%63heckout",
+		"wss://supplier.example/?action=checkout",
+	} {
+		if !anyRuleMatches(denies, url) {
+			t.Errorf("deny query bypass: %s", url)
+		}
+	}
+	for _, url := range []string{
+		"https://supplier.example/",
+		"https://supplier.example/?action=cart",
+		"https://supplier.example/?action=checkout-now",
+		"https://supplier.example/?xaction=checkout",
+		"https://supplier.example/?return=action%3Dcheckout",
+	} {
+		if anyRuleMatches(denies, url) {
+			t.Errorf("deny query broadened to unrelated URL: %s", url)
+		}
+	}
+}
+
+func rulesAtPriority(rules []dnrRule, priority int) []dnrRule {
+	var matches []dnrRule
+	for _, rule := range rules {
+		if rule.Priority == priority {
+			matches = append(matches, rule)
+		}
+	}
+	return matches
+}
+
+func anyRuleMatches(rules []dnrRule, url string) bool {
+	for _, rule := range rules {
+		if regexp.MustCompile("(?i)" + rule.Condition.RegexFilter).MatchString(url) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestPrepareTransactionPolicyExtensionIsPrivateAndGeneratedOnly(t *testing.T) {
+	stateDir := t.TempDir()
+	if err := os.Chmod(stateDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.RuntimeConfig{StateDir: stateDir, ChromeBinary: "/usr/bin/chromium", TransactionPolicy: testTransactionPolicy()}
+	launch, err := PrepareTransactionPolicyExtension(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.ExtensionPaths) != 0 || len(launch.ExtensionPaths) != 1 {
+		t.Fatalf("operator=%v launch=%v", cfg.ExtensionPaths, launch.ExtensionPaths)
+	}
+	if got := filepath.Dir(launch.ExtensionPaths[0]); got != filepath.Join(stateDir, transactionPolicyStateRoot) {
+		t.Fatalf("generation escaped policy root: %q", got)
+	}
+	if info, err := os.Stat(stateDir); err != nil || info.Mode().Perm() != 0755 {
+		t.Fatalf("StateDir permissions changed: %v %v", info, err)
+	}
+	for _, name := range []string{"manifest.json", "rules.json", "background.js"} {
+		info, err := os.Stat(filepath.Join(launch.ExtensionPaths[0], name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Mode().Perm() != 0600 {
+			t.Fatalf("%s permissions = %o", name, info.Mode().Perm())
+		}
+	}
+	info, err := os.Stat(filepath.Dir(launch.ExtensionPaths[0]))
+	if err != nil || info.Mode().Perm() != 0700 {
+		t.Fatalf("policy root mode = %v, %v", info.Mode(), err)
+	}
+	if err := validateTransactionPolicyLaunch(launch); err != nil {
+		t.Fatalf("generated launch rejected: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(launch.ExtensionPaths[0], "rules.json"), []byte("[]\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateTransactionPolicyLaunch(launch); err == nil {
+		t.Fatal("tampered generated policy passed launch validation")
+	}
+}
+
+func TestPrepareTransactionPolicyExtensionRejectsExtensionsAndUnsafeState(t *testing.T) {
+	cfg := &config.RuntimeConfig{StateDir: t.TempDir(), ChromeBinary: "/usr/bin/chromium", ExtensionPaths: []string{"/operator-extension"}, TransactionPolicy: testTransactionPolicy()}
+	if _, err := PrepareTransactionPolicyExtension(cfg); err == nil {
+		t.Fatal("operator extension accepted in policy mode")
+	}
+	state := t.TempDir()
+	link := filepath.Join(t.TempDir(), "state-link")
+	if err := os.Symlink(state, link); err != nil {
+		t.Fatal(err)
+	}
+	cfg = &config.RuntimeConfig{StateDir: link, ChromeBinary: "/usr/bin/chromium", TransactionPolicy: testTransactionPolicy()}
+	if _, err := PrepareTransactionPolicyExtension(cfg); err == nil {
+		t.Fatal("symlink StateDir accepted")
+	}
+	state = t.TempDir()
+	if err := os.Symlink(t.TempDir(), filepath.Join(state, transactionPolicyStateRoot)); err != nil {
+		t.Fatal(err)
+	}
+	cfg = &config.RuntimeConfig{StateDir: state, ChromeBinary: "/usr/bin/chromium", TransactionPolicy: testTransactionPolicy()}
+	if _, err := PrepareTransactionPolicyExtension(cfg); err == nil {
+		t.Fatal("symlink policy root accepted")
+	}
+}
+
+func TestTransactionPolicyGenerationsAreDeterministicAndBounded(t *testing.T) {
+	state := t.TempDir()
+	cfg := &config.RuntimeConfig{StateDir: state, ChromeBinary: "/usr/bin/chromium", TransactionPolicy: testTransactionPolicy()}
+	first, err := PrepareTransactionPolicyExtension(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := PrepareTransactionPolicyExtension(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.ExtensionPaths[0] != second.ExtensionPaths[0] {
+		t.Fatalf("same content generation changed: %q != %q", first.ExtensionPaths[0], second.ExtensionPaths[0])
+	}
+	for i := 0; i < maxTransactionPolicyGenerations+2; i++ {
+		cfg.TransactionPolicy.DenyRules = []config.TransactionPolicyRule{{Method: "*", PathPrefix: "/checkout", PathSegment: strings.Repeat("x", i+1)}}
+		if _, err := PrepareTransactionPolicyExtension(cfg); err != nil {
+			t.Fatal(err)
+		}
+	}
+	entries, err := os.ReadDir(filepath.Join(state, transactionPolicyStateRoot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	count := 0
+	for _, entry := range entries {
+		if transactionPolicyGenerationName.MatchString(entry.Name()) {
+			count++
+		}
+	}
+	if count > maxTransactionPolicyGenerations {
+		t.Fatalf("generations not retained: %d", count)
+	}
+}
+
+func TestExactTransactionPolicyRulesetState(t *testing.T) {
+	if !hasExactTransactionPolicyRulesets([]string{transactionPolicyRulesetID}) {
+		t.Fatal("exact generated ruleset was rejected")
+	}
+	for _, ids := range [][]string{nil, {"other"}, {transactionPolicyRulesetID, "other"}, {"prefix-" + transactionPolicyRulesetID}} {
+		if hasExactTransactionPolicyRulesets(ids) {
+			t.Fatalf("non-exact ruleset state accepted: %v", ids)
+		}
+	}
+}
+
+func TestValidateTransactionPolicyLaunchRejectsSpoofedPathAndFallback(t *testing.T) {
+	cfg := &config.RuntimeConfig{StateDir: t.TempDir(), TransactionPolicy: testTransactionPolicy()}
+	if err := validateTransactionPolicyLaunch(cfg); err == nil {
+		t.Fatal("missing binary accepted")
+	}
+	cfg.ChromeBinary = "/Applications/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing"
+	cfg.ExtensionPaths = []string{filepath.Join(cfg.StateDir, "transaction-policy-extension-spoof")}
+	if err := validateTransactionPolicyLaunch(cfg); err == nil || strings.Contains(err.Error(), "Google Chrome Stable") {
+		t.Fatalf("Chrome for Testing was classified as Stable: %v", err)
+	}
+	cfg.ChromeBinary = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+	if err := validateTransactionPolicyLaunch(cfg); err == nil || !strings.Contains(err.Error(), "Google Chrome Stable") {
+		t.Fatalf("Google Chrome Stable was accepted or misclassified: %v", err)
+	}
+	cfg.ChromeBinary = "/usr/bin/chromium"
+	cfg.ExtensionPaths = []string{filepath.Join(cfg.StateDir, "transaction-policy-extension-spoof")}
+	if err := validateTransactionPolicyLaunch(cfg); err == nil {
+		t.Fatal("spoofed generated path accepted")
+	}
+	if _, _, _, err := startChromeWithRemoteAllocator(t.Context(), cfg, nil, 9222, ""); err == nil {
+		t.Fatal("direct fallback bypassed validation")
+	}
+}

--- a/internal/bridge/tab_manager.go
+++ b/internal/bridge/tab_manager.go
@@ -267,18 +267,116 @@ func (tm *TabManager) closeLRUTab() error {
 	return tm.CloseTab(lruID)
 }
 
+// trackedCDPIDs returns the raw CDP target IDs this manager currently tracks.
+func (tm *TabManager) trackedCDPIDs() map[string]bool {
+	tm.mu.RLock()
+	defer tm.mu.RUnlock()
+	out := make(map[string]bool, len(tm.tabs))
+	for _, entry := range tm.tabs {
+		if entry != nil && entry.CDPID != "" {
+			out[entry.CDPID] = true
+		}
+	}
+	return out
+}
+
+// selectOrphanTargets returns page targets that exist in Chrome but are not
+// tracked by this TabManager, oldest-first (GetTargets returns newest first),
+// capped at `limit` entries. A negative or zero limit means "all orphans".
+//
+// Orphans accumulate whenever the bridge process is restarted, a tab context
+// dies, or Chromium restores a previous session: the Chrome target survives
+// but the managed entry does not. They are invisible to a managed-count-only
+// tab cap, which is how a `maxTabs: 8` instance ended up holding 158 live
+// page targets in production (SBSA lane, 2026-08-17) and starved every other
+// caller of that instance.
+func selectOrphanTargets(tracked map[string]bool, pages []*target.Info, limit int) []target.ID {
+	orphans := make([]target.ID, 0)
+	// GetTargets is newest-first; walk backwards so we reap the oldest first.
+	for i := len(pages) - 1; i >= 0; i-- {
+		t := pages[i]
+		if t == nil || t.Type != TargetTypePage {
+			continue
+		}
+		if tracked[string(t.TargetID)] {
+			continue
+		}
+		orphans = append(orphans, t.TargetID)
+		if limit > 0 && len(orphans) >= limit {
+			break
+		}
+	}
+	return orphans
+}
+
+// reapOrphanTargets closes untracked page targets so the configured tab cap
+// reflects Chrome reality rather than in-process bookkeeping. Returns the
+// number of targets actually closed.
+func (tm *TabManager) reapOrphanTargets(limit int) int {
+	pages, err := tm.ListTargets()
+	if err != nil {
+		slog.Warn("tab budget: cannot list chrome targets", "err", err)
+		return 0
+	}
+	orphans := selectOrphanTargets(tm.trackedCDPIDs(), pages, limit)
+	closed := 0
+	for _, id := range orphans {
+		closeCtx, cancel := context.WithTimeout(tm.browserCtx, 5*time.Second)
+		c := chromedp.FromContext(closeCtx)
+		if c == nil || c.Browser == nil {
+			cancel()
+			break
+		}
+		if err := target.CloseTarget(id).Do(cdp.WithExecutor(closeCtx, c.Browser)); err != nil {
+			slog.Debug("tab budget: orphan close failed", "targetId", id, "err", err)
+			cancel()
+			continue
+		}
+		cancel()
+		closed++
+	}
+	if closed > 0 {
+		slog.Info("tab budget: closed untracked chrome targets", "count", closed, "maxTabs", tm.config.MaxTabs)
+	}
+	return closed
+}
+
+// liveTabCount is the number of tabs the cap must be enforced against: every
+// open page target in Chrome, not just the ones this process happens to track.
+// Falls back to the managed count if Chrome cannot be queried.
+func (tm *TabManager) liveTabCount() int {
+	tm.mu.RLock()
+	managed := len(tm.tabs)
+	tm.mu.RUnlock()
+
+	pages, err := tm.ListTargets()
+	if err != nil {
+		return managed
+	}
+	if len(pages) > managed {
+		return len(pages)
+	}
+	return managed
+}
+
 func (tm *TabManager) CreateTab(url string) (string, context.Context, context.CancelFunc, error) {
 	if tm.browserCtx == nil {
 		return "", nil, nil, fmt.Errorf("no browser context available")
 	}
 
 	if tm.config.MaxTabs > 0 {
-		// Count managed tabs for eviction decisions. Using Chrome's target list
-		// would include unmanaged targets (e.g. the initial about:blank tab),
-		// causing premature eviction of managed tabs.
-		tm.mu.RLock()
-		managedCount := len(tm.tabs)
-		tm.mu.RUnlock()
+		// Enforce against Chrome's real page-target count. Counting only the
+		// managed map lets untracked targets (bridge restart, dead tab
+		// contexts, Chromium session restore) grow without bound.
+		managedCount := tm.liveTabCount()
+
+		if managedCount >= tm.config.MaxTabs {
+			// Untracked targets are nobody's session — reap those before
+			// evicting a tab a caller may still be driving.
+			if closed := tm.reapOrphanTargets(managedCount - tm.config.MaxTabs + 1); closed > 0 {
+				managedCount = tm.liveTabCount()
+			}
+		}
 
 		if managedCount >= tm.config.MaxTabs {
 			switch tm.config.TabEvictionPolicy {

--- a/internal/bridge/tab_manager_orphan_test.go
+++ b/internal/bridge/tab_manager_orphan_test.go
@@ -1,0 +1,64 @@
+package bridge
+
+import (
+	"testing"
+
+	"github.com/chromedp/cdproto/target"
+)
+
+func pageTarget(id string) *target.Info {
+	return &target.Info{TargetID: target.ID(id), Type: TargetTypePage}
+}
+
+// The production failure: Chrome held 158 page targets on an instance
+// configured with maxTabs: 8, because the cap only ever counted the
+// in-process managed map. Untracked targets must be selectable for reaping.
+func TestSelectOrphanTargets_PicksUntrackedOldestFirst(t *testing.T) {
+	tracked := map[string]bool{"t-managed": true}
+	// GetTargets returns newest-first.
+	pages := []*target.Info{pageTarget("t-new"), pageTarget("t-managed"), pageTarget("t-old")}
+
+	got := selectOrphanTargets(tracked, pages, 0)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 orphans, got %d (%v)", len(got), got)
+	}
+	if got[0] != target.ID("t-old") {
+		t.Fatalf("expected oldest orphan first, got %v", got)
+	}
+	for _, id := range got {
+		if id == target.ID("t-managed") {
+			t.Fatal("a tracked target must never be reaped as an orphan")
+		}
+	}
+}
+
+func TestSelectOrphanTargets_RespectsLimit(t *testing.T) {
+	pages := []*target.Info{pageTarget("a"), pageTarget("b"), pageTarget("c")}
+	got := selectOrphanTargets(map[string]bool{}, pages, 2)
+	if len(got) != 2 {
+		t.Fatalf("expected limit of 2, got %d", len(got))
+	}
+}
+
+func TestSelectOrphanTargets_IgnoresNonPageTargets(t *testing.T) {
+	pages := []*target.Info{
+		{TargetID: target.ID("worker"), Type: "service_worker"},
+		nil,
+		pageTarget("page"),
+	}
+	got := selectOrphanTargets(map[string]bool{}, pages, 0)
+	if len(got) != 1 || got[0] != target.ID("page") {
+		t.Fatalf("expected only the page target, got %v", got)
+	}
+}
+
+func TestTrackedCDPIDs(t *testing.T) {
+	tm := &TabManager{tabs: map[string]*TabEntry{
+		"tab_1": {CDPID: "raw1"},
+		"tab_2": {CDPID: ""},
+	}}
+	got := tm.trackedCDPIDs()
+	if !got["raw1"] || len(got) != 1 {
+		t.Fatalf("unexpected tracked set: %v", got)
+	}
+}

--- a/internal/bridge/tabstate/tabstate.go
+++ b/internal/bridge/tabstate/tabstate.go
@@ -1,0 +1,140 @@
+// Package tabstate persists a pinchtab instance's open-tab list to disk so
+// the set of URLs can be reopened after a daemon (or pod) restart. This is
+// the smilerite-hardening F3 patch (SMI-81 retro, 2026-05-17): pod
+// rollovers in Kubernetes destroy in-memory chromedp tab handles, but the
+// chromium profile (cookies/storage) survives on a PersistentVolume.
+// Pairing the surviving profile with a persisted URL list lets a caller
+// reopen "where they were" after a restart without re-auth.
+//
+// Design notes:
+//
+//   - One file per pinchtab instance, lives at <profileDir>/tabs.json.
+//     The profile dir is the chromium --user-data-dir for the instance,
+//     so the persistence file rides on the same PV that already carries
+//     the session.
+//
+//   - Writes are atomic via tabs.json.tmp + rename. A torn write would
+//     either give us the old snapshot back or nothing; either is safe.
+//
+//   - Reads are tolerant: a missing file or malformed JSON returns an
+//     empty Snapshot with no error. Restore must not break the caller
+//     just because there was nothing to restore.
+//
+//   - No retention/versioning. tabs.json is overwritten on every save.
+//     If we ever need history we can rotate; today's design is "latest
+//     wins" because the caller (Smiles) only ever wants "what was open
+//     last".
+package tabstate
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// FileName is the on-disk name of the persistence file inside a profile dir.
+// Exported so handlers/tests can refer to it without duplicating the literal.
+const FileName = "tabs.json"
+
+// PersistedTab is the minimal projection of a chromium tab that we save.
+// Title is best-effort — if the tab hasn't loaded enough for chromium to
+// have a title yet, it'll be empty; not an error.
+type PersistedTab struct {
+	ID    string `json:"id"`
+	URL   string `json:"url"`
+	Title string `json:"title,omitempty"`
+}
+
+// Snapshot is what we serialize. InstanceID is informational — restore
+// matches by profile dir, not by InstanceID, because the daemon picks a
+// fresh InstanceID on every launch.
+type Snapshot struct {
+	InstanceID string         `json:"instanceId,omitempty"`
+	SavedAt    time.Time      `json:"savedAt"`
+	Tabs       []PersistedTab `json:"tabs"`
+}
+
+// Path returns the absolute path of the tabstate file for a given profile dir.
+// Exported because handlers + tests both need to know where the file lives.
+func Path(profileDir string) string {
+	return filepath.Join(profileDir, FileName)
+}
+
+// Persist writes snap to <profileDir>/tabs.json atomically. The profile
+// directory must already exist (it does — chromium would have failed to
+// launch otherwise). Atomic via tmp+rename within the same dir so the
+// rename is guaranteed by POSIX semantics to be atomic.
+//
+// SavedAt is overwritten with the current wall-clock time. Callers can
+// leave it zero.
+func Persist(profileDir string, snap Snapshot) error {
+	if profileDir == "" {
+		return errors.New("tabstate: empty profile dir")
+	}
+
+	snap.SavedAt = time.Now().UTC()
+	if snap.Tabs == nil {
+		// Always serialize a present-but-empty array, not a JSON null.
+		// Easier for downstream tooling (jq, dashboard) to read.
+		snap.Tabs = []PersistedTab{}
+	}
+
+	body, err := json.MarshalIndent(snap, "", "  ")
+	if err != nil {
+		return fmt.Errorf("tabstate: marshal: %w", err)
+	}
+
+	dst := Path(profileDir)
+	tmp := dst + ".tmp"
+
+	// 0600 — the profile dir is per-instance and only the daemon should
+	// read it. No reason for it to be group/world readable.
+	if err := os.WriteFile(tmp, body, 0600); err != nil {
+		return fmt.Errorf("tabstate: write tmp: %w", err)
+	}
+	if err := os.Rename(tmp, dst); err != nil {
+		// Best-effort cleanup of the orphan tmp file.
+		_ = os.Remove(tmp)
+		return fmt.Errorf("tabstate: rename: %w", err)
+	}
+	return nil
+}
+
+// Read returns the persisted snapshot for a profile dir. A missing file or
+// a malformed file is treated as "nothing persisted yet" — the returned
+// Snapshot will have an empty Tabs slice and no error.
+//
+// All other errors (permission denied, I/O failure on a present file) are
+// surfaced. Callers should distinguish between "no state" (snap.Tabs
+// length == 0) and "error reading state" by checking err.
+func Read(profileDir string) (Snapshot, error) {
+	if profileDir == "" {
+		return Snapshot{Tabs: []PersistedTab{}}, errors.New("tabstate: empty profile dir")
+	}
+
+	body, err := os.ReadFile(Path(profileDir))
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return Snapshot{Tabs: []PersistedTab{}}, nil
+		}
+		return Snapshot{Tabs: []PersistedTab{}}, fmt.Errorf("tabstate: read: %w", err)
+	}
+
+	var snap Snapshot
+	if err := json.Unmarshal(body, &snap); err != nil {
+		// Treat malformed-on-disk as "no state". This handles a partial
+		// write from a process killed mid-Persist (vanishingly rare given
+		// the atomic-rename strategy, but the renames-not-atomic edge
+		// case exists on some filesystems and we'd rather not crash the
+		// caller).
+		return Snapshot{Tabs: []PersistedTab{}}, nil
+	}
+	if snap.Tabs == nil {
+		snap.Tabs = []PersistedTab{}
+	}
+	return snap, nil
+}

--- a/internal/bridge/tabstate/tabstate_test.go
+++ b/internal/bridge/tabstate/tabstate_test.go
@@ -1,0 +1,213 @@
+package tabstate
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestPersist_RoundTrip writes a snapshot, reads it back, and confirms the
+// fields make the trip. SavedAt is overwritten on Persist so we don't try to
+// pin its value; only that it's set to ~now.
+func TestPersist_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	in := Snapshot{
+		InstanceID: "inst_42344f86",
+		Tabs: []PersistedTab{
+			{ID: "tab_a", URL: "https://secure.sarsefiling.co.za/TaxRefund/SOA", Title: "SOA"},
+			{ID: "tab_b", URL: "https://enterprisests.standardbank.co.za/login"},
+		},
+	}
+
+	before := time.Now().UTC().Add(-time.Second)
+	if err := Persist(dir, in); err != nil {
+		t.Fatalf("Persist: %v", err)
+	}
+	after := time.Now().UTC().Add(time.Second)
+
+	got, err := Read(dir)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+
+	if got.InstanceID != in.InstanceID {
+		t.Errorf("InstanceID: got %q want %q", got.InstanceID, in.InstanceID)
+	}
+	if len(got.Tabs) != len(in.Tabs) {
+		t.Fatalf("Tabs: got %d entries, want %d", len(got.Tabs), len(in.Tabs))
+	}
+	for i, tab := range got.Tabs {
+		if tab.URL != in.Tabs[i].URL {
+			t.Errorf("Tabs[%d].URL: got %q want %q", i, tab.URL, in.Tabs[i].URL)
+		}
+		if tab.ID != in.Tabs[i].ID {
+			t.Errorf("Tabs[%d].ID: got %q want %q", i, tab.ID, in.Tabs[i].ID)
+		}
+	}
+	if got.SavedAt.Before(before) || got.SavedAt.After(after) {
+		t.Errorf("SavedAt: got %v, want between %v and %v", got.SavedAt, before, after)
+	}
+}
+
+// TestPersist_FilePermissions checks that the persisted file is 0600
+// (per-instance secret-bearing, no need for group/world access).
+func TestPersist_FilePermissions(t *testing.T) {
+	dir := t.TempDir()
+	if err := Persist(dir, Snapshot{InstanceID: "x"}); err != nil {
+		t.Fatalf("Persist: %v", err)
+	}
+	info, err := os.Stat(Path(dir))
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0600 {
+		t.Errorf("file perm: got %#o want 0600", perm)
+	}
+}
+
+// TestPersist_NoTmpLeak verifies that no .tmp file is left behind after a
+// successful Persist. (Rename is atomic; the tmp should be gone.)
+func TestPersist_NoTmpLeak(t *testing.T) {
+	dir := t.TempDir()
+	if err := Persist(dir, Snapshot{InstanceID: "x"}); err != nil {
+		t.Fatalf("Persist: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, FileName+".tmp")); !os.IsNotExist(err) {
+		t.Errorf("tabs.json.tmp still present after rename: %v", err)
+	}
+}
+
+// TestPersist_NilTabsBecomesEmptyArray ensures the JSON has an empty array,
+// not a null, when there are no tabs. Easier for jq/dashboard to consume.
+func TestPersist_NilTabsBecomesEmptyArray(t *testing.T) {
+	dir := t.TempDir()
+	if err := Persist(dir, Snapshot{InstanceID: "x", Tabs: nil}); err != nil {
+		t.Fatalf("Persist: %v", err)
+	}
+	body, err := os.ReadFile(Path(dir))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.Contains(string(body), `"tabs": []`) {
+		t.Errorf("expected \"tabs\": [] in payload, got:\n%s", body)
+	}
+}
+
+// TestPersist_EmptyProfileDir is an error.
+func TestPersist_EmptyProfileDir(t *testing.T) {
+	if err := Persist("", Snapshot{}); err == nil {
+		t.Error("Persist(\"\"): expected error, got nil")
+	}
+}
+
+// TestRead_MissingFile is not an error — it's just "nothing to restore".
+func TestRead_MissingFile(t *testing.T) {
+	dir := t.TempDir()
+	snap, err := Read(dir)
+	if err != nil {
+		t.Fatalf("Read on empty dir: %v (want nil)", err)
+	}
+	if len(snap.Tabs) != 0 {
+		t.Errorf("Read on empty dir: got %d tabs, want 0", len(snap.Tabs))
+	}
+}
+
+// TestRead_MalformedFile is tolerated — empty snapshot, no error.
+// Why: an interrupted Persist (eg SIGKILL between WriteFile and Rename)
+// could leave us with a partially-written file in theory. We don't want
+// every subsequent Read to fail-loud.
+func TestRead_MalformedFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(Path(dir), []byte("{this is not json"), 0600); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	snap, err := Read(dir)
+	if err != nil {
+		t.Errorf("Read on malformed: %v (want nil)", err)
+	}
+	if len(snap.Tabs) != 0 {
+		t.Errorf("Read on malformed: got %d tabs, want 0", len(snap.Tabs))
+	}
+}
+
+// TestRead_NullTabsField — JSON null normalised to empty slice so callers
+// can iterate without nil-guarding.
+func TestRead_NullTabsField(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(Path(dir), []byte(`{"instanceId":"x","tabs":null,"savedAt":"2026-01-01T00:00:00Z"}`), 0600); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	snap, err := Read(dir)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if snap.Tabs == nil {
+		t.Error("expected non-nil tabs slice after Read of explicit null")
+	}
+}
+
+// TestPersist_OverwritesPrevious confirms latest-wins. We don't keep history.
+func TestPersist_OverwritesPrevious(t *testing.T) {
+	dir := t.TempDir()
+	if err := Persist(dir, Snapshot{Tabs: []PersistedTab{{ID: "a", URL: "https://a/"}}}); err != nil {
+		t.Fatalf("first Persist: %v", err)
+	}
+	if err := Persist(dir, Snapshot{Tabs: []PersistedTab{{ID: "b", URL: "https://b/"}}}); err != nil {
+		t.Fatalf("second Persist: %v", err)
+	}
+	snap, err := Read(dir)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if len(snap.Tabs) != 1 || snap.Tabs[0].URL != "https://b/" {
+		t.Errorf("got %+v, want the second snapshot to win", snap.Tabs)
+	}
+}
+
+// TestPath is trivial but it pins the on-disk filename so we don't
+// accidentally change it without changing it intentionally.
+func TestPath(t *testing.T) {
+	got := Path("/profiles/foo")
+	want := "/profiles/foo/tabs.json"
+	if got != want {
+		t.Errorf("Path: got %q want %q", got, want)
+	}
+}
+
+// TestPersist_RoundTrip_JSONShape verifies the wire shape so dashboards
+// and external tools can rely on these field names.
+func TestPersist_RoundTrip_JSONShape(t *testing.T) {
+	dir := t.TempDir()
+	if err := Persist(dir, Snapshot{
+		InstanceID: "inst_x",
+		Tabs:       []PersistedTab{{ID: "t1", URL: "https://example/", Title: "T"}},
+	}); err != nil {
+		t.Fatalf("Persist: %v", err)
+	}
+	body, err := os.ReadFile(Path(dir))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, k := range []string{"instanceId", "savedAt", "tabs"} {
+		if _, ok := got[k]; !ok {
+			t.Errorf("missing top-level field %q in JSON", k)
+		}
+	}
+	tabs, _ := got["tabs"].([]any)
+	if len(tabs) != 1 {
+		t.Fatalf("tabs len: got %d want 1", len(tabs))
+	}
+	tab, _ := tabs[0].(map[string]any)
+	for _, k := range []string{"id", "url", "title"} {
+		if _, ok := tab[k]; !ok {
+			t.Errorf("missing tab field %q", k)
+		}
+	}
+}

--- a/internal/cli/actions/actions_instance.go
+++ b/internal/cli/actions/actions_instance.go
@@ -19,6 +19,9 @@ func InstanceStart(client *http.Client, base, token string, cmd *cobra.Command) 
 	if v, _ := cmd.Flags().GetString("port"); v != "" {
 		body["port"] = v
 	}
+	if v, _ := cmd.Flags().GetString("stealth-level"); v != "" {
+		body["stealthLevel"] = v
+	}
 	if exts, _ := cmd.Flags().GetStringArray("extension"); len(exts) > 0 {
 		body["extensionPaths"] = exts
 	}

--- a/internal/cli/actions/actions_instance_test.go
+++ b/internal/cli/actions/actions_instance_test.go
@@ -1,0 +1,49 @@
+package actions
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func newInstanceStartCmd() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Flags().String("profile", "", "")
+	cmd.Flags().String("mode", "", "")
+	cmd.Flags().String("port", "", "")
+	cmd.Flags().String("stealth-level", "", "")
+	cmd.Flags().StringArray("extension", nil, "")
+	return cmd
+}
+
+func TestInstanceStartSendsStealthLevel(t *testing.T) {
+	m := newMockServer()
+	defer m.close()
+
+	cmd := newInstanceStartCmd()
+	_ = cmd.Flags().Set("profile", "rcs-luke")
+	_ = cmd.Flags().Set("mode", "headless")
+	_ = cmd.Flags().Set("port", "9870")
+	_ = cmd.Flags().Set("stealth-level", "full")
+
+	InstanceStart(m.server.Client(), m.base(), "", cmd)
+
+	if m.lastMethod != "POST" {
+		t.Fatalf("method = %s, want POST", m.lastMethod)
+	}
+	if m.lastPath != "/instances/start" {
+		t.Fatalf("path = %s, want /instances/start", m.lastPath)
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal([]byte(m.lastBody), &body); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	if body["profileId"] != "rcs-luke" {
+		t.Fatalf("profileId = %v, want rcs-luke", body["profileId"])
+	}
+	if body["stealthLevel"] != "full" {
+		t.Fatalf("stealthLevel = %v, want full", body["stealthLevel"])
+	}
+}

--- a/internal/config/config_file.go
+++ b/internal/config/config_file.go
@@ -70,6 +70,7 @@ func DefaultFileConfig() FileConfig {
 				AllowHosts:   []string{"127.0.0.1", "localhost", "::1"},
 				AllowSchemes: []string{"ws", "wss"},
 			},
+			TransactionPolicy: TransactionPolicyConfig{Enabled: false, Hosts: []string{}, DenyRules: []TransactionPolicyRule{}, AllowRules: []TransactionPolicyRule{}},
 			IDPI: IDPIConfig{
 				Enabled:        true,
 				AllowedDomains: append([]string(nil), defaultLocalAllowedDomains...),
@@ -163,22 +164,23 @@ type profilesConfigJSON struct {
 }
 
 type securityConfigJSON struct {
-	AllowEvaluate          *bool          `json:"allowEvaluate"`
-	AllowMacro             *bool          `json:"allowMacro"`
-	AllowScreencast        *bool          `json:"allowScreencast"`
-	AllowDownload          *bool          `json:"allowDownload"`
-	DownloadAllowedDomains []string       `json:"downloadAllowedDomains"`
-	DownloadMaxBytes       *int           `json:"downloadMaxBytes"`
-	AllowUpload            *bool          `json:"allowUpload"`
-	AllowClipboard         *bool          `json:"allowClipboard"`
-	UploadMaxRequestBytes  *int           `json:"uploadMaxRequestBytes"`
-	UploadMaxFiles         *int           `json:"uploadMaxFiles"`
-	UploadMaxFileBytes     *int           `json:"uploadMaxFileBytes"`
-	UploadMaxTotalBytes    *int           `json:"uploadMaxTotalBytes"`
-	MaxRedirects           *int           `json:"maxRedirects"`
-	TrustedProxyCIDRs      []string       `json:"trustedProxyCIDRs"`
-	Attach                 attachJSON     `json:"attach"`
-	IDPI                   idpiConfigJSON `json:"idpi"`
+	AllowEvaluate          *bool                   `json:"allowEvaluate"`
+	AllowMacro             *bool                   `json:"allowMacro"`
+	AllowScreencast        *bool                   `json:"allowScreencast"`
+	AllowDownload          *bool                   `json:"allowDownload"`
+	DownloadAllowedDomains []string                `json:"downloadAllowedDomains"`
+	DownloadMaxBytes       *int                    `json:"downloadMaxBytes"`
+	AllowUpload            *bool                   `json:"allowUpload"`
+	AllowClipboard         *bool                   `json:"allowClipboard"`
+	UploadMaxRequestBytes  *int                    `json:"uploadMaxRequestBytes"`
+	UploadMaxFiles         *int                    `json:"uploadMaxFiles"`
+	UploadMaxFileBytes     *int                    `json:"uploadMaxFileBytes"`
+	UploadMaxTotalBytes    *int                    `json:"uploadMaxTotalBytes"`
+	MaxRedirects           *int                    `json:"maxRedirects"`
+	TrustedProxyCIDRs      []string                `json:"trustedProxyCIDRs"`
+	Attach                 attachJSON              `json:"attach"`
+	IDPI                   idpiConfigJSON          `json:"idpi"`
+	TransactionPolicy      TransactionPolicyConfig `json:"transactionPolicy"`
 }
 
 type attachJSON struct {
@@ -304,6 +306,7 @@ func (fc FileConfig) MarshalJSON() ([]byte, error) {
 				AllowHosts:   copyStringSlice(fc.Security.Attach.AllowHosts),
 				AllowSchemes: copyStringSlice(fc.Security.Attach.AllowSchemes),
 			},
+			TransactionPolicy: fc.Security.TransactionPolicy,
 			IDPI: idpiConfigJSON{
 				Enabled:         fc.Security.IDPI.Enabled,
 				AllowedDomains:  copyStringSlice(fc.Security.IDPI.AllowedDomains),
@@ -457,7 +460,8 @@ func FileConfigFromRuntime(cfg *RuntimeConfig) FileConfig {
 				AllowHosts:   append([]string(nil), cfg.AttachAllowHosts...),
 				AllowSchemes: append([]string(nil), cfg.AttachAllowSchemes...),
 			},
-			IDPI: cfg.IDPI,
+			IDPI:              cfg.IDPI,
+			TransactionPolicy: cfg.TransactionPolicy,
 		},
 		Profiles: ProfilesConfig{
 			BaseDir:        cfg.ProfilesBaseDir,

--- a/internal/config/config_load.go
+++ b/internal/config/config_load.go
@@ -2,10 +2,12 @@ package config
 
 import (
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -33,6 +35,7 @@ func Load() *RuntimeConfig {
 		UploadMaxFileBytes:     DefaultUploadMaxFileBytes,
 		UploadMaxTotalBytes:    DefaultUploadMaxTotalBytes,
 		MaxRedirects:           -1, // Unlimited by default; set to N to limit redirect hops
+		TransactionPolicy:      TransactionPolicyConfig{},
 
 		// Browser / instance defaults
 		Headless:          true,
@@ -129,10 +132,18 @@ func Load() *RuntimeConfig {
 		}
 	}
 
-	// Validate file config and log warnings
+	// Validate file config and log warnings. A transaction policy must not start
+	// partially configured, but unrelated validation warnings remain non-fatal.
 	if errs := ValidateFileConfig(fc); len(errs) > 0 {
+		invalidTransactionPolicy := false
 		for _, e := range errs {
 			slog.Warn("config validation error", "path", configPath, "error", e)
+			if validationErr, ok := e.(ValidationError); ok && strings.HasPrefix(validationErr.Field, "security.transactionPolicy") {
+				invalidTransactionPolicy = true
+			}
+		}
+		if invalidTransactionPolicy {
+			panic(fmt.Sprintf("invalid security.transactionPolicy in %s", configPath))
 		}
 	}
 
@@ -241,6 +252,7 @@ func applyFileConfig(cfg *RuntimeConfig, fc *FileConfig) {
 	cfg.AttachAllowHosts = append([]string(nil), fc.Security.Attach.AllowHosts...)
 	cfg.AttachAllowSchemes = append([]string(nil), fc.Security.Attach.AllowSchemes...)
 	cfg.TrustedProxyCIDRs = append([]string(nil), fc.Security.TrustedProxyCIDRs...)
+	cfg.TransactionPolicy = fc.Security.TransactionPolicy
 	// IDPI – copy the whole struct; individual fields have safe zero-value defaults.
 	cfg.IDPI = fc.Security.IDPI
 	if fc.Observability.Activity.Enabled != nil {
@@ -406,6 +418,10 @@ func ApplyFileConfigToRuntime(cfg *RuntimeConfig, fc *FileConfig) {
 		return
 	}
 
+	// Transaction policy is restart-only. The configuration API may persist it,
+	// but must not turn a network guard on or off in a running process.
+	transactionPolicy := cfg.TransactionPolicy
 	applyFileConfig(cfg, fc)
+	cfg.TransactionPolicy = transactionPolicy
 	finalizeProfileConfig(cfg)
 }

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -29,6 +29,7 @@ type RuntimeConfig struct {
 	UploadMaxTotalBytes    int
 	MaxRedirects           int      // Max HTTP redirects (-1=unlimited, 0=none, default=-1)
 	TrustedProxyCIDRs      []string // CIDRs/IPs whose RemoteIPAddress is trusted in navigation responses (e.g. internal proxy)
+	TransactionPolicy      TransactionPolicyConfig
 
 	// Browser/instance settings
 	Headless          bool
@@ -88,6 +89,26 @@ type RuntimeConfig struct {
 
 	// Observability settings
 	Observability ObservabilityConfig
+}
+
+// TransactionPolicyConfig controls MV3 network blocking for configured supplier hosts.
+// It is compiled for managed browser launch only; changes take effect on restart.
+type TransactionPolicyConfig struct {
+	Enabled    bool                    `json:"enabled,omitempty"`
+	Hosts      []string                `json:"hosts,omitempty"`
+	DenyRules  []TransactionPolicyRule `json:"denyRules,omitempty"`
+	AllowRules []TransactionPolicyRule `json:"allowRules,omitempty"`
+}
+
+// TransactionPolicyRule matches an HTTP method and a DNR-safe URL path prefix.
+// PathSegment optionally requires one exact unescaped path segment. QueryParam
+// and QueryValue optionally narrow the match to one exact unescaped query pair.
+type TransactionPolicyRule struct {
+	Method      string `json:"method,omitempty"`
+	PathPrefix  string `json:"pathPrefix,omitempty"`
+	PathSegment string `json:"pathSegment,omitempty"`
+	QueryParam  string `json:"queryParam,omitempty"`
+	QueryValue  string `json:"queryValue,omitempty"`
 }
 
 // IDPIConfig holds the configuration for the Indirect Prompt Injection (IDPI)
@@ -182,22 +203,23 @@ type ProfilesConfig struct {
 }
 
 type SecurityConfig struct {
-	AllowEvaluate          *bool        `json:"allowEvaluate,omitempty"`
-	AllowMacro             *bool        `json:"allowMacro,omitempty"`
-	AllowScreencast        *bool        `json:"allowScreencast,omitempty"`
-	AllowDownload          *bool        `json:"allowDownload,omitempty"`
-	DownloadAllowedDomains []string     `json:"downloadAllowedDomains,omitempty"`
-	DownloadMaxBytes       *int         `json:"downloadMaxBytes,omitempty"`
-	AllowUpload            *bool        `json:"allowUpload,omitempty"`
-	AllowClipboard         *bool        `json:"allowClipboard,omitempty"`
-	UploadMaxRequestBytes  *int         `json:"uploadMaxRequestBytes,omitempty"`
-	UploadMaxFiles         *int         `json:"uploadMaxFiles,omitempty"`
-	UploadMaxFileBytes     *int         `json:"uploadMaxFileBytes,omitempty"`
-	UploadMaxTotalBytes    *int         `json:"uploadMaxTotalBytes,omitempty"`
-	MaxRedirects           *int         `json:"maxRedirects,omitempty"`
-	TrustedProxyCIDRs      []string     `json:"trustedProxyCIDRs,omitempty"`
-	Attach                 AttachConfig `json:"attach,omitempty"`
-	IDPI                   IDPIConfig   `json:"idpi,omitempty"`
+	AllowEvaluate          *bool                   `json:"allowEvaluate,omitempty"`
+	AllowMacro             *bool                   `json:"allowMacro,omitempty"`
+	AllowScreencast        *bool                   `json:"allowScreencast,omitempty"`
+	AllowDownload          *bool                   `json:"allowDownload,omitempty"`
+	DownloadAllowedDomains []string                `json:"downloadAllowedDomains,omitempty"`
+	DownloadMaxBytes       *int                    `json:"downloadMaxBytes,omitempty"`
+	AllowUpload            *bool                   `json:"allowUpload,omitempty"`
+	AllowClipboard         *bool                   `json:"allowClipboard,omitempty"`
+	UploadMaxRequestBytes  *int                    `json:"uploadMaxRequestBytes,omitempty"`
+	UploadMaxFiles         *int                    `json:"uploadMaxFiles,omitempty"`
+	UploadMaxFileBytes     *int                    `json:"uploadMaxFileBytes,omitempty"`
+	UploadMaxTotalBytes    *int                    `json:"uploadMaxTotalBytes,omitempty"`
+	MaxRedirects           *int                    `json:"maxRedirects,omitempty"`
+	TrustedProxyCIDRs      []string                `json:"trustedProxyCIDRs,omitempty"`
+	Attach                 AttachConfig            `json:"attach,omitempty"`
+	IDPI                   IDPIConfig              `json:"idpi,omitempty"`
+	TransactionPolicy      TransactionPolicyConfig `json:"transactionPolicy,omitempty"`
 }
 
 type MultiInstanceConfig struct {

--- a/internal/config/transaction_policy_test.go
+++ b/internal/config/transaction_policy_test.go
@@ -1,0 +1,98 @@
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestValidateTransactionPolicy(t *testing.T) {
+	valid := TransactionPolicyConfig{Enabled: true, Hosts: []string{"supplier.example"}, DenyRules: []TransactionPolicyRule{{Method: "POST", PathPrefix: "/checkout"}}}
+	if errs := ValidateFileConfig(&FileConfig{Security: SecurityConfig{TransactionPolicy: valid}}); len(errs) != 0 {
+		t.Fatalf("valid policy errors: %v", errs)
+	}
+	invalid := []TransactionPolicyConfig{
+		{Enabled: true},
+		{Enabled: true, Hosts: []string{"https://supplier.example"}, DenyRules: []TransactionPolicyRule{{Method: "POST", PathPrefix: "/checkout"}}},
+		{Enabled: true, Hosts: []string{"supplier.example:443"}, DenyRules: []TransactionPolicyRule{{Method: "POST", PathPrefix: "/checkout"}}},
+		{Enabled: true, Hosts: []string{"*.supplier.example"}, DenyRules: []TransactionPolicyRule{{Method: "POST", PathPrefix: "/checkout"}}},
+		{Enabled: true, Hosts: []string{"supplier..example"}, DenyRules: []TransactionPolicyRule{{Method: "POST", PathPrefix: "/checkout"}}},
+		{Enabled: true, Hosts: []string{"supplier.example"}, DenyRules: []TransactionPolicyRule{{Method: "CONNECT", PathPrefix: "checkout?x=1"}}},
+		{Enabled: true, Hosts: []string{"supplier.example"}, DenyRules: []TransactionPolicyRule{{Method: "POST", PathPrefix: "/checkout", QueryParam: "wc-ajax"}}},
+		{Enabled: true, Hosts: []string{"supplier.example"}, DenyRules: []TransactionPolicyRule{{Method: "POST", PathPrefix: "/checkout", QueryParam: "wc ajax", QueryValue: "checkout"}}},
+		{Enabled: true, Hosts: []string{"supplier.example"}, DenyRules: []TransactionPolicyRule{{Method: "POST", PathPrefix: "/", PathSegment: "orders/cancel"}}},
+	}
+	for _, policy := range invalid {
+		if errs := ValidateFileConfig(&FileConfig{Security: SecurityConfig{TransactionPolicy: policy}}); len(errs) == 0 {
+			t.Fatalf("invalid policy %+v unexpectedly passed", policy)
+		}
+	}
+	if errs := ValidateFileConfig(&FileConfig{Security: SecurityConfig{TransactionPolicy: TransactionPolicyConfig{Enabled: false, Hosts: []string{"https://not-a-host"}}}}); len(errs) != 0 {
+		t.Fatalf("disabled policy should be a no-op: %v", errs)
+	}
+	withExtension := FileConfig{Browser: BrowserConfig{ExtensionPaths: []string{"/operator-extension"}}, Security: SecurityConfig{TransactionPolicy: valid}}
+	if errs := ValidateFileConfig(&withExtension); len(errs) == 0 {
+		t.Fatal("enabled policy accepted operator extension paths")
+	}
+}
+
+func TestLoadRejectsInvalidEnabledTransactionPolicy(t *testing.T) {
+	clearConfigEnvVars(t)
+	path := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(path, []byte(`{"security":{"transactionPolicy":{"enabled":true,"hosts":[],"denyRules":[]}}}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PINCHTAB_CONFIG", path)
+	defer func() {
+		if recover() == nil {
+			t.Fatal("Load did not reject invalid enabled transaction policy")
+		}
+	}()
+	Load()
+}
+
+func TestLoadDoesNotPanicForUnrelatedValidationError(t *testing.T) {
+	clearConfigEnvVars(t)
+	path := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(path, []byte(`{"server":{"port":"invalid"},"security":{"transactionPolicy":{"enabled":true,"hosts":["supplier.example"],"denyRules":[{"method":"POST","pathPrefix":"/checkout"}]}}}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PINCHTAB_CONFIG", path)
+	Load()
+}
+
+func TestApplyFileConfigToRuntimeDoesNotToggleTransactionPolicy(t *testing.T) {
+	cfg := &RuntimeConfig{TransactionPolicy: TransactionPolicyConfig{Enabled: true}}
+	fc := DefaultFileConfig()
+	fc.Security.TransactionPolicy.Enabled = false
+	ApplyFileConfigToRuntime(cfg, &fc)
+	if !cfg.TransactionPolicy.Enabled {
+		t.Fatal("runtime transaction policy changed without a restart")
+	}
+}
+
+func TestTransactionPolicyConfigRoundTrip(t *testing.T) {
+	fc := DefaultFileConfig()
+	fc.Security.TransactionPolicy = TransactionPolicyConfig{Enabled: true, Hosts: []string{"supplier.example"}, DenyRules: []TransactionPolicyRule{{Method: "POST", PathPrefix: "/checkout"}}, AllowRules: []TransactionPolicyRule{{Method: "POST", PathPrefix: "/cart"}}}
+	cfg := &RuntimeConfig{}
+	applyFileConfig(cfg, &fc) // Load uses this startup-only path.
+	if !cfg.TransactionPolicy.Enabled || len(cfg.TransactionPolicy.AllowRules) != 1 {
+		t.Fatalf("runtime policy = %+v", cfg.TransactionPolicy)
+	}
+	roundTripped := FileConfigFromRuntime(cfg)
+	if got := roundTripped.Security.TransactionPolicy; !got.Enabled || len(got.DenyRules) != 1 {
+		t.Fatalf("round-trip policy = %+v", got)
+	}
+	data, err := json.Marshal(roundTripped)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var parsed FileConfig
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatal(err)
+	}
+	if !parsed.Security.TransactionPolicy.Enabled || len(parsed.Security.TransactionPolicy.AllowRules) != 1 {
+		t.Fatalf("JSON round-trip policy = %+v", parsed.Security.TransactionPolicy)
+	}
+}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -151,6 +151,10 @@ func ValidateFileConfig(fc *FileConfig) []error {
 
 	// IDPI validation
 	errs = append(errs, validateIDPIConfig(fc.Security.IDPI)...)
+	errs = append(errs, validateTransactionPolicyConfig(fc.Security.TransactionPolicy)...)
+	if fc.Security.TransactionPolicy.Enabled && len(fc.Browser.ExtensionPaths) != 0 {
+		errs = append(errs, ValidationError{Field: "browser.extensionPaths", Message: "must be empty when security.transactionPolicy is enabled"})
+	}
 	errs = append(errs, validateAllowedDomainList("security.downloadAllowedDomains", fc.Security.DownloadAllowedDomains)...)
 	errs = append(errs, validatePositiveIntLimit("security.downloadMaxBytes", fc.Security.DownloadMaxBytes, MaxDownloadMaxBytes)...)
 	errs = append(errs, validatePositiveIntLimit("security.uploadMaxRequestBytes", fc.Security.UploadMaxRequestBytes, MaxUploadMaxRequestBytes)...)
@@ -326,6 +330,116 @@ func validateIDPIConfig(cfg IDPIConfig) []error {
 	}
 
 	return errs
+}
+
+// validateTransactionPolicyConfig validates the request guard only when enabled.
+func validateTransactionPolicyConfig(cfg TransactionPolicyConfig) []error {
+	if !cfg.Enabled {
+		return nil
+	}
+	var errs []error
+	if len(cfg.Hosts) == 0 {
+		errs = append(errs, ValidationError{Field: "security.transactionPolicy.hosts", Message: "must contain at least one host when enabled"})
+	}
+	if len(cfg.DenyRules) == 0 {
+		errs = append(errs, ValidationError{Field: "security.transactionPolicy.denyRules", Message: "must contain at least one rule when enabled"})
+	}
+	for _, host := range cfg.Hosts {
+		host = strings.TrimSpace(host)
+		if !validTransactionHost(host) {
+			errs = append(errs, ValidationError{Field: "security.transactionPolicy.hosts", Message: "host must be an exact DNS hostname or IPv4 address without a scheme, port, wildcard, trailing dot, path, or whitespace"})
+		}
+	}
+	for _, group := range []struct {
+		field string
+		rules []TransactionPolicyRule
+		allow bool
+	}{{"security.transactionPolicy.denyRules", cfg.DenyRules, false}, {"security.transactionPolicy.allowRules", cfg.AllowRules, true}} {
+		for _, rule := range group.rules {
+			method := strings.ToUpper(strings.TrimSpace(rule.Method))
+			if !isValidTransactionMethod(method) {
+				errs = append(errs, ValidationError{Field: group.field, Message: fmt.Sprintf("invalid method %q", rule.Method)})
+			}
+			if !validTransactionPathPrefix(rule.PathPrefix) {
+				errs = append(errs, ValidationError{Field: group.field, Message: fmt.Sprintf("pathPrefix %q must be an unescaped absolute path made of unreserved ASCII characters", rule.PathPrefix)})
+			}
+			if rule.PathSegment != "" && !validTransactionToken(rule.PathSegment) {
+				errs = append(errs, ValidationError{Field: group.field, Message: "pathSegment must be one unescaped unreserved path segment"})
+			}
+			if (rule.QueryParam == "") != (rule.QueryValue == "") {
+				errs = append(errs, ValidationError{Field: group.field, Message: "queryParam and queryValue must be set together"})
+			}
+			if (rule.QueryParam != "" && !validTransactionToken(rule.QueryParam)) || (rule.QueryValue != "" && !validTransactionToken(rule.QueryValue)) {
+				errs = append(errs, ValidationError{Field: group.field, Message: "queryParam/queryValue must be unescaped unreserved ASCII"})
+			}
+			if group.allow && isUnsafeTransactionMethod(method) && strings.Trim(strings.TrimSpace(rule.PathPrefix), "/") == "" && rule.QueryParam == "" {
+				errs = append(errs, ValidationError{Field: group.field, Message: "unsafe root-wide allow requires an exact query condition"})
+			}
+		}
+	}
+	return errs
+}
+
+func validTransactionHost(host string) bool {
+	if host == "" || len(host) > 253 || strings.HasSuffix(host, ".") {
+		return false
+	}
+	for _, label := range strings.Split(host, ".") {
+		if label == "" || len(label) > 63 || label[0] == '-' || label[len(label)-1] == '-' {
+			return false
+		}
+		for _, r := range label {
+			if !((r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-') {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func validTransactionPathPrefix(value string) bool {
+	if !strings.HasPrefix(value, "/") || strings.Contains(value, "//") {
+		return false
+	}
+	for _, segment := range strings.Split(strings.Trim(value, "/"), "/") {
+		if segment == "" {
+			continue
+		}
+		if segment == "." || segment == ".." || !validTransactionToken(segment) {
+			return false
+		}
+	}
+	return true
+}
+
+func validTransactionToken(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, r := range value {
+		if !((r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || strings.ContainsRune("-._~", r)) {
+			return false
+		}
+	}
+	return true
+}
+
+func isUnsafeTransactionMethod(method string) bool {
+	switch method {
+	case "GET", "HEAD", "OPTIONS":
+		return false
+	default:
+		return true
+	}
+}
+
+func isValidTransactionMethod(method string) bool {
+	switch method {
+	case "*", "GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS":
+		return true
+	default:
+		return false
+	}
 }
 
 func validateAllowedDomainList(field string, domains []string) []error {

--- a/internal/dashboard/config_api.go
+++ b/internal/dashboard/config_api.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -274,6 +275,9 @@ func (c *ConfigAPI) restartReasonsFor(next config.FileConfig) []string {
 	}
 	if c.boot.InstanceDefaults.StealthLevel != next.InstanceDefaults.StealthLevel {
 		reasons = append(reasons, "Stealth level")
+	}
+	if !reflect.DeepEqual(c.boot.Security.TransactionPolicy, next.Security.TransactionPolicy) {
+		reasons = append(reasons, "Transaction policy")
 	}
 	if !sameIntPtr(c.boot.MultiInstance.Restart.MaxRestarts, next.MultiInstance.Restart.MaxRestarts) ||
 		!sameIntPtr(c.boot.MultiInstance.Restart.InitBackoffSec, next.MultiInstance.Restart.InitBackoffSec) ||

--- a/internal/dashboard/transaction_policy_test.go
+++ b/internal/dashboard/transaction_policy_test.go
@@ -1,0 +1,19 @@
+package dashboard
+
+import (
+	"testing"
+
+	"github.com/pinchtab/pinchtab/internal/config"
+)
+
+func TestRestartReasonsIncludesTransactionPolicy(t *testing.T) {
+	api := &ConfigAPI{boot: config.DefaultFileConfig()}
+	next := config.DefaultFileConfig()
+	next.Security.TransactionPolicy = config.TransactionPolicyConfig{Enabled: true, Hosts: []string{"supplier.example"}}
+	for _, reason := range api.restartReasonsFor(next) {
+		if reason == "Transaction policy" {
+			return
+		}
+	}
+	t.Fatal("transaction policy change did not require restart")
+}

--- a/internal/handlers/navigation.go
+++ b/internal/handlers/navigation.go
@@ -224,6 +224,11 @@ func (h *Handlers) HandleNavigate(w http.ResponseWriter, r *http.Request) {
 		h.recordResolvedTab(r, newTabID)
 		h.recordResolvedURL(r, url)
 
+		// F3 (SMI-81 hardening): snapshot the open-tab list to
+		// <profileDir>/tabs.json so pod rolls can restore. Best-effort:
+		// failures here do not affect the nav response.
+		h.persistTabStateAfterNav()
+
 		httpx.JSON(w, 200, map[string]any{"tabId": newTabID, "url": url, "title": title})
 		return
 	}
@@ -278,6 +283,9 @@ func (h *Handlers) HandleNavigate(w http.ResponseWriter, r *http.Request) {
 	_ = chromedp.Run(tCtx, chromedp.Location(&url))
 	title, _ := bridge.WaitForTitle(tCtx, titleWait)
 	h.recordResolvedURL(r, url)
+
+	// F3 (SMI-81 hardening): see comment in the new-tab branch above.
+	h.persistTabStateAfterNav()
 
 	httpx.JSON(w, 200, map[string]any{"tabId": resolvedTabID, "url": url, "title": title})
 }

--- a/internal/handlers/navigation_persist.go
+++ b/internal/handlers/navigation_persist.go
@@ -1,0 +1,75 @@
+package handlers
+
+import (
+	"log/slog"
+
+	"github.com/pinchtab/pinchtab/internal/bridge/tabstate"
+)
+
+// persistTabStateAfterNav snapshots the current list of open pages and writes
+// it to <profileDir>/tabs.json. Called from the success path of HandleNavigate
+// (both new-tab and existing-tab branches) so the on-disk state stays current
+// after every URL change.
+//
+// This is the smilerite-hardening F3 hook (SMI-81 retro): if the daemon dies
+// or the pod rolls, the persisted snapshot lets a caller reopen the same
+// URLs against the surviving chromium profile via
+// `POST /instances/{id}/tabs/restore`.
+//
+// Failures here are logged at warn and discarded — a tabstate write
+// failure must not break the user-visible nav response. The next nav will
+// try again.
+func (h *Handlers) persistTabStateAfterNav() {
+	if h == nil || h.Bridge == nil || h.Config == nil {
+		return
+	}
+	profileDir := h.Config.ProfileDir
+	if profileDir == "" {
+		// Single-instance daemons launched without a per-instance profile
+		// dir have nowhere safe to persist to. No-op.
+		return
+	}
+
+	targets, err := h.Bridge.ListTargets()
+	if err != nil {
+		slog.Warn("tabstate: list targets failed; skipping persist",
+			"err", err, "profileDir", profileDir)
+		return
+	}
+
+	snap := tabstate.Snapshot{
+		Tabs: make([]tabstate.PersistedTab, 0, len(targets)),
+	}
+	for _, t := range targets {
+		if t == nil {
+			continue
+		}
+		url := t.URL
+		// Skip about:blank, chrome://, devtools:// — they're not useful
+		// to restore. about:blank in particular is the placeholder used
+		// while a real URL is loading; restoring it would create empty
+		// tabs.
+		if url == "" || url == "about:blank" {
+			continue
+		}
+		if len(url) >= 9 && url[:9] == "chrome://" {
+			continue
+		}
+		if len(url) >= 11 && url[:11] == "devtools://" {
+			continue
+		}
+		snap.Tabs = append(snap.Tabs, tabstate.PersistedTab{
+			ID:    string(t.TargetID),
+			URL:   url,
+			Title: t.Title,
+		})
+	}
+
+	if err := tabstate.Persist(profileDir, snap); err != nil {
+		slog.Warn("tabstate: persist failed; continuing",
+			"err", err, "profileDir", profileDir, "tabs", len(snap.Tabs))
+		return
+	}
+	slog.Debug("tabstate: persisted",
+		"profileDir", profileDir, "tabs", len(snap.Tabs))
+}

--- a/internal/orchestrator/handlers.go
+++ b/internal/orchestrator/handlers.go
@@ -51,6 +51,9 @@ func (o *Orchestrator) registerHandlers(mux *http.ServeMux, skipLaunch bool) {
 	mux.HandleFunc("GET /instances/{id}/logs/stream", o.handleLogsStreamByID)
 	mux.HandleFunc("GET /instances/{id}/tabs", o.handleInstanceTabs)
 	mux.HandleFunc("POST /instances/{id}/tabs/open", o.handleInstanceTabOpen)
+	// F3 (SMI-81 hardening): reopen tabs persisted by the per-instance
+	// bridge across daemon/pod restarts. See handleInstanceTabsRestore.
+	mux.HandleFunc("POST /instances/{id}/tabs/restore", o.handleInstanceTabsRestore)
 	mux.HandleFunc("POST /instances/{id}/tab", o.proxyToInstance)
 	registerCapabilityRoute(mux, "GET /instances/{id}/proxy/screencast", o.AllowsScreencast(), "screencast", "security.allowScreencast", "screencast_disabled", o.handleProxyScreencast)
 	registerCapabilityRoute(mux, "GET /instances/{id}/screencast", o.AllowsScreencast(), "screencast", "security.allowScreencast", "screencast_disabled", o.proxyToInstance)

--- a/internal/orchestrator/handlers_instances.go
+++ b/internal/orchestrator/handlers_instances.go
@@ -17,6 +17,7 @@ type startInstanceRequest struct {
 	Mode           string   `json:"mode,omitempty"`
 	Port           string   `json:"port,omitempty"`
 	ExtensionPaths []string `json:"extensionPaths,omitempty"`
+	StealthLevel   string   `json:"stealthLevel,omitempty"`
 }
 
 func (o *Orchestrator) handleGetInstance(w http.ResponseWriter, r *http.Request) {
@@ -229,7 +230,7 @@ func (o *Orchestrator) startInstanceWithRequest(w http.ResponseWriter, r *http.R
 
 	headless := req.Mode != "headed"
 
-	inst, err := o.Launch(profileName, req.Port, headless, req.ExtensionPaths)
+	inst, err := o.LaunchWithOptions(profileName, req.Port, headless, req.ExtensionPaths, LaunchOptions{StealthLevel: req.StealthLevel})
 	if err != nil {
 		statusCode := classifyLaunchError(err)
 		httpx.Error(w, statusCode, err)

--- a/internal/orchestrator/handlers_profiles.go
+++ b/internal/orchestrator/handlers_profiles.go
@@ -30,8 +30,9 @@ func (o *Orchestrator) handleStartByID(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req struct {
-		Port     string `json:"port,omitempty"`
-		Headless bool   `json:"headless"`
+		Port         string `json:"port,omitempty"`
+		Headless     bool   `json:"headless"`
+		StealthLevel string `json:"stealthLevel,omitempty"`
 	}
 	if r.ContentLength > 0 {
 		if err := httpx.DecodeJSONBody(w, r, 0, &req); err != nil {
@@ -40,7 +41,7 @@ func (o *Orchestrator) handleStartByID(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	inst, err := o.Launch(name, req.Port, req.Headless, nil)
+	inst, err := o.LaunchWithOptions(name, req.Port, req.Headless, nil, LaunchOptions{StealthLevel: req.StealthLevel})
 	if err != nil {
 		statusCode := classifyLaunchError(err)
 		httpx.Error(w, statusCode, err)

--- a/internal/orchestrator/handlers_tabs_restore.go
+++ b/internal/orchestrator/handlers_tabs_restore.go
@@ -1,0 +1,185 @@
+package orchestrator
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"path/filepath"
+	"time"
+
+	"github.com/pinchtab/pinchtab/internal/bridge/tabstate"
+	"github.com/pinchtab/pinchtab/internal/httpx"
+)
+
+// handleInstanceTabsRestore is the smilerite-hardening F3 endpoint: it
+// reopens fresh chromium tabs for every URL persisted in the instance's
+// <profileDir>/tabs.json snapshot. Smiles calls this after she sees a
+// `tab-not-found` error from a previous tabId (which happens when the
+// daemon process or pod has been restarted since she last looked).
+//
+// Semantics:
+//
+//   - Does NOT dedupe against currently-open tabs. The instance may
+//     already have some tabs from chromium's session-restore; this
+//     endpoint adds tabs from the persistence file on top. Callers who
+//     want a clean slate should close existing tabs first via GET
+//     /instances/{id}/tabs + POST /tabs/{id}/close.
+//
+//   - If the persistence file is missing or empty, returns
+//     200 {restored:[], skipped:[]}. Not an error — a fresh profile
+//     just hasn't navigated anywhere yet.
+//
+//   - If a per-tab open fails, that URL goes into `skipped` with the
+//     reason. Other tabs still proceed. The endpoint returns 200 unless
+//     EVERY tab failed (or the instance itself is unreachable).
+//
+//   - Restore is sequential, not parallel. Pinchtab serializes per-tab
+//     CDP work anyway, and bursting N concurrent /tab calls just queues
+//     them behind each other inside the bridge.
+//
+// Route: POST /instances/{id}/tabs/restore
+func (o *Orchestrator) handleInstanceTabsRestore(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+
+	o.mu.RLock()
+	inst, ok := o.instances[id]
+	o.mu.RUnlock()
+	if !ok {
+		httpx.Error(w, 404, fmt.Errorf("instance %q not found", id))
+		return
+	}
+	if inst.Status != "running" {
+		httpx.Error(w, 503, fmt.Errorf("instance %q is not running (status: %s)", id, inst.Status))
+		return
+	}
+
+	profilePath := o.profilePathFor(inst.ProfileName)
+	if profilePath == "" {
+		httpx.Error(w, 500, fmt.Errorf("instance %q has no resolvable profile path", id))
+		return
+	}
+
+	snap, err := tabstate.Read(profilePath)
+	if err != nil {
+		// Read only returns errors for genuine I/O problems (missing file
+		// is treated as empty). Surface as 500 — the caller can't recover.
+		httpx.Error(w, 500, fmt.Errorf("read tabstate: %w", err))
+		return
+	}
+
+	type restoredEntry struct {
+		NewTabID    string    `json:"newTabId"`
+		URL         string    `json:"url"`
+		FromSavedAt time.Time `json:"fromSavedAt"`
+	}
+	type skippedEntry struct {
+		URL    string `json:"url"`
+		Reason string `json:"reason"`
+	}
+
+	restored := make([]restoredEntry, 0, len(snap.Tabs))
+	skipped := make([]skippedEntry, 0)
+
+	for _, tab := range snap.Tabs {
+		newTabID, openErr := o.openTabOnInstance(r, inst, tab.URL)
+		if openErr != nil {
+			skipped = append(skipped, skippedEntry{URL: tab.URL, Reason: openErr.Error()})
+			continue
+		}
+		restored = append(restored, restoredEntry{
+			NewTabID:    newTabID,
+			URL:         tab.URL,
+			FromSavedAt: snap.SavedAt,
+		})
+	}
+
+	// Edge case: persisted state had tabs but ALL of them failed to
+	// reopen. Still return 200 with both arrays — the caller can inspect
+	// `skipped` and decide what to do (Smiles will fail the run with a
+	// clear message per her preflight rule).
+	httpx.JSON(w, 200, map[string]any{
+		"ok":         true,
+		"restored":   restored,
+		"skipped":    skipped,
+		"instanceId": inst.ID,
+		"profile":    inst.ProfileName,
+		"savedAt":    snap.SavedAt,
+	})
+}
+
+// profilePathFor mirrors the resolution used at instance-launch time
+// (orchestrator.go: `profilePath := filepath.Join(o.baseDir, name); …
+// profiles.ProfilePath(name)`). Returning the empty string means no path
+// could be resolved.
+func (o *Orchestrator) profilePathFor(profileName string) string {
+	if profileName == "" {
+		return ""
+	}
+	path := filepath.Join(o.baseDir, profileName)
+	if o.profiles != nil {
+		if resolved, err := o.profiles.ProfilePath(profileName); err == nil {
+			path = resolved
+		}
+	}
+	return path
+}
+
+// openTabOnInstance POSTs `{action:"new", url:url}` to the instance's
+// bridge /tab endpoint and returns the new tabId from the response.
+// This is the same shape handleInstanceTabOpen uses; we just do it
+// from the orchestrator side because we need to drive N opens in a
+// single request and stitch the responses together.
+func (o *Orchestrator) openTabOnInstance(r *http.Request, inst *InstanceInternal, url string) (string, error) {
+	body, err := json.Marshal(map[string]any{
+		"action": "new",
+		"url":    url,
+	})
+	if err != nil {
+		return "", fmt.Errorf("marshal open request: %w", err)
+	}
+
+	targetURL, err := o.instancePathURL(inst, "/tab", "")
+	if err != nil {
+		return "", fmt.Errorf("build target url: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(r.Context(), http.MethodPost, targetURL.String(), bytes.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	o.applyInstanceAuth(req, inst)
+
+	client := o.client
+	if client == nil {
+		client = &http.Client{Timeout: 60 * time.Second}
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("instance unreachable: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	rb, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		// Keep the error short; the upstream body may be verbose.
+		preview := string(rb)
+		if len(preview) > 200 {
+			preview = preview[:200] + "…"
+		}
+		return "", fmt.Errorf("instance returned %d: %s", resp.StatusCode, preview)
+	}
+
+	var parsed struct {
+		TabID string `json:"tabId"`
+	}
+	if err := json.Unmarshal(rb, &parsed); err != nil {
+		return "", fmt.Errorf("parse instance response: %w", err)
+	}
+	if parsed.TabID == "" {
+		return "", fmt.Errorf("instance response missing tabId")
+	}
+	return parsed.TabID, nil
+}

--- a/internal/orchestrator/handlers_tabs_restore_test.go
+++ b/internal/orchestrator/handlers_tabs_restore_test.go
@@ -1,0 +1,294 @@
+package orchestrator
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/pinchtab/pinchtab/internal/bridge"
+	"github.com/pinchtab/pinchtab/internal/bridge/tabstate"
+)
+
+// fakeTabBackend returns an http.Handler that pretends to be the per-instance
+// bridge's /tab endpoint. It accepts POST /tab with {action:new, url}, returns
+// {tabId: "tab_<n>", url: "<url>"}, and tracks the URLs it received.
+type fakeTabBackend struct {
+	mu     sync.Mutex
+	opens  []string
+	count  atomic.Int64
+	failFn func(url string) bool // optional: return true to fail this URL
+}
+
+func (f *fakeTabBackend) handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/tab" || r.Method != http.MethodPost {
+			http.NotFound(w, r)
+			return
+		}
+		var body struct {
+			Action string `json:"action"`
+			URL    string `json:"url"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+
+		if f.failFn != nil && f.failFn(body.URL) {
+			http.Error(w, "synthetic failure", http.StatusBadGateway)
+			return
+		}
+
+		f.mu.Lock()
+		f.opens = append(f.opens, body.URL)
+		f.mu.Unlock()
+		n := f.count.Add(1)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"tabId":"tab_%d","url":%q,"title":""}`, n, body.URL)
+	})
+}
+
+// writeTabState seeds a tabs.json snapshot into profileDir.
+func writeTabState(t *testing.T, profileDir string, urls ...string) {
+	t.Helper()
+	tabs := make([]tabstate.PersistedTab, 0, len(urls))
+	for i, u := range urls {
+		tabs = append(tabs, tabstate.PersistedTab{
+			ID:    fmt.Sprintf("old_%d", i),
+			URL:   u,
+			Title: "T",
+		})
+	}
+	if err := tabstate.Persist(profileDir, tabstate.Snapshot{
+		InstanceID: "inst_seeded",
+		Tabs:       tabs,
+	}); err != nil {
+		t.Fatalf("seed tabstate: %v", err)
+	}
+}
+
+// newRestoreFixture wires up an orchestrator with one running instance whose
+// /tab requests land on `backend`. The instance's profileName is "smiles" and
+// its profile dir is baseDir/smiles (which mirrors orchestrator.profilePathFor
+// when ProfileManager is nil — the test setup keeps profiles unset for clarity).
+func newRestoreFixture(t *testing.T, backend *httptest.Server) (*Orchestrator, string) {
+	t.Helper()
+	baseDir := t.TempDir()
+	o := NewOrchestrator(baseDir)
+	o.client = backend.Client()
+
+	profileName := "smiles"
+	profileDir := filepath.Join(baseDir, profileName)
+	if err := os.MkdirAll(profileDir, 0o755); err != nil {
+		t.Fatalf("mkdir profile: %v", err)
+	}
+
+	port := strings.TrimPrefix(backend.URL, "http://localhost:")
+	port = strings.TrimPrefix(port, "http://127.0.0.1:")
+
+	o.instances["inst_smiles"] = &InstanceInternal{
+		Instance: bridge.Instance{
+			ID:          "inst_smiles",
+			ProfileName: profileName,
+			Port:        port,
+			Status:      "running",
+		},
+		URL: backend.URL,
+		cmd: &mockCmd{pid: 1, isAlive: true},
+	}
+
+	orig := processAliveFunc
+	processAliveFunc = func(pid int) bool { return true }
+	t.Cleanup(func() { processAliveFunc = orig })
+
+	return o, profileDir
+}
+
+func doRestore(t *testing.T, o *Orchestrator, instanceID string) (*httptest.ResponseRecorder, map[string]any) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/instances/"+instanceID+"/tabs/restore", bytes.NewReader(nil))
+	req.SetPathValue("id", instanceID)
+	w := httptest.NewRecorder()
+	o.handleInstanceTabsRestore(w, req)
+
+	resp := w.Result()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode == http.StatusOK {
+		var parsed map[string]any
+		if err := json.Unmarshal(body, &parsed); err != nil {
+			t.Fatalf("parse body %q: %v", body, err)
+		}
+		return w, parsed
+	}
+	// Non-200 — surface the body as the test failure message via map.
+	return w, map[string]any{"__error_body": string(body)}
+}
+
+func TestRestoreTabs_ReopensAllURLs(t *testing.T) {
+	backend := &fakeTabBackend{}
+	srv := httptest.NewServer(backend.handler())
+	defer srv.Close()
+
+	o, profileDir := newRestoreFixture(t, srv)
+	writeTabState(t, profileDir,
+		"https://secure.sarsefiling.co.za/TaxRefund/SOA",
+		"https://enterprisests.standardbank.co.za/login",
+	)
+
+	w, body := doRestore(t, o, "inst_smiles")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %v", w.Code, body)
+	}
+	if got, want := body["ok"], true; got != want {
+		t.Errorf("ok = %v, want %v", got, want)
+	}
+	restored, _ := body["restored"].([]any)
+	if len(restored) != 2 {
+		t.Fatalf("restored len = %d, want 2 — body: %v", len(restored), body)
+	}
+	skipped, _ := body["skipped"].([]any)
+	if len(skipped) != 0 {
+		t.Errorf("skipped len = %d, want 0 — body: %v", len(skipped), body)
+	}
+
+	// New tab IDs were synthesized by the fake backend.
+	for i, entry := range restored {
+		m := entry.(map[string]any)
+		newID, _ := m["newTabId"].(string)
+		if !strings.HasPrefix(newID, "tab_") {
+			t.Errorf("restored[%d].newTabId = %q, want tab_*", i, newID)
+		}
+		url, _ := m["url"].(string)
+		if url == "" {
+			t.Errorf("restored[%d].url is empty", i)
+		}
+	}
+
+	// The fake backend should have seen the same URLs we persisted, in order.
+	backend.mu.Lock()
+	gotURLs := append([]string(nil), backend.opens...)
+	backend.mu.Unlock()
+	if len(gotURLs) != 2 {
+		t.Fatalf("backend saw %d open requests, want 2", len(gotURLs))
+	}
+}
+
+func TestRestoreTabs_MissingState_ReturnsEmpty(t *testing.T) {
+	backend := &fakeTabBackend{}
+	srv := httptest.NewServer(backend.handler())
+	defer srv.Close()
+
+	o, _ := newRestoreFixture(t, srv)
+	// Don't write any tabstate file.
+
+	w, body := doRestore(t, o, "inst_smiles")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %v", w.Code, body)
+	}
+	restored, _ := body["restored"].([]any)
+	if len(restored) != 0 {
+		t.Errorf("restored len = %d, want 0", len(restored))
+	}
+	skipped, _ := body["skipped"].([]any)
+	if len(skipped) != 0 {
+		t.Errorf("skipped len = %d, want 0", len(skipped))
+	}
+}
+
+func TestRestoreTabs_InstanceNotFound(t *testing.T) {
+	backend := &fakeTabBackend{}
+	srv := httptest.NewServer(backend.handler())
+	defer srv.Close()
+
+	o, _ := newRestoreFixture(t, srv)
+	w, _ := doRestore(t, o, "inst_nope")
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestRestoreTabs_InstanceNotRunning(t *testing.T) {
+	backend := &fakeTabBackend{}
+	srv := httptest.NewServer(backend.handler())
+	defer srv.Close()
+
+	o, _ := newRestoreFixture(t, srv)
+	o.instances["inst_smiles"].Status = "stopped"
+	w, _ := doRestore(t, o, "inst_smiles")
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", w.Code)
+	}
+}
+
+func TestRestoreTabs_PartialFailure_StillReturns200(t *testing.T) {
+	backend := &fakeTabBackend{
+		failFn: func(u string) bool { return strings.Contains(u, "fails") },
+	}
+	srv := httptest.NewServer(backend.handler())
+	defer srv.Close()
+
+	o, profileDir := newRestoreFixture(t, srv)
+	writeTabState(t, profileDir,
+		"https://ok.example/",
+		"https://fails.example/",
+		"https://ok-two.example/",
+	)
+
+	w, body := doRestore(t, o, "inst_smiles")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %v", w.Code, body)
+	}
+	restored, _ := body["restored"].([]any)
+	skipped, _ := body["skipped"].([]any)
+	if len(restored) != 2 {
+		t.Errorf("restored len = %d, want 2", len(restored))
+	}
+	if len(skipped) != 1 {
+		t.Errorf("skipped len = %d, want 1", len(skipped))
+	} else {
+		entry := skipped[0].(map[string]any)
+		if u, _ := entry["url"].(string); !strings.Contains(u, "fails") {
+			t.Errorf("skipped url = %q, want one containing 'fails'", u)
+		}
+		if r, _ := entry["reason"].(string); r == "" {
+			t.Errorf("skipped reason is empty")
+		}
+	}
+}
+
+func TestRestoreTabs_PreservesSavedAt(t *testing.T) {
+	backend := &fakeTabBackend{}
+	srv := httptest.NewServer(backend.handler())
+	defer srv.Close()
+
+	o, profileDir := newRestoreFixture(t, srv)
+	writeTabState(t, profileDir, "https://example/")
+
+	_, body := doRestore(t, o, "inst_smiles")
+	restored, _ := body["restored"].([]any)
+	if len(restored) != 1 {
+		t.Fatalf("restored len = %d, want 1", len(restored))
+	}
+	entry := restored[0].(map[string]any)
+	if _, ok := entry["fromSavedAt"]; !ok {
+		t.Errorf("restored entry missing fromSavedAt")
+	}
+}
+
+func TestProfilePathFor_FallsBackToBaseDirJoin(t *testing.T) {
+	o := NewOrchestrator("/var/profiles")
+	got := o.profilePathFor("smiles")
+	if want := filepath.Join("/var/profiles", "smiles"); got != want {
+		t.Errorf("profilePathFor = %q, want %q", got, want)
+	}
+	if got := o.profilePathFor(""); got != "" {
+		t.Errorf("profilePathFor(\"\") = %q, want \"\"", got)
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -77,6 +77,10 @@ func (o *Orchestrator) EmitEvent(eventType string, inst *bridge.Instance) {
 	o.emitEvent(eventType, inst)
 }
 
+type LaunchOptions struct {
+	StealthLevel string
+}
+
 type InstanceInternal struct {
 	bridge.Instance
 	URL   string
@@ -241,6 +245,10 @@ func installStableBinary(src, dst string) error {
 }
 
 func (o *Orchestrator) Launch(name, port string, headless bool, extensionPaths []string) (*bridge.Instance, error) {
+	return o.LaunchWithOptions(name, port, headless, extensionPaths, LaunchOptions{})
+}
+
+func (o *Orchestrator) LaunchWithOptions(name, port string, headless bool, extensionPaths []string, opts LaunchOptions) (*bridge.Instance, error) {
 	// Validate profile name to prevent path traversal attacks
 	if err := profiles.ValidateProfileName(name); err != nil {
 		return nil, err
@@ -324,7 +332,7 @@ func (o *Orchestrator) Launch(name, port string, headless bool, extensionPaths [
 		return nil, fmt.Errorf("create state dir: %w", err)
 	}
 
-	childConfigPath, err := o.writeChildConfig(port, cdpPort, profilePath, instanceStateDir, headless, extensionPaths)
+	childConfigPath, err := o.writeChildConfig(name, port, cdpPort, profilePath, instanceStateDir, headless, extensionPaths, opts.StealthLevel)
 	if err != nil {
 		return nil, fmt.Errorf("write child config: %w", err)
 	}
@@ -370,7 +378,7 @@ func (o *Orchestrator) Launch(name, port string, headless bool, extensionPaths [
 	return &inst.Instance, nil
 }
 
-func (o *Orchestrator) writeChildConfig(port string, cdpPort int, profilePath, instanceStateDir string, headless bool, extensionPaths []string) (string, error) {
+func (o *Orchestrator) writeChildConfig(profileName, port string, cdpPort int, profilePath, instanceStateDir string, headless bool, extensionPaths []string, stealthLevel string) (string, error) {
 	fc := config.FileConfigFromRuntime(o.runtimeCfg)
 	fc.Server.Port = port
 	fc.Server.StateDir = instanceStateDir
@@ -381,6 +389,13 @@ func (o *Orchestrator) writeChildConfig(port string, cdpPort int, profilePath, i
 		fc.InstanceDefaults.Mode = "headless"
 	} else {
 		fc.InstanceDefaults.Mode = "headed"
+	}
+	resolvedStealthLevel, err := o.resolveProfileStealthLevel(profileName, profilePath, stealthLevel)
+	if err != nil {
+		return "", err
+	}
+	if resolvedStealthLevel != "" {
+		fc.InstanceDefaults.StealthLevel = resolvedStealthLevel
 	}
 
 	if len(extensionPaths) > 0 {
@@ -410,6 +425,56 @@ func (o *Orchestrator) writeChildConfig(port string, cdpPort int, profilePath, i
 		return "", err
 	}
 	return configPath, nil
+}
+
+func normalizeStealthLevel(level string) (string, error) {
+	level = strings.ToLower(strings.TrimSpace(level))
+	if level == "" {
+		return "", nil
+	}
+	switch level {
+	case "light", "medium", "full":
+		return level, nil
+	default:
+		return "", fmt.Errorf("invalid stealthLevel %q (must be light, medium, or full)", level)
+	}
+}
+
+func readStealthLevelOverride(path string) (string, bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+	var doc struct {
+		StealthLevel string `json:"stealthLevel"`
+	}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return "", true, fmt.Errorf("read stealth override %s: %w", path, err)
+	}
+	level, err := normalizeStealthLevel(doc.StealthLevel)
+	if err != nil {
+		return "", true, fmt.Errorf("read stealth override %s: %w", path, err)
+	}
+	return level, level != "", nil
+}
+
+func (o *Orchestrator) resolveProfileStealthLevel(profileName, profilePath, requestLevel string) (string, error) {
+	if level, err := normalizeStealthLevel(requestLevel); err != nil || level != "" {
+		return level, err
+	}
+	baseDir := filepath.Dir(profilePath)
+	for _, path := range []string{
+		filepath.Join(baseDir, profileName+".json"),
+		filepath.Join(profilePath, "profile.json"),
+	} {
+		if level, ok, err := readStealthLevelOverride(path); err != nil || ok {
+			return level, err
+		}
+	}
+	return "", nil
 }
 
 func intPtr(v int) *int {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -341,6 +341,16 @@ func (o *Orchestrator) LaunchWithOptions(name, port string, headless bool, exten
 		"PINCHTAB_PORT":   port,
 		"PINCHTAB_CONFIG": childConfigPath,
 	}
+	// filterEnvWithPrefixes strips ALL PINCHTAB_-prefixed vars from the parent
+	// environment before spawning the per-instance child process, so runtime
+	// container-compatibility overrides (e.g. the no-sandbox flag needed under
+	// containerd/CRI-O, which lack a Docker-only /.dockerenv marker) must be
+	// explicitly re-forwarded here or every profile-managed instance silently
+	// loses them, even though the top-level always-on bridge process (which
+	// inherits the full container env directly) keeps working fine.
+	if v := os.Getenv(config.ChromeNoSandboxEnvVar()); v != "" {
+		envOverrides[config.ChromeNoSandboxEnvVar()] = v
+	}
 	env := mergeEnvWithOverrides(filterEnvWithPrefixes(os.Environ(), "PINCHTAB_"), envOverrides)
 
 	logBuf := newRingBuffer(256 * 1024)

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -249,6 +249,12 @@ func (o *Orchestrator) Launch(name, port string, headless bool, extensionPaths [
 }
 
 func (o *Orchestrator) LaunchWithOptions(name, port string, headless bool, extensionPaths []string, opts LaunchOptions) (*bridge.Instance, error) {
+	o.mu.RLock()
+	policyEnabled := o.runtimeCfg != nil && o.runtimeCfg.TransactionPolicy.Enabled
+	o.mu.RUnlock()
+	if policyEnabled && len(extensionPaths) > 0 {
+		return nil, fmt.Errorf("request-supplied extensionPaths are not allowed while transaction policy is enabled")
+	}
 	// Validate profile name to prevent path traversal attacks
 	if err := profiles.ValidateProfileName(name); err != nil {
 		return nil, err
@@ -499,6 +505,10 @@ func intPtr(v int) *int {
 // bridge in place (upsert). Non-bridge duplicates still return an error.
 func (o *Orchestrator) attachExternalInstance(name string, inst bridge.Instance, authToken string) (*bridge.Instance, bool, error) {
 	o.mu.Lock()
+	if o.runtimeCfg != nil && o.runtimeCfg.TransactionPolicy.Enabled {
+		o.mu.Unlock()
+		return nil, false, fmt.Errorf("transaction policy requires a PinchTab-managed browser launch; attached browsers are not protected")
+	}
 	for _, existing := range o.instances {
 		if existing.ProfileName == name && instanceIsActive(existing) {
 			if existing.Attached && inst.AttachType == "bridge" && existing.AttachType == "bridge" {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -325,13 +325,33 @@ func (o *Orchestrator) LaunchWithOptions(name, port string, headless bool, exten
 	reservedPorts = append(reservedPorts, cdpPort)
 
 	profilePath := filepath.Join(o.baseDir, name)
+	resolved := false
 	if o.profiles != nil {
 		if resolvedPath, err := o.profiles.ProfilePath(name); err == nil {
 			profilePath = resolvedPath
+			resolved = true
 		}
+	}
+	if !resolved {
+		// The named profile is not in the profile store. We still start — that
+		// is the documented "profile dirs are created on demand" behaviour —
+		// but it means the caller gets a BLANK browser: no cookies, no
+		// remembered-device token, no logged-in session. For a bank profile
+		// that silently turns "reuse my session" into "full re-auth", so say
+		// so loudly instead of leaving it to be inferred from a failed login.
+		slog.Warn("profile not found in store; starting instance on a fresh empty profile dir",
+			"profile", name, "path", profilePath)
 	}
 	if err := os.MkdirAll(filepath.Join(profilePath, "Default"), 0755); err != nil {
 		return nil, fmt.Errorf("create profile dir: %w", err)
+	}
+	// Mark the directory as a real Chromium user-data-dir immediately; see
+	// profiles.seedChromiumPreferences for why an unmarked dir is dangerous.
+	prefsPath := filepath.Join(profilePath, "Default", "Preferences")
+	if _, err := os.Stat(prefsPath); os.IsNotExist(err) {
+		if werr := os.WriteFile(prefsPath, []byte("{}"), 0600); werr != nil {
+			slog.Warn("failed to seed Chromium Preferences", "path", prefsPath, "err", werr)
+		}
 	}
 	instanceStateDir := filepath.Join(profilePath, ".pinchtab-state")
 	if err := os.MkdirAll(instanceStateDir, 0755); err != nil {

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -7,12 +7,14 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/pinchtab/pinchtab/internal/bridge"
 	"github.com/pinchtab/pinchtab/internal/config"
+	"github.com/pinchtab/pinchtab/internal/profiles"
 )
 
 func envMap(items []string) map[string]string {
@@ -660,5 +662,106 @@ func TestOrchestrator_RegisterHandlers_LocksSensitiveRoutes(t *testing.T) {
 		if !strings.Contains(w.Body.String(), tt.setting) {
 			t.Fatalf("%s %s expected setting %s in response, got %s", tt.method, tt.path, tt.setting, w.Body.String())
 		}
+	}
+}
+
+func TestOrchestrator_Launch_PerRequestStealthLevelOverridesRuntimeDefault(t *testing.T) {
+	old := processAliveFunc
+	processAliveFunc = func(pid int) bool { return pid > 0 }
+	defer func() { processAliveFunc = old }()
+	stubPortAvailability(t, func(int) bool { return true })
+
+	runner := &mockRunner{portAvail: true}
+	o := NewOrchestratorWithRunner(t.TempDir(), runner)
+	o.ApplyRuntimeConfig(&config.RuntimeConfig{StealthLevel: "light"})
+
+	if _, err := o.LaunchWithOptions("discovery-bank-luke", "9001", true, nil, LaunchOptions{StealthLevel: "full"}); err != nil {
+		t.Fatalf("LaunchWithOptions failed: %v", err)
+	}
+
+	cfgPath := envMap(runner.env)["PINCHTAB_CONFIG"]
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", cfgPath, err)
+	}
+	var fc config.FileConfig
+	if err := json.Unmarshal(data, &fc); err != nil {
+		t.Fatalf("Unmarshal child config error = %v", err)
+	}
+	if got := fc.InstanceDefaults.StealthLevel; got != "full" {
+		t.Fatalf("stealthLevel = %q, want full", got)
+	}
+}
+
+func TestOrchestrator_HandleStartByProfileHonorsStealthLevel(t *testing.T) {
+	old := processAliveFunc
+	processAliveFunc = func(pid int) bool { return pid > 0 }
+	defer func() { processAliveFunc = old }()
+	stubPortAvailability(t, func(int) bool { return true })
+
+	baseDir := t.TempDir()
+	pm := profiles.NewProfileManager(baseDir)
+	if err := pm.Create("rcs-luke"); err != nil {
+		t.Fatalf("create profile: %v", err)
+	}
+	runner := &mockRunner{portAvail: true}
+	o := NewOrchestratorWithRunner(baseDir, runner)
+	o.SetProfileManager(pm)
+	o.ApplyRuntimeConfig(&config.RuntimeConfig{StealthLevel: "light"})
+
+	mux := http.NewServeMux()
+	o.RegisterHandlers(mux)
+	req := httptest.NewRequest("POST", "/profiles/rcs-luke/start", strings.NewReader(`{"headless":true,"stealthLevel":"full"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	cfgPath := envMap(runner.env)["PINCHTAB_CONFIG"]
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", cfgPath, err)
+	}
+	var fc config.FileConfig
+	if err := json.Unmarshal(data, &fc); err != nil {
+		t.Fatalf("Unmarshal child config error = %v", err)
+	}
+	if got := fc.InstanceDefaults.StealthLevel; got != "full" {
+		t.Fatalf("stealthLevel = %q, want full", got)
+	}
+}
+
+func TestOrchestrator_Launch_ProfileStealthLevelOverridesRuntimeDefault(t *testing.T) {
+	old := processAliveFunc
+	processAliveFunc = func(pid int) bool { return pid > 0 }
+	defer func() { processAliveFunc = old }()
+	stubPortAvailability(t, func(int) bool { return true })
+
+	baseDir := t.TempDir()
+	runner := &mockRunner{portAvail: true}
+	o := NewOrchestratorWithRunner(baseDir, runner)
+	o.ApplyRuntimeConfig(&config.RuntimeConfig{StealthLevel: "light"})
+	if err := os.WriteFile(filepath.Join(baseDir, "discovery-bank-luke.json"), []byte(`{"stealthLevel":"full"}`), 0644); err != nil {
+		t.Fatalf("write profile override: %v", err)
+	}
+
+	if _, err := o.Launch("discovery-bank-luke", "9001", true, nil); err != nil {
+		t.Fatalf("Launch failed: %v", err)
+	}
+
+	cfgPath := envMap(runner.env)["PINCHTAB_CONFIG"]
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", cfgPath, err)
+	}
+	var fc config.FileConfig
+	if err := json.Unmarshal(data, &fc); err != nil {
+		t.Fatalf("Unmarshal child config error = %v", err)
+	}
+	if got := fc.InstanceDefaults.StealthLevel; got != "full" {
+		t.Fatalf("stealthLevel = %q, want full", got)
 	}
 }

--- a/internal/orchestrator/process_test.go
+++ b/internal/orchestrator/process_test.go
@@ -64,6 +64,32 @@ func TestLaunch_Mocked(t *testing.T) {
 	}
 }
 
+func TestLaunch_ForwardsChromeNoSandboxCompatEnvVar(t *testing.T) {
+	old := portAvailableFunc
+	portAvailableFunc = func(int) bool { return true }
+	defer func() { portAvailableFunc = old }()
+
+	t.Setenv("PINCHTAB_CHROME_NO_SANDBOX", "1")
+
+	runner := &mockRunner{portAvail: true}
+	o := NewOrchestratorWithRunner(t.TempDir(), runner)
+
+	if _, err := o.Launch("test-prof", "9999", true, nil); err != nil {
+		t.Fatalf("Launch failed: %v", err)
+	}
+
+	found := false
+	for _, kv := range runner.env {
+		if kv == "PINCHTAB_CHROME_NO_SANDBOX=1" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected child env to include PINCHTAB_CHROME_NO_SANDBOX=1, got %v", runner.env)
+	}
+}
+
 func TestLaunch_PortConflict(t *testing.T) {
 	old := portAvailableFunc
 	portAvailableFunc = func(int) bool { return true }

--- a/internal/orchestrator/proxy.go
+++ b/internal/orchestrator/proxy.go
@@ -310,7 +310,7 @@ func (o *Orchestrator) applyInstanceAuth(req *http.Request, inst *InstanceIntern
 // classifyLaunchError returns appropriate HTTP status code for launch errors.
 func classifyLaunchError(err error) int {
 	msg := err.Error()
-	if strings.Contains(msg, "cannot contain") || strings.Contains(msg, "cannot be empty") {
+	if strings.Contains(msg, "cannot contain") || strings.Contains(msg, "cannot be empty") || strings.Contains(msg, "invalid stealthLevel") {
 		return 400 // Bad Request - validation error
 	}
 	if strings.Contains(msg, "already") || strings.Contains(msg, "in use") {

--- a/internal/orchestrator/transaction_policy_test.go
+++ b/internal/orchestrator/transaction_policy_test.go
@@ -1,0 +1,20 @@
+package orchestrator
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/pinchtab/pinchtab/internal/config"
+)
+
+func TestLaunchRejectsRequestExtensionPathsWhenTransactionPolicyEnabled(t *testing.T) {
+	o := NewOrchestratorWithRunner(t.TempDir(), &mockRunner{portAvail: true})
+	o.ApplyRuntimeConfig(&config.RuntimeConfig{TransactionPolicy: config.TransactionPolicyConfig{Enabled: true}})
+	_, err := o.Launch("profile", "9868", true, []string{"/request-extension"})
+	if err == nil || !strings.Contains(err.Error(), "request-supplied extensionPaths") {
+		t.Fatalf("Launch error = %v", err)
+	}
+	if _, err := o.Attach("external", "ws://127.0.0.1:9222/devtools/browser/x"); err == nil || !strings.Contains(err.Error(), "managed browser launch") {
+		t.Fatalf("Attach error = %v", err)
+	}
+}

--- a/internal/profiles/profiles.go
+++ b/internal/profiles/profiles.go
@@ -355,10 +355,36 @@ func (pm *ProfileManager) Create(name string) error {
 	if err := os.MkdirAll(filepath.Join(dest, "Default"), 0755); err != nil {
 		return err
 	}
+	if err := seedChromiumPreferences(dest); err != nil {
+		return err
+	}
 	return writeProfileMeta(dest, ProfileMeta{
 		ID:   profileID(name),
 		Name: name,
 	})
+}
+
+// seedChromiumPreferences writes a minimal Default/Preferences file if none
+// exists yet.
+//
+// A freshly created profile is structurally indistinguishable from a corrupt
+// one until Chromium first launches into it and writes Preferences itself —
+// and Chromium writes that file atomically (temp + rename), so a hard kill
+// (pod eviction, OOM, SIGKILL on scale-to-zero) can also leave the directory
+// without one. External profile-volume janitors reasonably treat "no
+// Preferences" as "broken, safe to delete"; on 2026-08-17 that heuristic
+// destroyed the `stdbank-luke` and `bobgo-luke` bank profiles on the
+// production PinchTab volume, along with their remembered-device tokens.
+//
+// Seeding an empty-but-valid Preferences file at create time makes a managed
+// profile self-identifying from the filesystem alone. Chromium overwrites it
+// on first run.
+func seedChromiumPreferences(dest string) error {
+	prefs := filepath.Join(dest, "Default", "Preferences")
+	if _, err := os.Stat(prefs); err == nil {
+		return nil
+	}
+	return os.WriteFile(prefs, []byte("{}"), 0600)
 }
 
 func resolveImportSourcePath(sourcePath string) (string, error) {

--- a/internal/profiles/profiles_test.go
+++ b/internal/profiles/profiles_test.go
@@ -879,3 +879,46 @@ func TestProfileRenameRejectsDuplicate(t *testing.T) {
 		t.Errorf("expected 'already exists' error, got: %v", err)
 	}
 }
+
+// A freshly created profile must look like a real Chromium user-data-dir on
+// disk. External profile-volume janitors delete "no Preferences" directories
+// as corrupt; on 2026-08-17 that destroyed two live bank profiles.
+func TestCreateSeedsChromiumPreferences(t *testing.T) {
+	dir := t.TempDir()
+	pm := NewProfileManager(dir)
+
+	if err := pm.Create("stdbank-luke"); err != nil {
+		t.Fatal(err)
+	}
+
+	prefs := filepath.Join(dir, profileID("stdbank-luke"), "Default", "Preferences")
+	data, err := os.ReadFile(prefs)
+	if err != nil {
+		t.Fatalf("Preferences not seeded at %s: %v", prefs, err)
+	}
+	if len(data) == 0 {
+		t.Fatal("seeded Preferences must not be empty")
+	}
+}
+
+// Seeding must never clobber a real Chromium Preferences file (import path).
+func TestSeedChromiumPreferencesPreservesExisting(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "Default"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	prefs := filepath.Join(dir, "Default", "Preferences")
+	if err := os.WriteFile(prefs, []byte(`{"real":"prefs"}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := seedChromiumPreferences(dir); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(prefs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != `{"real":"prefs"}` {
+		t.Fatalf("existing Preferences was overwritten: %s", data)
+	}
+}

--- a/npm/skills/pinchtab/SKILL.md
+++ b/npm/skills/pinchtab/SKILL.md
@@ -142,11 +142,11 @@ pinchtab instance start --profile work --mode headed
 pinchtab --server http://localhost:9868 nav https://mail.google.com
 ```
 
-If the login is already stored in that profile, you can switch to headless later:
+If the login is already stored in that profile, you can switch to headless later. Use `--stealth-level full` only for sites that need the stronger fingerprint bundle:
 
 ```bash
 pinchtab instance stop inst_ea2e747f
-pinchtab instance start --profile work --mode headless
+pinchtab instance start --profile work --mode headless --stealth-level full
 ```
 
 ### 3. Create a dedicated auth profile over HTTP
@@ -184,9 +184,12 @@ Use this when the agent cannot call the CLI directly.
 
 ```bash
 curl http://localhost:9867/health
-curl -X POST http://localhost:9867/instances/launch \
+curl -X POST http://localhost:9867/profiles \
   -H "Content-Type: application/json" \
-  -d '{"name":"work","headless":true}'
+  -d '{"name":"work"}'
+curl -X POST http://localhost:9867/instances/start \
+  -H "Content-Type: application/json" \
+  -d '{"profileId":"work","mode":"headless"}'
 curl -X POST http://localhost:9868/action \
   -H "Content-Type: application/json" \
   -d '{"kind":"click","selector":"e5"}'

--- a/npm/skills/pinchtab/references/profiles.md
+++ b/npm/skills/pinchtab/references/profiles.md
@@ -16,10 +16,10 @@ Returns array of profiles with `id`, `name`, `accountEmail`, `useWhen`, etc.
 # Auto-allocate port (recommended)
 curl -X POST http://localhost:9867/profiles/<ID>/start
 
-# With specific port and headless mode
+# With specific port, headless mode, and per-run stealth override
 curl -X POST http://localhost:9867/profiles/<ID>/start \
   -H 'Content-Type: application/json' \
-  -d '{"port": "9868", "headless": true}'
+  -d '{"port": "9868", "headless": true, "stealthLevel": "full"}'
 
 # Short alias
 curl -X POST http://localhost:9867/start/<ID>
@@ -46,12 +46,16 @@ curl http://localhost:9867/profiles/<ID>/instance
 curl http://localhost:9867/profiles/My%20Profile/instance
 ```
 
-## Launch by name
+## Start by existing profile
 
 ```bash
-curl -X POST http://localhost:9867/instances/launch \
+curl -X POST http://localhost:9867/profiles \
   -H 'Content-Type: application/json' \
-  -d '{"name": "work", "port": "9868"}'
+  -d '{"name": "work"}'
+
+curl -X POST http://localhost:9867/instances/start \
+  -H 'Content-Type: application/json' \
+  -d '{"profileId": "work", "port": "9868"}'
 ```
 
 ## CLI usage with profiles

--- a/skills/pinchtab/SKILL.md
+++ b/skills/pinchtab/SKILL.md
@@ -142,11 +142,11 @@ pinchtab instance start --profile work --mode headed
 pinchtab --server http://localhost:9868 nav https://mail.google.com
 ```
 
-If the login is already stored in that profile, you can switch to headless later:
+If the login is already stored in that profile, you can switch to headless later. Use `--stealth-level full` only for sites that need the stronger fingerprint bundle:
 
 ```bash
 pinchtab instance stop inst_ea2e747f
-pinchtab instance start --profile work --mode headless
+pinchtab instance start --profile work --mode headless --stealth-level full
 ```
 
 ### 3. Create a dedicated auth profile over HTTP

--- a/skills/pinchtab/references/profiles.md
+++ b/skills/pinchtab/references/profiles.md
@@ -16,10 +16,10 @@ Returns array of profiles with `id`, `name`, `accountEmail`, `useWhen`, etc.
 # Auto-allocate port (recommended)
 curl -X POST http://localhost:9867/profiles/<ID>/start
 
-# With specific port and headless mode
+# With specific port, headless mode, and per-run stealth override
 curl -X POST http://localhost:9867/profiles/<ID>/start \
   -H 'Content-Type: application/json' \
-  -d '{"port": "9868", "headless": true}'
+  -d '{"port": "9868", "headless": true, "stealthLevel": "full"}'
 
 # Short alias
 curl -X POST http://localhost:9867/start/<ID>


### PR DESCRIPTION
Root cause of the 2026-08-17 SBSA outage (SMI-3785), part 2 of 3. Two defects that combined to make a bank login impossible.

## 1. `maxTabs` was enforced against in-process bookkeeping
`CreateTab` compared `len(tm.tabs)` — the managed map — against `MaxTabs`. Any page target Chrome holds that this process no longer tracks (bridge restart, dead tab context, Chromium session restore) was invisible to the cap.

Production instance `inst_bcf833a9` was configured `maxTabs: 8` and held **158 live page targets** (31x ivodent login, 23x curaden search, 20x happyfresh, 68x local scraper pages). It starved every other caller of that shared instance and timed out the sidecar's own readiness probe.

The cap now counts real Chrome page targets (`liveTabCount`) and reaps untracked orphan targets (`reapOrphanTargets`, oldest-first) **before** evicting a tab a caller may still be driving.

## 2. A new profile was indistinguishable from a corrupt one
`profiles.Create()` left `Default/` with no `Preferences`. External profile-volume janitors reasonably read "no Preferences" as "broken, delete" — on 2026-08-17 that destroyed the `stdbank-luke` and `bobgo-luke` bank profiles along with their remembered-device tokens.

`Create()` now seeds a minimal `Preferences` (never overwriting a real one). The orchestrator seeds it too, and now WARNs loudly when it auto-creates a profile dir the store doesn't know about — previously a silent path that quietly hands the caller a blank browser instead of their logged-in session.

## Tests
- `selectOrphanTargets` / `trackedCDPIDs` unit tests (untracked-only, oldest-first, limit, non-page targets ignored)
- `TestCreateSeedsChromiumPreferences`, `TestSeedChromiumPreferencesPreservesExisting`
- `go vet ./internal/...`, `go test ./internal/bridge ./internal/profiles ./internal/orchestrator` all green