### PR TITLE
fix: enforce tab cap against Chrome reality; make new profiles self-identifying

### DIFF
--- a/internal/bridge/action_text.go
+++ b/internal/bridge/action_text.go
@@ -15,26 +15,41 @@ func (b *Bridge) actionType(ctx context.Context, req ActionRequest) (map[string]
 		return b.actionHumanizedType(ctx, req)
 	}
 	if req.Selector != "" {
-		return map[string]any{"typed": req.Text}, chromedp.Run(ctx,
+		// Probe the field before typing: after SendKeys the selector still
+		// resolves, but probing first also covers pages that swap the node.
+		echo := textEcho(ctx, req.Selector, 0, echoKeyTyped, req.Text, nil)
+		if err := chromedp.Run(ctx,
 			chromedp.Click(req.Selector, chromedp.ByQuery),
 			chromedp.SendKeys(req.Selector, req.Text, chromedp.ByQuery),
-		)
+		); err != nil {
+			return nil, err
+		}
+		return echo, nil
 	}
 	if req.NodeID > 0 {
-		return map[string]any{"typed": req.Text}, TypeByNodeID(ctx, req.NodeID, req.Text)
+		echo := textEcho(ctx, "", req.NodeID, echoKeyTyped, req.Text, nil)
+		if err := TypeByNodeID(ctx, req.NodeID, req.Text); err != nil {
+			return nil, err
+		}
+		return echo, nil
 	}
 	return nil, fmt.Errorf("need selector or ref")
 }
 
 func (b *Bridge) actionFill(ctx context.Context, req ActionRequest) (map[string]any, error) {
 	if req.Selector != "" {
-		return map[string]any{"filled": req.Text}, chromedp.Run(ctx, chromedp.SetValue(req.Selector, req.Text, chromedp.ByQuery))
+		echo := textEcho(ctx, req.Selector, 0, echoKeyFilled, req.Text, nil)
+		if err := chromedp.Run(ctx, chromedp.SetValue(req.Selector, req.Text, chromedp.ByQuery)); err != nil {
+			return nil, err
+		}
+		return echo, nil
 	}
 	if req.NodeID > 0 {
+		echo := textEcho(ctx, "", req.NodeID, echoKeyFilled, req.Text, nil)
 		if err := FillByNodeID(ctx, req.NodeID, req.Text); err != nil {
 			return nil, err
 		}
-		result := map[string]any{"filled": req.Text}
+		result := echo
 		if actual, err := ReadInputValue(ctx, req.NodeID); err == nil && req.Text != "" && actual != req.Text {
 			result["warning"] = "fill may not have been picked up by the page (e.g. React controlled input); try 'type' instead"
 		}
@@ -71,12 +86,15 @@ func (b *Bridge) actionHumanizedType(ctx context.Context, req ActionRequest) (ma
 		return nil, fmt.Errorf("need selector, ref, or nodeId")
 	}
 
+	// Focused above, so the focused element is the target.
+	echo := textEcho(ctx, req.Selector, req.NodeID, echoKeyTyped, req.Text, map[string]any{"human": true})
+
 	actions := Type(req.Text, req.Fast)
 	if err := chromedp.Run(ctx, actions...); err != nil {
 		return nil, err
 	}
 
-	return map[string]any{"typed": req.Text, "human": true}, nil
+	return echo, nil
 }
 
 // keyboardTypeThreshold is the character count above which we switch from
@@ -98,11 +116,20 @@ func (b *Bridge) actionKeyboardType(ctx context.Context, req ActionRequest) (map
 	// We still fire a keydown at the start and keyup at the end to trigger
 	// any key-event listeners that apps might depend on.
 	// Use rune count (not byte length) since we're counting keystrokes.
+	// These paths dispatch to whatever is focused, so probe the focused element.
 	if len([]rune(req.Text)) > keyboardTypeThreshold {
-		return b.keyboardTypeBatched(ctx, req.Text)
+		echo := textEcho(ctx, "", 0, echoKeyTyped, req.Text, map[string]any{"batched": true})
+		if _, err := b.keyboardTypeBatched(ctx, req.Text); err != nil {
+			return nil, err
+		}
+		return echo, nil
 	}
 
-	return b.keyboardTypePerChar(ctx, req.Text)
+	echo := textEcho(ctx, "", 0, echoKeyTyped, req.Text, nil)
+	if _, err := b.keyboardTypePerChar(ctx, req.Text); err != nil {
+		return nil, err
+	}
+	return echo, nil
 }
 
 // keyboardTypePerChar dispatches individual keyDown/keyUp events for each character.
@@ -145,7 +172,8 @@ func (b *Bridge) keyboardTypePerChar(ctx context.Context, text string) (map[stri
 	if err != nil {
 		return nil, err
 	}
-	return map[string]any{"typed": text}, nil
+	// Internal result; callers replace this with a redaction-aware echo.
+	return map[string]any{"typed_len": len([]rune(text))}, nil
 }
 
 // keyboardTypeBatchedEdgeChars is how many characters to type with real
@@ -189,13 +217,15 @@ func (b *Bridge) keyboardTypeBatched(ctx context.Context, text string) (map[stri
 		return nil, err
 	}
 
-	return map[string]any{"typed": text, "batched": true}, nil
+	// Internal result; callers replace this with a redaction-aware echo.
+	return map[string]any{"typed_len": len([]rune(text)), "batched": true}, nil
 }
 
 func (b *Bridge) actionKeyboardInsert(ctx context.Context, req ActionRequest) (map[string]any, error) {
 	if req.Text == "" {
 		return nil, fmt.Errorf("text required for keyboard-inserttext")
 	}
+	echo := textEcho(ctx, "", 0, "inserted", req.Text, nil)
 	err := chromedp.Run(ctx, chromedp.ActionFunc(func(ctx context.Context) error {
 		return chromedp.FromContext(ctx).Target.Execute(ctx, "Input.insertText", map[string]any{
 			"text": req.Text,
@@ -204,7 +234,7 @@ func (b *Bridge) actionKeyboardInsert(ctx context.Context, req ActionRequest) (m
 	if err != nil {
 		return nil, err
 	}
-	return map[string]any{"inserted": req.Text}, nil
+	return echo, nil
 }
 
 func (b *Bridge) actionKeyDown(ctx context.Context, req ActionRequest) (map[string]any, error) {

--- a/internal/bridge/bridge_lifecycle.go
+++ b/internal/bridge/bridge_lifecycle.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/chromedp/cdproto/page"
 	"github.com/chromedp/chromedp"
+	bridgeruntime "github.com/pinchtab/pinchtab/internal/bridge/runtime"
 	"github.com/pinchtab/pinchtab/internal/config"
 	"github.com/pinchtab/pinchtab/internal/ids"
 	"github.com/pinchtab/pinchtab/internal/stealth"
@@ -72,7 +73,7 @@ func (b *Bridge) tabSetup(ctx context.Context) {
 	b.applyTargetStealth(ctx)
 	b.installWorkerStealthParity(ctx)
 	b.injectStealth(ctx)
-	if b.Config.NoAnimations {
+	if b.Config != nil && b.Config.NoAnimations {
 		if err := b.InjectNoAnimations(ctx); err != nil {
 			slog.Warn("no-animations injection failed", "err", err)
 		}
@@ -144,9 +145,14 @@ func (b *Bridge) EnsureChrome(cfg *config.RuntimeConfig) error {
 		}
 	}
 
-	slog.Info("starting chrome with confirmed profile", "headless", cfg.Headless, "profile", cfg.ProfileDir)
+	launchCfg, err := bridgeruntime.PrepareTransactionPolicyExtension(cfg)
+	if err != nil {
+		return fmt.Errorf("prepare transaction policy: %w", err)
+	}
+
+	slog.Info("starting chrome with confirmed profile", "headless", launchCfg.Headless, "profile", launchCfg.ProfileDir)
 	b.ensureStealthBundle()
-	allocCtx, allocCancel, browserCtx, browserCancel, launchMode, err := InitChrome(cfg, b.StealthBundle)
+	allocCtx, allocCancel, browserCtx, browserCancel, launchMode, err := InitChrome(launchCfg, b.StealthBundle)
 	if err != nil {
 		return fmt.Errorf("failed to initialize chrome: %w", err)
 	}
@@ -333,7 +339,10 @@ func (b *Bridge) Cleanup() {
 	}
 }
 
-func (b *Bridge) SetBrowserContexts(allocCtx context.Context, allocCancel context.CancelFunc, browserCtx context.Context, browserCancel context.CancelFunc) {
+func (b *Bridge) SetBrowserContexts(allocCtx context.Context, allocCancel context.CancelFunc, browserCtx context.Context, browserCancel context.CancelFunc) error {
+	if b.Config != nil && b.Config.TransactionPolicy.Enabled {
+		return fmt.Errorf("transaction policy requires a PinchTab-managed browser launch; attached browsers cannot load the required extension")
+	}
 	b.initMu.Lock()
 	defer b.initMu.Unlock()
 
@@ -356,6 +365,7 @@ func (b *Bridge) SetBrowserContexts(allocCtx context.Context, allocCancel contex
 		b.SetDialogManager(b.Dialogs)
 		b.SetNetworkMonitor(b.netMonitor)
 	}
+	return nil
 }
 
 func cryptoRandSeed() int64 {

--- a/internal/bridge/runtime/init.go
+++ b/internal/bridge/runtime/init.go
@@ -14,11 +14,13 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	goruntime "runtime"
 	"strconv"
 	"strings"
 	"time"
 
+	cdpruntime "github.com/chromedp/cdproto/runtime"
 	"github.com/chromedp/chromedp"
 	"github.com/pinchtab/pinchtab/internal/config"
 	"github.com/pinchtab/pinchtab/internal/stealth"
@@ -48,10 +50,17 @@ func InitChrome(cfg *config.RuntimeConfig, bundle *stealth.Bundle, hooks Hooks) 
 		return initChromeFromExistingCDP(cfg, bundle)
 	}
 
+	if err := validateTransactionPolicyLaunch(cfg); err != nil {
+		return nil, nil, nil, nil, stealth.LaunchModeUninitialized, err
+	}
+
 	slog.Info("starting chrome initialization", "headless", cfg.Headless, "profile", cfg.ProfileDir, "binary", cfg.ChromeBinary)
 
 	bundle = ensureStealthBundle(cfg, bundle)
-	allocCtx, allocCancel, opts, debugPort := setupAllocator(cfg, bundle, hooks)
+	allocCtx, allocCancel, opts, debugPort, err := setupAllocator(cfg, bundle, hooks)
+	if err != nil {
+		return nil, nil, nil, nil, stealth.LaunchModeUninitialized, err
+	}
 	browserCtx, browserCancel, launchMode, err := startChrome(allocCtx, cfg, bundle, opts, debugPort, hooks)
 	if err != nil {
 		allocCancel()
@@ -145,7 +154,13 @@ func appendExecAllocatorFlags(opts []chromedp.ExecAllocatorOption, flags []strin
 	return opts
 }
 
-func setupAllocator(cfg *config.RuntimeConfig, bundle *stealth.Bundle, hooks Hooks) (context.Context, context.CancelFunc, []chromedp.ExecAllocatorOption, int) {
+func setupAllocator(cfg *config.RuntimeConfig, bundle *stealth.Bundle, hooks Hooks) (context.Context, context.CancelFunc, []chromedp.ExecAllocatorOption, int, error) {
+	// Recheck immediately before building allocator arguments. If the generated
+	// directory vanished after InitChrome's first check, do not silently launch
+	// with profile extensions or an unprotected browser.
+	if err := validateTransactionPolicyLaunch(cfg); err != nil {
+		return nil, nil, nil, 0, err
+	}
 	opts := []chromedp.ExecAllocatorOption{
 		chromedp.NoFirstRun,
 		chromedp.NoDefaultBrowserCheck,
@@ -232,7 +247,7 @@ func setupAllocator(cfg *config.RuntimeConfig, bundle *stealth.Bundle, hooks Hoo
 	}))
 
 	ctx, cancel := context.WithCancel(context.Background())
-	return ctx, cancel, opts, debugPort
+	return ctx, cancel, opts, debugPort, nil
 }
 
 func startChrome(parentCtx context.Context, cfg *config.RuntimeConfig, bundle *stealth.Bundle, opts []chromedp.ExecAllocatorOption, debugPort int, hooks Hooks) (context.Context, context.CancelFunc, stealth.LaunchMode, error) {
@@ -288,6 +303,14 @@ func startChromeWithRecovery(parentCtx context.Context, cfg *config.RuntimeConfi
 		return nil, nil, stealth.LaunchModeUninitialized, fmt.Errorf("failed to connect to chrome: %w", err)
 	}
 
+	if cfg.TransactionPolicy.Enabled {
+		if err := verifyTransactionPolicyExtension(browserCtx); err != nil {
+			browserCancel()
+			allocCancel()
+			return nil, nil, stealth.LaunchModeUninitialized, fmt.Errorf("transaction policy extension did not activate: %w", err)
+		}
+	}
+
 	if err := chromedp.Run(browserCtx, chromedp.ActionFunc(func(ctx context.Context) error {
 		if err := stealth.ApplyTargetEmulation(ctx, cfg, bundle.LaunchUserAgent()); err != nil {
 			return err
@@ -327,6 +350,12 @@ func shouldRetryChromeStartupWithDirectLaunch(parentCtx context.Context, err err
 }
 
 func startChromeWithRemoteAllocator(parentCtx context.Context, cfg *config.RuntimeConfig, bundle *stealth.Bundle, debugPort int, injectedStealthScript string) (context.Context, context.CancelFunc, stealth.LaunchMode, error) {
+	// This path can be reached after allocator startup has timed out. Keep its
+	// guard independent so a future direct caller cannot bypass policy launch
+	// validation before starting a process.
+	if err := validateTransactionPolicyLaunch(cfg); err != nil {
+		return nil, nil, stealth.LaunchModeUninitialized, err
+	}
 	chromeBinary := cfg.ChromeBinary
 	if chromeBinary == "" {
 		chromeBinary = findChromeBinary()
@@ -365,6 +394,18 @@ func startChromeWithRemoteAllocator(parentCtx context.Context, cfg *config.Runti
 	remoteAllocCtx, remoteAllocCancel := chromedp.NewRemoteAllocator(parentCtx, wsURL)
 	browserCtx, browserCancel := chromedp.NewContext(remoteAllocCtx)
 
+	// The direct-launch recovery path must prove the extension activated too;
+	// otherwise a startup workaround could turn an enabled policy into an
+	// unprotected managed browser.
+	if cfg.TransactionPolicy.Enabled {
+		if err := verifyTransactionPolicyExtension(browserCtx); err != nil {
+			browserCancel()
+			remoteAllocCancel()
+			_ = cmd.Process.Kill()
+			return nil, nil, stealth.LaunchModeUninitialized, fmt.Errorf("transaction policy extension did not activate: %w", err)
+		}
+	}
+
 	if err := chromedp.Run(browserCtx, chromedp.ActionFunc(func(ctx context.Context) error {
 		if err := stealth.ApplyTargetEmulation(ctx, cfg, bundle.LaunchUserAgent()); err != nil {
 			return err
@@ -382,6 +423,101 @@ func startChromeWithRemoteAllocator(parentCtx context.Context, cfg *config.Runti
 		remoteAllocCancel()
 		killAndReap()
 	}, stealth.LaunchModeDirectFallback, nil
+}
+
+func validateTransactionPolicyLaunch(cfg *config.RuntimeConfig) error {
+	if cfg == nil || !cfg.TransactionPolicy.Enabled {
+		return nil
+	}
+	if strings.TrimSpace(cfg.ChromeBinary) == "" {
+		return fmt.Errorf("transaction policy requires browser.binary to name an unpacked-extension-capable Chromium or Chrome for Testing executable")
+	}
+	binary := strings.ToLower(strings.TrimSpace(cfg.ChromeBinary))
+	base := filepath.Base(binary)
+	// Chrome for Testing on macOS is named "Google Chrome for Testing" and is
+	// supported. Reject Stable by its app/path identity rather than matching the
+	// generic words "google chrome".
+	if (strings.Contains(binary, "google chrome") && !strings.Contains(binary, "for testing")) || base == "google-chrome" || base == "google-chrome-stable" || strings.Contains(binary, "program files/google/chrome/application") {
+		return fmt.Errorf("transaction policy does not support Google Chrome Stable; configure a compatible Chromium or Chrome for Testing executable")
+	}
+	// Policy activation is meaningful only when this generated extension is the
+	// sole extension Chrome can load. Do not accept a path merely because it has
+	// a familiar prefix: it must be a validated content-addressed generation.
+	if len(cfg.ExtensionPaths) != 1 {
+		return fmt.Errorf("transaction policy requires exactly one generated extension and rejects browser.extensionPaths")
+	}
+	if !isTransactionPolicyExtensionPath(cfg.StateDir, cfg.ExtensionPaths[0]) {
+		return fmt.Errorf("transaction policy extension is not a managed generated extension")
+	}
+	manifest, rules, err := compileTransactionPolicy(cfg.TransactionPolicy)
+	if err != nil {
+		return fmt.Errorf("recompile transaction policy for launch validation: %w", err)
+	}
+	if err := checkTransactionPolicyGenerationContent(cfg.ExtensionPaths[0], manifest, rules); err != nil {
+		return fmt.Errorf("transaction policy extension is unavailable, unsafe, or does not match policy: %w", err)
+	}
+	return nil
+}
+
+func isTransactionPolicyExtensionPath(stateDir, extensionPath string) bool {
+	stateRoot, err := filepath.Abs(stateDir)
+	if err != nil {
+		return false
+	}
+	path, err := filepath.Abs(extensionPath)
+	if err != nil || filepath.Dir(path) != filepath.Join(stateRoot, transactionPolicyStateRoot) {
+		return false
+	}
+	return transactionPolicyGenerationName.MatchString(filepath.Base(path))
+}
+
+func hasExactTransactionPolicyRulesets(enabled []string) bool {
+	return len(enabled) == 1 && enabled[0] == transactionPolicyRulesetID
+}
+
+func verifyTransactionPolicyExtension(browserCtx context.Context) error {
+	// The fixed manifest key makes this exact extension URL an identity-bound
+	// probe. Evaluate DNR directly in that extension page; MV3 workers need not
+	// be separately visible or attachable through Target.getTargets.
+	if err := chromedp.Run(browserCtx, chromedp.Navigate("chrome-extension://"+transactionPolicyExtensionID+"/probe.html")); err != nil {
+		return fmt.Errorf("open generated extension activation probe: %w", err)
+	}
+	var state struct {
+		Enabled     []string `json:"enabled"`
+		Unsupported []int    `json:"unsupported"`
+		Disabled    []int    `json:"disabled"`
+		RuleCount   int      `json:"ruleCount"`
+	}
+	const probe = `(async () => {
+		const rules = await (await fetch(chrome.runtime.getURL('rules.json'), {cache: 'no-store'})).json();
+		const regexRules = rules.filter(rule => typeof rule.condition.regexFilter === 'string');
+		const unsupported = [];
+		for (const rule of regexRules) {
+			const result = await chrome.declarativeNetRequest.isRegexSupported({
+				regex: rule.condition.regexFilter,
+				isCaseSensitive: rule.condition.isUrlFilterCaseSensitive
+			});
+			if (!result.isSupported) unsupported.push(rule.id);
+		}
+		return {
+			enabled: Array.from(await chrome.declarativeNetRequest.getEnabledRulesets()),
+			unsupported,
+			disabled: Array.from(await chrome.declarativeNetRequest.getDisabledRuleIds({rulesetId: 'pinchtab_transaction_policy'})),
+			ruleCount: rules.length
+		};
+	})()`
+	if err := chromedp.Run(browserCtx, chromedp.Evaluate(probe, &state, func(p *cdpruntime.EvaluateParams) *cdpruntime.EvaluateParams {
+		return p.WithAwaitPromise(true)
+	})); err != nil {
+		return fmt.Errorf("inspect generated extension rules: %w", err)
+	}
+	if !hasExactTransactionPolicyRulesets(state.Enabled) {
+		return fmt.Errorf("generated ruleset %q was not exclusively enabled (enabled rulesets=%v)", transactionPolicyRulesetID, state.Enabled)
+	}
+	if state.RuleCount == 0 || len(state.Unsupported) != 0 || len(state.Disabled) != 0 {
+		return fmt.Errorf("generated ruleset is incomplete (rules=%d unsupported=%v disabled=%v)", state.RuleCount, state.Unsupported, state.Disabled)
+	}
+	return nil
 }
 
 func findFreePort(start, end int) (int, error) {

--- a/internal/bridge/runtime/transaction_policy.go
+++ b/internal/bridge/runtime/transaction_policy.go
@@ -219,7 +219,7 @@ func transactionRuleConditions(hostPattern string, hosts []string, rule config.T
 	guardedUnsafeMethod := method == "CONNECT" || method == "DELETE" || method == "OTHER" || method == "PATCH" || method == "POST" || method == "PUT"
 	rootSegment := strings.TrimSpace(rule.PathPrefix) == "/" && strings.TrimSpace(rule.PathSegment) != "" && strings.TrimSpace(rule.QueryParam) == ""
 
-	regexEncodePath := encodePath && !guardedUnsafeMethod && !(method == "*" && rootSegment)
+	regexEncodePath := encodePath && !guardedUnsafeMethod && (method != "*" || !rootSegment)
 	regexes, err := transactionRuleRegexes(hostPattern, rule, regexEncodePath)
 	if err != nil {
 		return nil, err

--- a/internal/bridge/runtime/transaction_policy.go
+++ b/internal/bridge/runtime/transaction_policy.go
@@ -1,0 +1,372 @@
+package runtime
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/pinchtab/pinchtab/internal/config"
+)
+
+const (
+	transactionPolicyRulesetID   = "pinchtab_transaction_policy"
+	transactionPolicyExtensionID = "amadgaedoaaekpjejecafmbdhacgmlig"
+	transactionPolicyManifestKey = "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuinfEBuVQwc6FKF/tVRTn6rfITooe1jQaIMYk/rTRwYg4Pe1GqvFafjT7ghbL58Tjf55M+VhVhvEMSIzCPzjRfp7m8cUgm8/Qz7b86DRkyBzz+ovEMvtZLtN8f8xLIaR1dWVt++Lti1QOMBDNB6DVdGIDGUJm5xXVWhQTh1pRRBY2Fcbg5BgH4SG8/VAOXbVnXuXvniKf1skZlO3lUZeTVBlF8Rly4Drgep/B5wQEVhIiiomm+LV6saes6nKHbMysFlgfAOxL7wiEt6oqtFvGfh+QiVe8pazpA1N6Xf8Q47ljG2oTEtdGaPouHdOcnNwC0WtZ8p8LfhL7zqVqpCkpQIDAQAB"
+	// Chrome accepts at most 1,000 regex rules in one static ruleset. Exceeding
+	// that limit makes Chrome ignore later rules, so reject instead of launching
+	// a partially enforced transaction policy.
+	maxTransactionPolicyRegexRules = 1000
+)
+
+type transactionPolicyManifest struct {
+	ManifestVersion       int           `json:"manifest_version"`
+	Name                  string        `json:"name"`
+	Version               string        `json:"version"`
+	Key                   string        `json:"key"`
+	Permissions           []string      `json:"permissions"`
+	HostPermissions       []string      `json:"host_permissions"`
+	DeclarativeNetRequest dnrSpec       `json:"declarative_net_request"`
+	Background            dnrBackground `json:"background"`
+}
+
+type dnrBackground struct {
+	ServiceWorker string `json:"service_worker"`
+}
+type dnrSpec struct {
+	RuleResources []dnrResource `json:"rule_resources"`
+}
+type dnrResource struct {
+	ID      string `json:"id"`
+	Enabled bool   `json:"enabled"`
+	Path    string `json:"path"`
+}
+type dnrRule struct {
+	ID        int          `json:"id"`
+	Priority  int          `json:"priority"`
+	Action    dnrAction    `json:"action"`
+	Condition dnrCondition `json:"condition"`
+}
+type dnrAction struct {
+	Type string `json:"type"`
+}
+type dnrCondition struct {
+	RegexFilter              string   `json:"regexFilter,omitempty"`
+	URLFilter                string   `json:"urlFilter,omitempty"`
+	IsURLFilterCaseSensitive bool     `json:"isUrlFilterCaseSensitive"`
+	RequestDomains           []string `json:"requestDomains,omitempty"`
+	RequestMethods           []string `json:"requestMethods,omitempty"`
+	ExcludedRequestMethods   []string `json:"excludedRequestMethods,omitempty"`
+}
+
+// PrepareTransactionPolicyExtension compiles the configured policy into an
+// unpacked MV3 extension. Policy mode deliberately loads no operator supplied
+// extensions: an additional extension could spoof activation or change DNR.
+func PrepareTransactionPolicyExtension(cfg *config.RuntimeConfig) (*config.RuntimeConfig, error) {
+	if cfg == nil || !cfg.TransactionPolicy.Enabled {
+		return cfg, nil
+	}
+	if strings.TrimSpace(cfg.StateDir) == "" {
+		return nil, fmt.Errorf("transaction policy requires server.stateDir")
+	}
+	if len(cfg.ExtensionPaths) != 0 {
+		return nil, fmt.Errorf("transaction policy cannot be used with browser.extensionPaths")
+	}
+	manifest, rules, err := compileTransactionPolicy(cfg.TransactionPolicy)
+	if err != nil {
+		return nil, fmt.Errorf("compile transaction policy: %w", err)
+	}
+	path, err := writeTransactionPolicyExtension(cfg.StateDir, manifest, rules)
+	if err != nil {
+		return nil, fmt.Errorf("write transaction policy extension: %w", err)
+	}
+	launch := *cfg
+	launch.ExtensionPaths = []string{path}
+	return &launch, nil
+}
+
+func compileTransactionPolicy(policy config.TransactionPolicyConfig) (transactionPolicyManifest, []dnrRule, error) {
+	if !policy.Enabled {
+		return transactionPolicyManifest{}, nil, nil
+	}
+	if errs := config.ValidateFileConfig(&config.FileConfig{Security: config.SecurityConfig{TransactionPolicy: policy}}); len(errs) != 0 {
+		return transactionPolicyManifest{}, nil, fmt.Errorf("invalid policy: %v", errs[0])
+	}
+	hosts := append([]string(nil), policy.Hosts...)
+	for i := range hosts {
+		hosts[i] = strings.ToLower(strings.TrimSuffix(strings.TrimSpace(hosts[i]), "."))
+	}
+	sort.Strings(hosts)
+	hosts = compactStrings(hosts)
+	manifest := transactionPolicyManifest{ManifestVersion: 3, Name: "PinchTab Transaction Policy", Version: "1.0", Key: transactionPolicyManifestKey, Permissions: []string{"declarativeNetRequest"}, HostPermissions: transactionHostPermissions(hosts), DeclarativeNetRequest: dnrSpec{RuleResources: []dnrResource{{ID: transactionPolicyRulesetID, Enabled: true, Path: "rules.json"}}}, Background: dnrBackground{ServiceWorker: "background.js"}}
+	rules := make([]dnrRule, 0, len(policy.DenyRules)+len(policy.AllowRules)+1)
+	id := 1
+	appendRules := func(source []config.TransactionPolicyRule, priority int, action string, encodePath bool) error {
+		type group struct {
+			condition dnrCondition
+			wildcard  bool
+			methods   map[string]struct{}
+		}
+		groups := make([]group, 0, len(source))
+		byCondition := make(map[string]int, len(source))
+		domainScoped := action == "block"
+		hostPatterns := []string{"[^/?#]+"}
+		if !domainScoped {
+			hostPatterns = make([]string, len(hosts))
+			for i, host := range hosts {
+				hostPatterns[i] = regexp.QuoteMeta(host)
+			}
+		}
+		for _, rule := range source {
+			method := strings.ToLower(strings.TrimSpace(rule.Method))
+			for _, pattern := range hostPatterns {
+				conditions, err := transactionRuleConditions(pattern, hosts, rule, encodePath, domainScoped)
+				if err != nil {
+					return err
+				}
+				for _, condition := range conditions {
+					key := condition.RegexFilter + "\x00" + condition.URLFilter + "\x00" + strings.Join(condition.RequestDomains, "\x00")
+					index, ok := byCondition[key]
+					if !ok {
+						index = len(groups)
+						byCondition[key] = index
+						groups = append(groups, group{condition: condition, methods: make(map[string]struct{})})
+					}
+					if method == "*" {
+						groups[index].wildcard = true
+					} else {
+						groups[index].methods[method] = struct{}{}
+					}
+				}
+			}
+		}
+		for _, group := range groups {
+			condition := group.condition
+			if !group.wildcard {
+				condition.RequestMethods = make([]string, 0, len(group.methods))
+				for method := range group.methods {
+					condition.RequestMethods = append(condition.RequestMethods, method)
+				}
+				sort.Strings(condition.RequestMethods)
+			}
+			rules = append(rules, dnrRule{ID: id, Priority: priority, Action: dnrAction{Type: action}, Condition: condition})
+			id++
+		}
+		return nil
+	}
+	// Unsafe requests with percent escapes are ambiguous at the DNR/raw-URL
+	// boundary. Block them before explicit allows; callers can use canonical raw
+	// unreserved paths/queries and put arbitrary data in the request body.
+	encodedUnsafeRegex := "^(https?|wss?)://([^/?#@]*@)?[^/?#]+(:[0-9]+)?[^#]*%[0-9A-F]{2}"
+	if err := validateDNRRegex(encodedUnsafeRegex); err != nil {
+		return transactionPolicyManifest{}, nil, err
+	}
+	rules = append(rules, dnrRule{ID: id, Priority: 3, Action: dnrAction{Type: "block"}, Condition: dnrCondition{RegexFilter: encodedUnsafeRegex, IsURLFilterCaseSensitive: false, RequestDomains: append([]string(nil), hosts...), RequestMethods: []string{"connect", "delete", "other", "patch", "post", "put"}}})
+	id++
+	// Denies use an encoding-tolerant path representation. This only broadens a
+	// block, never an allow, so URL serialization ambiguities fail closed.
+	if err := appendRules(policy.DenyRules, 3, "block", true); err != nil {
+		return transactionPolicyManifest{}, nil, err
+	}
+	if err := appendRules(policy.AllowRules, 2, "allow", false); err != nil {
+		return transactionPolicyManifest{}, nil, err
+	}
+	regex := "^(https?|wss?)://([^/?#@]*@)?[^/?#]+(:[0-9]+)?(/|$)"
+	if err := validateDNRRegex(regex); err != nil {
+		return transactionPolicyManifest{}, nil, err
+	}
+	rules = append(rules, dnrRule{ID: id, Priority: 1, Action: dnrAction{Type: "block"}, Condition: dnrCondition{RegexFilter: regex, IsURLFilterCaseSensitive: false, RequestDomains: append([]string(nil), hosts...), ExcludedRequestMethods: []string{"get", "head", "options"}}})
+	if err := validateTransactionPolicyRuleCounts(rules); err != nil {
+		return transactionPolicyManifest{}, nil, err
+	}
+	return manifest, rules, nil
+}
+
+func validateTransactionPolicyRuleCounts(rules []dnrRule) error {
+	regexRules := 0
+	for _, rule := range rules {
+		if rule.Condition.RegexFilter != "" {
+			regexRules++
+		}
+	}
+	if regexRules > maxTransactionPolicyRegexRules {
+		return fmt.Errorf("policy produces %d static regex rules, Chrome maximum is %d", regexRules, maxTransactionPolicyRegexRules)
+	}
+	return nil
+}
+
+func validateDNRRegex(regex string) error {
+	if len(regex) > 2000 {
+		return fmt.Errorf("DNR regex exceeds the 2000 byte limit")
+	}
+	if _, err := regexp.Compile(regex); err != nil {
+		return fmt.Errorf("invalid DNR regex: %w", err)
+	}
+	return nil
+}
+func transactionHostPermissions(hosts []string) []string {
+	permissions := make([]string, 0, len(hosts)*4)
+	for _, host := range hosts {
+		for _, name := range []string{host, host + "."} {
+			permissions = append(permissions, "http://"+name+"/*", "https://"+name+"/*")
+		}
+	}
+	return permissions
+}
+
+func transactionRuleConditions(hostPattern string, hosts []string, rule config.TransactionPolicyRule, encodePath bool, domainScoped bool) ([]dnrCondition, error) {
+	method := strings.ToUpper(strings.TrimSpace(rule.Method))
+	guardedUnsafeMethod := method == "CONNECT" || method == "DELETE" || method == "OTHER" || method == "PATCH" || method == "POST" || method == "PUT"
+	rootSegment := strings.TrimSpace(rule.PathPrefix) == "/" && strings.TrimSpace(rule.PathSegment) != "" && strings.TrimSpace(rule.QueryParam) == ""
+
+	regexEncodePath := encodePath && !guardedUnsafeMethod && !(method == "*" && rootSegment)
+	regexes, err := transactionRuleRegexes(hostPattern, rule, regexEncodePath)
+	if err != nil {
+		return nil, err
+	}
+	conditions := make([]dnrCondition, 0, len(regexes))
+	for _, regex := range regexes {
+		if err := validateDNRRegex(regex); err != nil {
+			return nil, err
+		}
+		condition := dnrCondition{RegexFilter: regex, IsURLFilterCaseSensitive: false}
+		if domainScoped {
+			condition.RequestDomains = append([]string(nil), hosts...)
+		}
+		conditions = append(conditions, condition)
+	}
+	if encodePath && method == "*" && rootSegment {
+		for _, filter := range transactionRuleEncodedSegmentURLFilters(rule) {
+			conditions = append(conditions, dnrCondition{
+				URLFilter:                filter,
+				IsURLFilterCaseSensitive: false,
+				RequestDomains:           append([]string(nil), hosts...),
+			})
+		}
+	}
+	return conditions, nil
+}
+
+func transactionRuleEncodedSegmentURLFilters(rule config.TransactionPolicyRule) []string {
+	segment := strings.TrimSpace(rule.PathSegment)
+	filters := make([]string, 0, len(segment))
+	for position := range len(segment) {
+		var b strings.Builder
+		b.WriteString("*")
+		for index := range len(segment) {
+			if index == position {
+				fmt.Fprintf(&b, "%%%02X", segment[index])
+			} else {
+				b.WriteByte(segment[index])
+			}
+		}
+		b.WriteString("*")
+		filters = append(filters, b.String())
+	}
+	return filters
+}
+
+// transactionRuleRegexes describes the raw network URL. Denies get the raw
+// spelling plus one variant for each single percent-encoded unreserved byte.
+// transactionRuleConditions moves only root-segment wildcard variants into
+// block-only URL filters and relies on the unsafe percent guard for explicit
+// mutation methods, keeping the static regex ruleset below Chrome's hard cap.
+func transactionRuleRegexes(hostPattern string, rule config.TransactionPolicyRule, encodePath bool) ([]string, error) {
+	base, positions, err := transactionRuleRegexVariant(hostPattern, rule, encodePath, -1)
+	if err != nil {
+		return nil, err
+	}
+	regexes := []string{base}
+	if !encodePath {
+		return regexes, nil
+	}
+	for position := 0; position < positions; position++ {
+		variant, _, err := transactionRuleRegexVariant(hostPattern, rule, true, position)
+		if err != nil {
+			return nil, err
+		}
+		regexes = append(regexes, variant)
+	}
+	return regexes, nil
+}
+
+func transactionRuleRegexVariant(hostPattern string, rule config.TransactionPolicyRule, encodePath bool, encodeAt int) (string, int, error) {
+	prefix := strings.TrimSuffix(strings.TrimSpace(rule.PathPrefix), "/")
+	if prefix == "" {
+		prefix = "/"
+	}
+	segment := strings.TrimSpace(rule.PathSegment)
+	position := 0
+	literal := func(value string) string {
+		if !encodePath {
+			return regexp.QuoteMeta(value)
+		}
+		var b strings.Builder
+		for i := 0; i < len(value); i++ {
+			c := value[i]
+			if c == '/' {
+				b.WriteString("(/|%2F)+")
+				continue
+			}
+			if position == encodeAt {
+				fmt.Fprintf(&b, "%%%02X", c)
+			} else {
+				b.WriteString(regexp.QuoteMeta(string(c)))
+			}
+			position++
+		}
+		return b.String()
+	}
+	separator := "/"
+	if encodePath {
+		separator = "(/|%2F)"
+	}
+	var pathPart string
+	switch {
+	case segment == "" && prefix == "/":
+		pathPart = "/[^?]*"
+	case segment == "":
+		pathPart = literal(prefix) + "(" + separator + "[^?]*)?"
+	case prefix == "/":
+		pathPart = separator + "([^?]*" + separator + ")?" + literal(segment) + "(" + separator + "[^?]*)?"
+	case pathPrefixHasSegment(prefix, segment):
+		pathPart = literal(prefix) + "(" + separator + "[^?]*)?"
+	default:
+		pathPart = literal(prefix) + "(" + separator + "[^?]*)?" + separator + literal(segment) + "(" + separator + "[^?]*)?"
+	}
+	query := "(\\?[^#]*)?(#.*)?$"
+	if rule.QueryParam != "" {
+		if encodePath {
+			// Denies match the configured pair anywhere in the query. Extra or
+			// conflicting parameters cannot turn a forbidden action into an allow.
+			pair := literal(rule.QueryParam) + "=" + literal(rule.QueryValue)
+			query = "\\?([^#&]*&)*" + pair + "(&[^#]*)?(#.*)?$"
+		} else {
+			// Allows must have exactly this whole query. A query condition is not a
+			// permission to add another action, duplicate, or empty value.
+			query = "\\?" + regexp.QuoteMeta(rule.QueryParam) + "=" + regexp.QuoteMeta(rule.QueryValue) + "(#.*)?$"
+		}
+	}
+	regex := "^(https?|wss?)://([^/?#@]*@)?" + hostPattern + "(\\.)?(:[0-9]+)?" + pathPart + query
+	return regex, position, nil
+}
+func pathPrefixHasSegment(prefix, segment string) bool {
+	for _, part := range strings.Split(strings.Trim(prefix, "/"), "/") {
+		if strings.EqualFold(part, segment) {
+			return true
+		}
+	}
+	return false
+}
+func compactStrings(values []string) []string {
+	if len(values) == 0 {
+		return values
+	}
+	out := values[:1]
+	for _, value := range values[1:] {
+		if value != out[len(out)-1] {
+			out = append(out, value)
+		}
+	}
+	return out
+}

--- a/internal/bridge/runtime/transaction_policy_integration_test.go
+++ b/internal/bridge/runtime/transaction_policy_integration_test.go
@@ -1,0 +1,187 @@
+//go:build integration
+
+package runtime
+
+import (
+	"crypto/sha1"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/chromedp/chromedp"
+	"github.com/pinchtab/pinchtab/internal/config"
+)
+
+// Run manually with an unpacked-extension-capable Chrome for Testing or Chromium:
+//
+//	PINCHTAB_TEST_TRANSACTION_POLICY_CHROME=/path/to/chrome \
+//	  go test -tags=integration ./internal/bridge/runtime -run TestTransactionPolicyDNRIntegration -count=1
+//
+// This is environment-gated and is not asserted to run in CI. The fixture uses
+// server-side counters only; a blocked request has no JavaScript "attempt" flag
+// that could turn a browser failure into a passing policy proof.
+func TestTransactionPolicyDNRIntegration(t *testing.T) {
+	binary := os.Getenv("PINCHTAB_TEST_TRANSACTION_POLICY_CHROME")
+	if binary == "" {
+		t.Skip("set PINCHTAB_TEST_TRANSACTION_POLICY_CHROME to a Chrome for Testing or Chromium binary")
+	}
+	var mu sync.Mutex
+	counts := map[string]int{}
+	methodCounts := map[string]int{}
+	count := func(path string) int { mu.Lock(); defer mu.Unlock(); return counts[path] }
+	methodCount := func(method, path string) int { mu.Lock(); defer mu.Unlock(); return methodCounts[method+" "+path] }
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		counts[r.URL.Path]++
+		methodCounts[r.Method+" "+r.URL.Path]++
+		mu.Unlock()
+		switch r.URL.Path {
+		case "/worker.js":
+			w.Header().Set("Content-Type", "application/javascript")
+			_, _ = w.Write([]byte(`fetch('/worker-forbidden',{method:'POST'}).catch(()=>{}).then(()=>fetch('/worker-ran'));`))
+		case "/shared-worker.js":
+			w.Header().Set("Content-Type", "application/javascript")
+			_, _ = w.Write([]byte(`fetch('/shared-worker-forbidden',{method:'POST'}).catch(()=>{}).then(()=>fetch('/shared-worker-ran'));`))
+		case "/service-worker.js":
+			w.Header().Set("Content-Type", "application/javascript")
+			_, _ = w.Write([]byte(`self.addEventListener('install', e => e.waitUntil(fetch('/service-worker-forbidden',{method:'POST'}).catch(()=>{}).then(()=>fetch('/service-worker-ran'))));`))
+		case "/redirect":
+			http.Redirect(w, r, "/redirect-forbidden", http.StatusTemporaryRedirect)
+		case "/ws-allowed":
+			// A real 101 response makes the counter evidence an actual WebSocket
+			// handshake rather than merely a JavaScript construction attempt.
+			h, ok := w.(http.Hijacker)
+			if !ok {
+				http.Error(w, "hijacking unavailable", http.StatusInternalServerError)
+				return
+			}
+			conn, rw, err := h.Hijack()
+			if err != nil {
+				return
+			}
+			defer conn.Close()
+			sum := sha1.Sum([]byte(r.Header.Get("Sec-WebSocket-Key") + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"))
+			_, _ = rw.WriteString("HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: " + base64.StdEncoding.EncodeToString(sum[:]) + "\r\n\r\n")
+			_ = rw.Flush()
+		default:
+			w.Header().Set("Content-Type", "text/html")
+			_, _ = w.Write([]byte(`<!doctype html><iframe name=normal hidden></iframe>
+<form action=/form-forbidden method=POST target=normal><input name=x value=1></form>
+<form action=/popup-initial-forbidden method=POST target=policyPopup><input name=x value=1></form>
+<script>
+fetch('/page-forbidden',{method:'POST'}).catch(()=>{}).then(()=>fetch('/page-ran'));
+document.forms[0].submit(); fetch('/form-ran'); document.forms[1].submit();
+new Worker('/worker.js'); new SharedWorker('/shared-worker.js'); navigator.serviceWorker && navigator.serviceWorker.register('/service-worker.js');
+fetch('/redirect',{method:'POST'}).catch(()=>{});
+new WebSocket(location.origin.replace(/^http/,'ws')+'/ws-forbidden'); new WebSocket(location.origin.replace(/^http/,'ws')+'/ws-allowed');
+fetch('/cart/add',{method:'POST'}); fetch('/cart/update',{method:'POST'}); fetch('/cart/remove',{method:'POST'});
+fetch('/orders'); fetch('/orders',{method:'POST'}); fetch('/orders/%6F%72der',{method:'POST'});
+fetch('/cart/preparation',{method:'POST'}); fetch('/cart/123/order',{method:'POST'}); fetch('/cart/123/%6Frder',{method:'POST'}); fetch('/cart/123/%6F%72der',{method:'POST'}); fetch('/cart/123/%2Forder',{method:'POST'}); fetch('/cart/preorder',{method:'POST'});
+fetch('/checkout',{method:'POST'}); fetch('/chec%6bout',{method:'POST'});
+const trailing = location.origin.replace('//127.0.0.1:', '//127.0.0.1.:'); fetch(trailing+'/trailing-read'); fetch(trailing+'/trailing-forbidden',{method:'POST'}); fetch(trailing+'/ord%65r',{method:'POST'}); fetch(trailing+'/%6F%72der',{method:'POST'});
+fetch('/?wc-ajax=add_to_cart',{method:'POST'}); fetch('/?wc-ajax=add_to_cart&action=checkout',{method:'POST'});
+fetch('/?action=checkout'); fetch('/?%61ction=checkout'); fetch('/?action=%63heckout'); fetch('/?%61%63tion=checkout',{method:'POST'}); fetch('/?action=cart');
+fetch('/read'); fetch('/read',{method:'HEAD'});
+</script>`))
+		}
+	}))
+	defer server.Close()
+	cfg := &config.RuntimeConfig{StateDir: t.TempDir(), ProfileDir: t.TempDir(), ChromeBinary: binary, Headless: true, TransactionPolicy: config.TransactionPolicyConfig{Enabled: true, Hosts: []string{"127.0.0.1"}, DenyRules: []config.TransactionPolicyRule{{Method: "*", PathPrefix: "/page-forbidden"}, {Method: "*", PathPrefix: "/form-forbidden"}, {Method: "*", PathPrefix: "/popup-initial-forbidden"}, {Method: "*", PathPrefix: "/worker-forbidden"}, {Method: "*", PathPrefix: "/shared-worker-forbidden"}, {Method: "*", PathPrefix: "/service-worker-forbidden"}, {Method: "*", PathPrefix: "/redirect-forbidden"}, {Method: "*", PathPrefix: "/ws-forbidden"}, {Method: "*", PathPrefix: "/checkout"}, {Method: "*", PathPrefix: "/trailing-forbidden"}, {Method: "POST", PathPrefix: "/orders"}, {Method: "POST", PathPrefix: "/", PathSegment: "order"}, {Method: "*", PathPrefix: "/", QueryParam: "action", QueryValue: "checkout"}}, AllowRules: []config.TransactionPolicyRule{{Method: "*", PathPrefix: "/cart"}, {Method: "POST", PathPrefix: "/redirect"}, {Method: "*", PathPrefix: "/ws-allowed"}, {Method: "POST", PathPrefix: "/checkout"}, {Method: "POST", PathPrefix: "/", QueryParam: "wc-ajax", QueryValue: "add_to_cart"}}}}
+	launch, err := PrepareTransactionPolicyExtension(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, allocCancel, browserCtx, browserCancel, _, err := InitChrome(launch, nil, Hooks{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Register Chrome teardown via t.Cleanup so it runs in LIFO order relative
+	// to t.TempDir() cleanup: because ProfileDir/StateDir TempDirs were
+	// registered first, this cleanup runs before them, ensuring the browser
+	// process (and its renderer/GPU children) have fully released the profile
+	// directory before the Go test runner tries to RemoveAll it.
+	t.Cleanup(func() {
+		browserCancel()
+		allocCancel()
+		// Chrome's SingletonLock is the last file-system artifact removed by the
+		// browser process on exit.  Poll until it is gone, then allow a short
+		// grace period for any in-flight renderer-process writes to drain.
+		const (
+			shutdownTimeout     = 10 * time.Second
+			pollInterval        = 50 * time.Millisecond
+			rendererGracePeriod = 200 * time.Millisecond
+		)
+		lock := filepath.Join(cfg.ProfileDir, "SingletonLock")
+		deadline := time.Now().Add(shutdownTimeout)
+		for time.Now().Before(deadline) {
+			if _, err := os.Lstat(lock); os.IsNotExist(err) {
+				time.Sleep(rendererGracePeriod)
+				return
+			}
+			time.Sleep(pollInterval)
+		}
+		t.Logf("chrome profile SingletonLock still present after %v; TempDir cleanup may log a spurious RemoveAll warning", shutdownTimeout)
+	})
+	if err := chromedp.Run(browserCtx, chromedp.Navigate(server.URL)); err != nil {
+		t.Fatal(err)
+	}
+	need := []string{"/", "/trailing-read", "/orders", "/cart/add", "/cart/update", "/cart/remove", "/cart/preparation", "/cart/preorder", "/redirect", "/worker.js", "/worker-ran", "/shared-worker.js", "/shared-worker-ran", "/service-worker.js", "/service-worker-ran", "/page-ran", "/form-ran", "/ws-allowed"}
+	deadline := time.Now().Add(8 * time.Second)
+	for time.Now().Before(deadline) {
+		ready := true
+		for _, path := range need {
+			if count(path) == 0 {
+				ready = false
+				break
+			}
+		}
+		if ready && count("/") >= 3 && count("/read") >= 2 {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	for _, path := range []string{"/page-forbidden", "/form-forbidden", "/popup-initial-forbidden", "/worker-forbidden", "/shared-worker-forbidden", "/service-worker-forbidden", "/redirect-forbidden", "/ws-forbidden", "/checkout", "/trailing-forbidden", "/cart/123/order"} {
+		if got := count(path); got != 0 {
+			t.Errorf("forbidden request %s reached fixture %d times", path, got)
+		}
+	}
+	for _, path := range need {
+		if got := count(path); got == 0 {
+			t.Errorf("allowed request %s did not reach fixture", path)
+		}
+	}
+	if got := count("/"); got != 3 {
+		t.Errorf("query deny bypass/broadening or missing exact query allow: root count = %d", got)
+	}
+	if got := count("/read"); got < 2 {
+		t.Errorf("allowed GET/HEAD reads did not reach fixture twice: %d", got)
+	}
+	if got := methodCount(http.MethodGet, "/orders"); got != 1 {
+		t.Errorf("GET /orders did not reach fixture exactly once: %d", got)
+	}
+	if got := methodCount(http.MethodPost, "/orders"); got != 0 {
+		t.Errorf("POST /orders reached fixture despite deny: %d", got)
+	}
+	for _, path := range []string{"/cart/123/order", "/cart/123//order", "/order"} {
+		if got := methodCount(http.MethodPost, path); got != 0 {
+			t.Errorf("POST %s reached fixture despite raw/encoded order deny: %d", path, got)
+		}
+	}
+	for _, path := range []string{"/cart/preparation", "/cart/preorder"} {
+		if got := methodCount(http.MethodPost, path); got != 1 {
+			t.Errorf("allowed POST %s did not reach fixture exactly once: %d", path, got)
+		}
+	}
+	if t.Failed() {
+		mu.Lock()
+		snapshot := fmt.Sprint(counts)
+		mu.Unlock()
+		t.Logf("fixture counters: %s", snapshot)
+	}
+}

--- a/internal/bridge/runtime/transaction_policy_state.go
+++ b/internal/bridge/runtime/transaction_policy_state.go
@@ -71,7 +71,7 @@ func writeTransactionPolicyExtension(stateDir string, manifest transactionPolicy
 		if err != nil {
 			return "", err
 		}
-		defer os.RemoveAll(staging)
+		defer func() { _ = os.RemoveAll(staging) }()
 		if err := os.Chmod(staging, 0700); err != nil {
 			return "", err
 		}
@@ -106,7 +106,7 @@ func jsonData(value any) ([]byte, error) {
 func policyDigest(parts ...[]byte) string {
 	h := sha256.New()
 	for _, part := range parts {
-		_, _ = h.Write([]byte(fmt.Sprintf("%d:", len(part))))
+		_, _ = fmt.Fprintf(h, "%d:", len(part))
 		_, _ = h.Write(part)
 	}
 	return hex.EncodeToString(h.Sum(nil))
@@ -243,8 +243,9 @@ func publishTransactionPolicyCurrent(root, name string) error {
 		return err
 	}
 	tempName := temp.Name()
-	defer os.Remove(tempName)
-	if err := temp.Chmod(0600); err == nil {
+	defer func() { _ = os.Remove(tempName) }()
+	err = temp.Chmod(0600)
+	if err == nil {
 		_, err = temp.WriteString(name + "\n")
 	}
 	if closeErr := temp.Close(); err == nil {

--- a/internal/bridge/runtime/transaction_policy_state.go
+++ b/internal/bridge/runtime/transaction_policy_state.go
@@ -1,0 +1,297 @@
+package runtime
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"sort"
+	"time"
+)
+
+const (
+	transactionPolicyStateRoot      = "transaction-policy"
+	transactionPolicyCurrentFile    = "current"
+	maxTransactionPolicyGenerations = 4
+)
+
+var transactionPolicyGenerationName = regexp.MustCompile(`^generation-[a-f0-9]{64}$`)
+
+func writeTransactionPolicyExtension(stateDir string, manifest transactionPolicyManifest, rules []dnrRule) (string, error) {
+	stateRoot, err := filepath.Abs(stateDir)
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(stateRoot, 0700); err != nil {
+		return "", err
+	} // never chmod StateDir
+	// StateDir may be shared with other application state and may intentionally
+	// have broader permissions. Only our dedicated child is policy-owned.
+	if err := checkStateDirectory(stateRoot); err != nil {
+		return "", fmt.Errorf("unsafe stateDir: %w", err)
+	}
+	root := filepath.Join(stateRoot, transactionPolicyStateRoot)
+	if err := os.Mkdir(root, 0700); err != nil && !os.IsExist(err) {
+		return "", err
+	}
+	if err := checkPolicyDirectory(root); err != nil {
+		return "", fmt.Errorf("unsafe transaction policy state root: %w", err)
+	}
+	unlock, err := lockTransactionPolicyRoot(root)
+	if err != nil {
+		return "", err
+	}
+	defer unlock()
+	manifestData, err := jsonData(manifest)
+	if err != nil {
+		return "", err
+	}
+	rulesData, err := jsonData(rules)
+	if err != nil {
+		return "", err
+	}
+	background := []byte("chrome.runtime.onMessage.addListener((_, __, reply) => { chrome.declarativeNetRequest.getEnabledRulesets().then(reply); return true; });\n")
+	probe := []byte("<script>chrome.runtime.sendMessage({pinchTabPolicyProbe: true});</script>\n")
+	digest := policyDigest(manifestData, rulesData, background, probe)
+	name := "generation-" + digest
+	target := filepath.Join(root, name)
+	if _, err := os.Lstat(target); err == nil {
+		if err := checkTransactionPolicyGenerationContent(target, manifest, rules); err != nil {
+			return "", err
+		}
+	} else if !os.IsNotExist(err) {
+		return "", err
+	} else {
+		staging, err := os.MkdirTemp(root, ".staging-")
+		if err != nil {
+			return "", err
+		}
+		defer os.RemoveAll(staging)
+		if err := os.Chmod(staging, 0700); err != nil {
+			return "", err
+		}
+		for _, file := range []struct {
+			name string
+			data []byte
+		}{{"manifest.json", manifestData}, {"rules.json", rulesData}, {"background.js", background}, {"probe.html", probe}} {
+			if err := os.WriteFile(filepath.Join(staging, file.name), file.data, 0600); err != nil {
+				return "", err
+			}
+		}
+		if err := os.Rename(staging, target); err != nil {
+			return "", err
+		}
+	}
+	if err := publishTransactionPolicyCurrent(root, name); err != nil {
+		return "", err
+	}
+	if err := retainTransactionPolicyGenerations(root, name); err != nil {
+		return "", err
+	}
+	return target, nil
+}
+
+func jsonData(value any) ([]byte, error) {
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(data, '\n'), nil
+}
+func policyDigest(parts ...[]byte) string {
+	h := sha256.New()
+	for _, part := range parts {
+		_, _ = h.Write([]byte(fmt.Sprintf("%d:", len(part))))
+		_, _ = h.Write(part)
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func checkStateDirectory(path string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&fs.ModeSymlink != 0 || !info.IsDir() {
+		return fmt.Errorf("not a real directory")
+	}
+	return nil
+}
+
+func checkPolicyDirectory(path string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&fs.ModeSymlink != 0 || !info.IsDir() {
+		return fmt.Errorf("not a real directory")
+	}
+	if info.Mode().Perm()&0077 != 0 {
+		return fmt.Errorf("permissions %o are not private", info.Mode().Perm())
+	}
+	return checkPolicyOwner(info)
+}
+func checkPolicyOwner(info fs.FileInfo) error {
+	if runtimeGOOS == "windows" {
+		return nil
+	}
+	v := reflect.ValueOf(info.Sys())
+	if v.Kind() == reflect.Pointer {
+		v = v.Elem()
+	}
+	uid := v.FieldByName("Uid")
+	if uid.IsValid() && uid.CanUint() && int(uid.Uint()) != osGeteuid() {
+		return fmt.Errorf("not owned by current user")
+	}
+	return nil
+}
+func checkTransactionPolicyGeneration(path string) error {
+	if err := checkPolicyDirectory(path); err != nil {
+		return err
+	}
+	for _, name := range []string{"manifest.json", "rules.json", "background.js", "probe.html"} {
+		info, err := os.Lstat(filepath.Join(path, name))
+		if err != nil {
+			return err
+		}
+		if info.Mode()&fs.ModeSymlink != 0 || !info.Mode().IsRegular() || info.Mode().Perm() != 0600 {
+			return fmt.Errorf("unsafe generated file %s", name)
+		}
+		if err := checkPolicyOwner(info); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// checkTransactionPolicyGenerationContent binds the content-addressed name to
+// the exact bytes compiled from this launch configuration. Ownership alone is
+// insufficient: a same-user accidental or compromised replacement must fail
+// before Chrome starts.
+func checkTransactionPolicyGenerationContent(path string, manifest transactionPolicyManifest, rules []dnrRule) error {
+	if err := checkTransactionPolicyGeneration(path); err != nil {
+		return err
+	}
+	manifestData, err := jsonData(manifest)
+	if err != nil {
+		return err
+	}
+	rulesData, err := jsonData(rules)
+	if err != nil {
+		return err
+	}
+	background := []byte("chrome.runtime.onMessage.addListener((_, __, reply) => { chrome.declarativeNetRequest.getEnabledRulesets().then(reply); return true; });\n")
+	probe := []byte("<script>chrome.runtime.sendMessage({pinchTabPolicyProbe: true});</script>\n")
+	expected := "generation-" + policyDigest(manifestData, rulesData, background, probe)
+	if filepath.Base(path) != expected {
+		return fmt.Errorf("generation name does not authenticate policy content")
+	}
+	for _, file := range []struct {
+		name string
+		data []byte
+	}{{"manifest.json", manifestData}, {"rules.json", rulesData}, {"background.js", background}, {"probe.html", probe}} {
+		actual, err := os.ReadFile(filepath.Join(path, file.name))
+		if err != nil {
+			return err
+		}
+		if string(actual) != string(file.data) {
+			return fmt.Errorf("generated %s does not match compiled policy", file.name)
+		}
+	}
+	return nil
+}
+func lockTransactionPolicyRoot(root string) (func(), error) {
+	path := filepath.Join(root, ".lock")
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		err := os.Mkdir(path, 0700)
+		if err == nil {
+			return func() { _ = os.Remove(path) }, nil
+		}
+		if !os.IsExist(err) {
+			return nil, err
+		}
+		info, statErr := os.Lstat(path)
+		if statErr != nil {
+			return nil, statErr
+		}
+		if info.Mode()&fs.ModeSymlink != 0 || !info.Mode().IsDir() {
+			return nil, fmt.Errorf("unsafe transaction policy lock")
+		}
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("timed out waiting for transaction policy state lock")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+func publishTransactionPolicyCurrent(root, name string) error {
+	current := filepath.Join(root, transactionPolicyCurrentFile)
+	if info, err := os.Lstat(current); err == nil {
+		if info.Mode()&fs.ModeSymlink != 0 || !info.Mode().IsRegular() {
+			return fmt.Errorf("unsafe transaction policy current pointer")
+		}
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	temp, err := os.CreateTemp(root, ".current-")
+	if err != nil {
+		return err
+	}
+	tempName := temp.Name()
+	defer os.Remove(tempName)
+	if err := temp.Chmod(0600); err == nil {
+		_, err = temp.WriteString(name + "\n")
+	}
+	if closeErr := temp.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		return err
+	}
+	return os.Rename(tempName, current)
+}
+func retainTransactionPolicyGenerations(root, current string) error {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return err
+	}
+	type generation struct {
+		name string
+		mod  time.Time
+	}
+	var gens []generation
+	for _, entry := range entries {
+		if !transactionPolicyGenerationName.MatchString(entry.Name()) {
+			continue
+		}
+		path := filepath.Join(root, entry.Name())
+		if err := checkTransactionPolicyGeneration(path); err != nil {
+			return err
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		gens = append(gens, generation{entry.Name(), info.ModTime()})
+	}
+	sort.Slice(gens, func(i, j int) bool { return gens[i].mod.After(gens[j].mod) })
+	kept := 0
+	for _, gen := range gens {
+		if gen.name == current {
+			continue // current is always retained, even if timestamps are skewed.
+		}
+		if kept < maxTransactionPolicyGenerations-1 {
+			kept++
+			continue
+		}
+		if err := os.RemoveAll(filepath.Join(root, gen.name)); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/bridge/runtime/transaction_policy_test.go
+++ b/internal/bridge/runtime/transaction_policy_test.go
@@ -1,0 +1,466 @@
+package runtime
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/pinchtab/pinchtab/internal/config"
+)
+
+func testTransactionPolicy() config.TransactionPolicyConfig {
+	return config.TransactionPolicyConfig{Enabled: true, Hosts: []string{"supplier.example"}, DenyRules: []config.TransactionPolicyRule{{Method: "*", PathPrefix: "/checkout"}}, AllowRules: []config.TransactionPolicyRule{{Method: "POST", PathPrefix: "/cart"}, {Method: "POST", PathPrefix: "/", QueryParam: "wc-ajax", QueryValue: "add_to_cart"}}}
+}
+
+func TestCompileTransactionPolicyPriorityMethodsAndTrailingDot(t *testing.T) {
+	manifest, rules, err := compileTransactionPolicy(testTransactionPolicy())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if manifest.ManifestVersion != 3 || len(manifest.HostPermissions) != 4 {
+		t.Fatalf("manifest = %#v", manifest)
+	}
+	if len(rules) != 13 {
+		t.Fatalf("rule count = %d", len(rules))
+	}
+	denies, allows, defaults := semanticDenyRules(rules), rulesAtPriority(rules, 2), rulesAtPriority(rules, 1)
+	if len(denies) != 9 || len(allows) != 2 || len(defaults) != 1 || denies[0].Action.Type != "block" || allows[0].Action.Type != "allow" {
+		t.Fatalf("priorities/actions = %#v", rules)
+	}
+	if got := strings.Join(defaults[0].Condition.ExcludedRequestMethods, ","); got != "get,head,options" {
+		t.Fatalf("default methods = %v", got)
+	}
+	for _, group := range [][]dnrRule{denies, defaults} {
+		if !anyRuleMatches(group, "https://supplier.example./checkout") {
+			t.Fatalf("trailing-dot URL bypasses priority %d rules", group[0].Priority)
+		}
+	}
+}
+
+func TestCompileTransactionPolicyConsolidatesHostsWithFailClosedDenyScope(t *testing.T) {
+	policy := config.TransactionPolicyConfig{Enabled: true, Hosts: []string{"supplier.example", "other.example", "supplier.example"}, DenyRules: []config.TransactionPolicyRule{{Method: "*", PathPrefix: "/x"}}}
+	manifest, rules, err := compileTransactionPolicy(policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rules) != 4 { // raw /x, one encoded URL filter, the encoded-unsafe guard, and the non-read default.
+		t.Fatalf("multiple hosts multiplied rule count: %d", len(rules))
+	}
+	if len(manifest.HostPermissions) != 8 {
+		t.Fatalf("exact host permissions = %v", manifest.HostPermissions)
+	}
+	for _, url := range []string{
+		"https://supplier.example/x",
+		"https://user:password@supplier.example:8443/x",
+		"https://supplier.example./x",
+		"https://other.example/x",
+		"https://other.example./x",
+	} {
+		if !anyRuleMatches(rules, url) {
+			t.Errorf("configured exact host did not match: %s", url)
+		}
+	}
+	if !anyRuleMatches(rulesAtPriority(rules, 3), "https://sub.supplier.example/x") {
+		t.Error("deny scope did not fail closed over a configured host subdomain")
+	}
+	if anyRuleMatches(rules, "https://supplier.example.evil/x") {
+		t.Error("sibling domain matched")
+	}
+}
+
+func TestCompileTransactionPolicyGroupsMethods(t *testing.T) {
+	policy := config.TransactionPolicyConfig{Enabled: true, Hosts: []string{"supplier.example"}, DenyRules: []config.TransactionPolicyRule{
+		{Method: "GET", PathPrefix: "/orders"},
+		{Method: "POST", PathPrefix: "/orders"},
+		{Method: "POST", PathPrefix: "/orders"},
+		{Method: "GET", PathPrefix: "/cart"},
+		{Method: "*", PathPrefix: "/cart"},
+	}}
+	_, rules, err := compileTransactionPolicy(policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	denies := semanticDenyRules(rules)
+	if len(denies) != 13 {
+		t.Fatalf("method-equivalent rules were not grouped: %d", len(denies))
+	}
+	var encodedRead, unsafeMutation, wildcard int
+	for _, rule := range denies {
+		switch got := strings.Join(rule.Condition.RequestMethods, ","); got {
+		case "get":
+			encodedRead++
+		case "post":
+			unsafeMutation++
+		case "":
+			wildcard++
+		default:
+			t.Errorf("unexpected grouped methods %q", got)
+		}
+	}
+	if encodedRead != 7 || unsafeMutation != 1 || wildcard != 5 {
+		t.Fatalf("grouped variants encoded-read=%d unsafe=%d wildcard=%d", encodedRead, unsafeMutation, wildcard)
+	}
+}
+
+func TestDenyPathSegmentKeepsSegmentBoundaries(t *testing.T) {
+	policy := config.TransactionPolicyConfig{Enabled: true, Hosts: []string{"supplier.example"}, DenyRules: []config.TransactionPolicyRule{{Method: "POST", PathPrefix: "/cart", PathSegment: "order"}}}
+	_, rules, err := compileTransactionPolicy(policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	denies := semanticDenyRules(rules)
+	if !anyRuleMatches(denies, "https://supplier.example/cart/123/order") {
+		t.Fatal("path segment deny did not match /cart/123/order")
+	}
+	if anyRuleMatches(denies, "https://supplier.example/cart/preorder") {
+		t.Fatal("path segment deny broadened to /cart/preorder")
+	}
+	for _, url := range []string{"https://supplier.example/cart%2F123/order", "https://supplier.example/cart/123/%6Frder"} {
+		if !anyRuleMatches(rulesAtPriority(rules, 3), url) {
+			t.Errorf("non-root encoded path-segment deny was dropped: %s", url)
+		}
+	}
+}
+
+func TestDenyPathSegmentRegexCoversArbitraryPercentEncoding(t *testing.T) {
+	policy := config.TransactionPolicyConfig{Enabled: true, Hosts: []string{"supplier.example"}, DenyRules: []config.TransactionPolicyRule{{Method: "POST", PathPrefix: "/", PathSegment: "checkout"}}}
+	_, rules, err := compileTransactionPolicy(policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	denies := semanticDenyRules(rules)
+	if len(denies) != 1 {
+		t.Fatalf("unsafe deny compiled to %d semantic rules", len(denies))
+	}
+	if rawURL := "https://supplier.example/a/checkout"; !anyRuleMatches(denies, rawURL) {
+		t.Errorf("raw deny bypass: %s", rawURL)
+	}
+	for _, rawURL := range []string{
+		"https://supplier.example/a/chec%6Bout",
+		"https://supplier.example/a%2Fcheckout",
+		"https://supplier.example./a/%63heckout",
+		"https://supplier.example/a/%63%68%65%63%6B%6F%75%74",
+		"https://supplier.example/a%2F%63h%65ckout",
+		"https://supplier.example./a/%63%68eckout",
+	} {
+		if !anyRuleMatches(rulesAtPriority(rules, 3), rawURL) {
+			t.Errorf("encoded deny bypass: %s", rawURL)
+		}
+	}
+	guardedPOST := false
+	for _, rule := range rulesAtPriority(rules, 3) {
+		if strings.Contains(rule.Condition.RegexFilter, "%[0-9A-F]{2}") && strings.Contains(strings.Join(rule.Condition.RequestMethods, ","), "post") {
+			guardedPOST = true
+		}
+	}
+	if !guardedPOST {
+		t.Fatal("encoded-unsafe guard does not cover POST")
+	}
+	for _, rawURL := range []string{
+		"https://supplier.example.evil/a/checkout",
+		"https://supplier.example/a/precheckout",
+		"https://supplier.example/cart/preparation?return=%2Fcheckout",
+	} {
+		if anyRuleMatches(denies, rawURL) {
+			t.Errorf("encoded deny broadened to %s", rawURL)
+		}
+	}
+}
+
+func TestDenyPathSegmentRegexGroupsMethods(t *testing.T) {
+	policy := config.TransactionPolicyConfig{Enabled: true, Hosts: []string{"supplier.example"}, DenyRules: []config.TransactionPolicyRule{{Method: "GET", PathPrefix: "/", PathSegment: "pay"}, {Method: "POST", PathPrefix: "/", PathSegment: "pay"}, {Method: "*", PathPrefix: "/", PathSegment: "pay"}}}
+	_, rules, err := compileTransactionPolicy(policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, rule := range semanticDenyRules(rules) {
+		if got := strings.Join(rule.Condition.RequestMethods, ","); got != "" && got != "get" {
+			t.Errorf("wildcard did not subsume specific methods: %q", got)
+		}
+	}
+	policy.DenyRules = policy.DenyRules[:2]
+	_, rules, err = compileTransactionPolicy(policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, rule := range semanticDenyRules(rules) {
+		if got := strings.Join(rule.Condition.RequestMethods, ","); got != "get" && got != "post" {
+			t.Errorf("regex methods = %q", got)
+		}
+	}
+}
+
+func TestTransactionPolicyRuleCountAccounting(t *testing.T) {
+	regexRules := make([]dnrRule, maxTransactionPolicyRegexRules+1)
+	for i := range regexRules {
+		regexRules[i].Condition.RegexFilter = "x"
+	}
+	if err := validateTransactionPolicyRuleCounts(regexRules); err == nil || !strings.Contains(err.Error(), "static regex rules") {
+		t.Fatalf("regex accounting error = %v", err)
+	}
+}
+
+func TestCompileTransactionPolicyRejectsChromeRegexRuleLimit(t *testing.T) {
+	policy := config.TransactionPolicyConfig{Enabled: true, Hosts: []string{"supplier.example"}}
+	for i := 0; i < maxTransactionPolicyRegexRules; i++ {
+		policy.DenyRules = append(policy.DenyRules, config.TransactionPolicyRule{Method: "*", PathPrefix: fmt.Sprintf("/r%d", i)})
+	}
+	_, _, err := compileTransactionPolicy(policy)
+	if err == nil {
+		t.Fatalf("policy exceeding Chrome's %d static regex-rule limit compiled", maxTransactionPolicyRegexRules)
+	}
+	if !strings.Contains(err.Error(), "static regex rules, Chrome maximum is 1000") {
+		t.Fatalf("limit error = %v", err)
+	}
+}
+
+func TestDenyRegexCoversChromeEncodedPathForms(t *testing.T) {
+	_, rules, err := compileTransactionPolicy(testTransactionPolicy())
+	if err != nil {
+		t.Fatal(err)
+	}
+	denies := semanticDenyRules(rules)
+	for _, url := range []string{"https://supplier.example/checkout", "https://user:password@supplier.example/checkout", "https://supplier.example/chec%6bout", "https://supplier.example/%2Fcheckout", "https://supplier.example./chec%6bout"} {
+		if !anyRuleMatches(denies, url) {
+			t.Errorf("encoded deny bypass: %s", url)
+		}
+	}
+	allows := rulesAtPriority(rules, 2)
+	allow := regexp.MustCompile(allows[1].Condition.RegexFilter)
+	for _, url := range []string{"https://supplier.example/?wc-ajax=add_to_cart", "https://supplier.example/?wc-ajax=add_to_cart#cart"} {
+		if !allow.MatchString(url) {
+			t.Errorf("exact query allow did not match %s", url)
+		}
+	}
+	for _, url := range []string{"https://supplier.example/?x=1&wc-ajax=add_to_cart", "https://supplier.example/?wc-ajax=add_to_cart&x=1", "https://supplier.example/?wc-ajax=add_to_cart&wc-ajax=add_to_cart", "https://supplier.example/?wc-ajax=add_to_cart&wc-ajax=checkout", "https://supplier.example/?action=checkout&wc-ajax=add_to_cart", "https://supplier.example/?wc-ajax="} {
+		if allow.MatchString(url) {
+			t.Errorf("polluted query allowed: %s", url)
+		}
+	}
+}
+
+func TestDenyQueryMatchesExactPairWithoutBroadeningPath(t *testing.T) {
+	policy := testTransactionPolicy()
+	policy.DenyRules = []config.TransactionPolicyRule{{Method: "*", PathPrefix: "/", QueryParam: "action", QueryValue: "checkout"}}
+	_, rules, err := compileTransactionPolicy(policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	denies := semanticDenyRules(rules)
+	for _, url := range []string{
+		"https://supplier.example/?action=checkout",
+		"https://supplier.example/?x=1&action=checkout",
+		"https://supplier.example/?action=checkout&x=1",
+		"https://supplier.example/?action=cancel&action=checkout",
+		"https://supplier.example/?%61ction=checkout",
+		"https://supplier.example/?action=%63heckout",
+		"wss://supplier.example/?action=checkout",
+	} {
+		if !anyRuleMatches(denies, url) {
+			t.Errorf("deny query bypass: %s", url)
+		}
+	}
+	for _, url := range []string{
+		"https://supplier.example/",
+		"https://supplier.example/?action=cart",
+		"https://supplier.example/?action=checkout-now",
+		"https://supplier.example/?xaction=checkout",
+		"https://supplier.example/?return=action%3Dcheckout",
+	} {
+		if anyRuleMatches(denies, url) {
+			t.Errorf("deny query broadened to unrelated URL: %s", url)
+		}
+	}
+}
+
+func rulesAtPriority(rules []dnrRule, priority int) []dnrRule {
+	var matches []dnrRule
+	for _, rule := range rules {
+		if rule.Priority == priority {
+			matches = append(matches, rule)
+		}
+	}
+	return matches
+}
+
+func semanticDenyRules(rules []dnrRule) []dnrRule {
+	var matches []dnrRule
+	for _, rule := range rulesAtPriority(rules, 3) {
+		if !strings.Contains(rule.Condition.RegexFilter, "%[0-9A-F]{2}") {
+			matches = append(matches, rule)
+		}
+	}
+	return matches
+}
+
+func anyRuleMatches(rules []dnrRule, rawURL string) bool {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		panic(err)
+	}
+	host := strings.TrimSuffix(strings.ToLower(parsed.Hostname()), ".")
+	for _, rule := range rules {
+		domainMatched := len(rule.Condition.RequestDomains) == 0
+		for _, domain := range rule.Condition.RequestDomains {
+			domain = strings.ToLower(domain)
+			if host == domain || strings.HasSuffix(host, "."+domain) {
+				domainMatched = true
+			}
+		}
+		if !domainMatched {
+			continue
+		}
+		if rule.Condition.RegexFilter != "" && regexp.MustCompile("(?i)"+rule.Condition.RegexFilter).MatchString(rawURL) {
+			return true
+		}
+		if rule.Condition.URLFilter == "" {
+			continue
+		}
+		needle := strings.Trim(strings.ToLower(rule.Condition.URLFilter), "*")
+		if strings.Contains(strings.ToLower(rawURL), needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestPrepareTransactionPolicyExtensionIsPrivateAndGeneratedOnly(t *testing.T) {
+	stateDir := t.TempDir()
+	if err := os.Chmod(stateDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.RuntimeConfig{StateDir: stateDir, ChromeBinary: "/usr/bin/chromium", TransactionPolicy: testTransactionPolicy()}
+	launch, err := PrepareTransactionPolicyExtension(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.ExtensionPaths) != 0 || len(launch.ExtensionPaths) != 1 {
+		t.Fatalf("operator=%v launch=%v", cfg.ExtensionPaths, launch.ExtensionPaths)
+	}
+	if got := filepath.Dir(launch.ExtensionPaths[0]); got != filepath.Join(stateDir, transactionPolicyStateRoot) {
+		t.Fatalf("generation escaped policy root: %q", got)
+	}
+	if info, err := os.Stat(stateDir); err != nil || info.Mode().Perm() != 0755 {
+		t.Fatalf("StateDir permissions changed: %v %v", info, err)
+	}
+	for _, name := range []string{"manifest.json", "rules.json", "background.js"} {
+		info, err := os.Stat(filepath.Join(launch.ExtensionPaths[0], name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Mode().Perm() != 0600 {
+			t.Fatalf("%s permissions = %o", name, info.Mode().Perm())
+		}
+	}
+	info, err := os.Stat(filepath.Dir(launch.ExtensionPaths[0]))
+	if err != nil || info.Mode().Perm() != 0700 {
+		t.Fatalf("policy root mode = %v, %v", info.Mode(), err)
+	}
+	if err := validateTransactionPolicyLaunch(launch); err != nil {
+		t.Fatalf("generated launch rejected: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(launch.ExtensionPaths[0], "rules.json"), []byte("[]\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateTransactionPolicyLaunch(launch); err == nil {
+		t.Fatal("tampered generated policy passed launch validation")
+	}
+}
+
+func TestPrepareTransactionPolicyExtensionRejectsExtensionsAndUnsafeState(t *testing.T) {
+	cfg := &config.RuntimeConfig{StateDir: t.TempDir(), ChromeBinary: "/usr/bin/chromium", ExtensionPaths: []string{"/operator-extension"}, TransactionPolicy: testTransactionPolicy()}
+	if _, err := PrepareTransactionPolicyExtension(cfg); err == nil {
+		t.Fatal("operator extension accepted in policy mode")
+	}
+	state := t.TempDir()
+	link := filepath.Join(t.TempDir(), "state-link")
+	if err := os.Symlink(state, link); err != nil {
+		t.Fatal(err)
+	}
+	cfg = &config.RuntimeConfig{StateDir: link, ChromeBinary: "/usr/bin/chromium", TransactionPolicy: testTransactionPolicy()}
+	if _, err := PrepareTransactionPolicyExtension(cfg); err == nil {
+		t.Fatal("symlink StateDir accepted")
+	}
+	state = t.TempDir()
+	if err := os.Symlink(t.TempDir(), filepath.Join(state, transactionPolicyStateRoot)); err != nil {
+		t.Fatal(err)
+	}
+	cfg = &config.RuntimeConfig{StateDir: state, ChromeBinary: "/usr/bin/chromium", TransactionPolicy: testTransactionPolicy()}
+	if _, err := PrepareTransactionPolicyExtension(cfg); err == nil {
+		t.Fatal("symlink policy root accepted")
+	}
+}
+
+func TestTransactionPolicyGenerationsAreDeterministicAndBounded(t *testing.T) {
+	state := t.TempDir()
+	cfg := &config.RuntimeConfig{StateDir: state, ChromeBinary: "/usr/bin/chromium", TransactionPolicy: testTransactionPolicy()}
+	first, err := PrepareTransactionPolicyExtension(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := PrepareTransactionPolicyExtension(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.ExtensionPaths[0] != second.ExtensionPaths[0] {
+		t.Fatalf("same content generation changed: %q != %q", first.ExtensionPaths[0], second.ExtensionPaths[0])
+	}
+	for i := 0; i < maxTransactionPolicyGenerations+2; i++ {
+		cfg.TransactionPolicy.DenyRules = []config.TransactionPolicyRule{{Method: "*", PathPrefix: "/checkout", PathSegment: strings.Repeat("x", i+1)}}
+		if _, err := PrepareTransactionPolicyExtension(cfg); err != nil {
+			t.Fatal(err)
+		}
+	}
+	entries, err := os.ReadDir(filepath.Join(state, transactionPolicyStateRoot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	count := 0
+	for _, entry := range entries {
+		if transactionPolicyGenerationName.MatchString(entry.Name()) {
+			count++
+		}
+	}
+	if count > maxTransactionPolicyGenerations {
+		t.Fatalf("generations not retained: %d", count)
+	}
+}
+
+func TestExactTransactionPolicyRulesetState(t *testing.T) {
+	if !hasExactTransactionPolicyRulesets([]string{transactionPolicyRulesetID}) {
+		t.Fatal("exact generated ruleset was rejected")
+	}
+	for _, ids := range [][]string{nil, {"other"}, {transactionPolicyRulesetID, "other"}, {"prefix-" + transactionPolicyRulesetID}} {
+		if hasExactTransactionPolicyRulesets(ids) {
+			t.Fatalf("non-exact ruleset state accepted: %v", ids)
+		}
+	}
+}
+
+func TestValidateTransactionPolicyLaunchRejectsSpoofedPathAndFallback(t *testing.T) {
+	cfg := &config.RuntimeConfig{StateDir: t.TempDir(), TransactionPolicy: testTransactionPolicy()}
+	if err := validateTransactionPolicyLaunch(cfg); err == nil {
+		t.Fatal("missing binary accepted")
+	}
+	cfg.ChromeBinary = "/Applications/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing"
+	cfg.ExtensionPaths = []string{filepath.Join(cfg.StateDir, "transaction-policy-extension-spoof")}
+	if err := validateTransactionPolicyLaunch(cfg); err == nil || strings.Contains(err.Error(), "Google Chrome Stable") {
+		t.Fatalf("Chrome for Testing was classified as Stable: %v", err)
+	}
+	cfg.ChromeBinary = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+	if err := validateTransactionPolicyLaunch(cfg); err == nil || !strings.Contains(err.Error(), "Google Chrome Stable") {
+		t.Fatalf("Google Chrome Stable was accepted or misclassified: %v", err)
+	}
+	cfg.ChromeBinary = "/usr/bin/chromium"
+	cfg.ExtensionPaths = []string{filepath.Join(cfg.StateDir, "transaction-policy-extension-spoof")}
+	if err := validateTransactionPolicyLaunch(cfg); err == nil {
+		t.Fatal("spoofed generated path accepted")
+	}
+	if _, _, _, err := startChromeWithRemoteAllocator(t.Context(), cfg, nil, 9222, ""); err == nil {
+		t.Fatal("direct fallback bypassed validation")
+	}
+}

--- a/internal/bridge/tab_manager.go
+++ b/internal/bridge/tab_manager.go
@@ -105,6 +105,98 @@ func browserExecutorContext(ctx context.Context) (context.Context, error) {
 	return cdp.WithExecutor(ctx, c.Browser), nil
 }
 
+// trackedCDPIDs returns the raw CDP target IDs this manager currently tracks.
+func (tm *TabManager) trackedCDPIDs() map[string]bool {
+	tm.mu.RLock()
+	defer tm.mu.RUnlock()
+	out := make(map[string]bool, len(tm.tabs))
+	for _, entry := range tm.tabs {
+		if entry != nil && entry.CDPID != "" {
+			out[entry.CDPID] = true
+		}
+	}
+	return out
+}
+
+// selectOrphanTargets returns page targets that exist in Chrome but are not
+// tracked by this TabManager, oldest-first (GetTargets returns newest first),
+// capped at `limit` entries. A negative or zero limit means "all orphans".
+//
+// Orphans accumulate whenever the bridge process is restarted, a tab context
+// dies, or Chromium restores a previous session: the Chrome target survives
+// but the managed entry does not. They are invisible to a managed-count-only
+// tab cap, which is how a `maxTabs: 8` instance ended up holding 158 live
+// page targets in production (SBSA lane, 2026-08-17) and starved every other
+// caller of that instance.
+func selectOrphanTargets(tracked map[string]bool, pages []*target.Info, limit int) []target.ID {
+	orphans := make([]target.ID, 0)
+	// GetTargets is newest-first; walk backwards so we reap the oldest first.
+	for i := len(pages) - 1; i >= 0; i-- {
+		t := pages[i]
+		if t == nil || t.Type != TargetTypePage {
+			continue
+		}
+		if tracked[string(t.TargetID)] {
+			continue
+		}
+		orphans = append(orphans, t.TargetID)
+		if limit > 0 && len(orphans) >= limit {
+			break
+		}
+	}
+	return orphans
+}
+
+// reapOrphanTargets closes untracked page targets so the configured tab cap
+// reflects Chrome reality rather than in-process bookkeeping. Returns the
+// number of targets actually closed.
+func (tm *TabManager) reapOrphanTargets(limit int) int {
+	pages, err := tm.ListTargets()
+	if err != nil {
+		slog.Warn("tab budget: cannot list chrome targets", "err", err)
+		return 0
+	}
+	orphans := selectOrphanTargets(tm.trackedCDPIDs(), pages, limit)
+	closed := 0
+	for _, id := range orphans {
+		closeCtx, cancel := context.WithTimeout(tm.browserCtx, 5*time.Second)
+		c := chromedp.FromContext(closeCtx)
+		if c == nil || c.Browser == nil {
+			cancel()
+			break
+		}
+		if err := target.CloseTarget(id).Do(cdp.WithExecutor(closeCtx, c.Browser)); err != nil {
+			slog.Debug("tab budget: orphan close failed", "targetId", id, "err", err)
+			cancel()
+			continue
+		}
+		cancel()
+		closed++
+	}
+	if closed > 0 {
+		slog.Info("tab budget: closed untracked chrome targets", "count", closed, "maxTabs", tm.config.MaxTabs)
+	}
+	return closed
+}
+
+// liveTabCount is the number of tabs the cap must be enforced against: every
+// open page target in Chrome, not just the ones this process happens to track.
+// Falls back to the managed count if Chrome cannot be queried.
+func (tm *TabManager) liveTabCount() int {
+	tm.mu.RLock()
+	managed := len(tm.tabs)
+	tm.mu.RUnlock()
+
+	pages, err := tm.ListTargets()
+	if err != nil {
+		return managed
+	}
+	if len(pages) > managed {
+		return len(pages)
+	}
+	return managed
+}
+
 func (tm *TabManager) CreateTab(url string) (string, context.Context, context.CancelFunc, error) {
 	if tm == nil {
 		return "", nil, nil, fmt.Errorf("tab manager not initialized")
@@ -113,13 +205,27 @@ func (tm *TabManager) CreateTab(url string) (string, context.Context, context.Ca
 		return "", nil, nil, fmt.Errorf("no browser context available")
 	}
 
+	// Upstream deliberately counted only the managed map here, to avoid
+	// premature eviction from unmanaged targets such as the initial
+	// about:blank tab. That is still the right concern, but the fix is to reap
+	// the untracked targets rather than to ignore them: counting only the
+	// managed map let untracked targets (bridge restart, dead tab contexts,
+	// Chromium session restore) grow without bound, which is how a
+	// `maxTabs: 8` instance ended up holding 158 live page targets in
+	// production and starved every other caller of that instance
+	// (SBSA lane, 2026-08-17).
+	//
+	// Orphans are reaped oldest-first BEFORE any managed tab is considered for
+	// eviction, so the about:blank case now resolves by closing that stray
+	// target instead of evicting a tab a caller may still be driving.
 	if tm.config != nil && tm.config.MaxTabs > 0 {
-		// Count managed tabs for eviction decisions. Using Chrome's target list
-		// would include unmanaged targets (e.g. the initial about:blank tab),
-		// causing premature eviction of managed tabs.
-		tm.mu.RLock()
-		managedCount := len(tm.tabs)
-		tm.mu.RUnlock()
+		managedCount := tm.liveTabCount()
+
+		if managedCount >= tm.config.MaxTabs {
+			if closed := tm.reapOrphanTargets(managedCount - tm.config.MaxTabs + 1); closed > 0 {
+				managedCount = tm.liveTabCount()
+			}
+		}
 
 		if managedCount >= tm.config.MaxTabs {
 			switch tm.config.TabEvictionPolicy {

--- a/internal/bridge/tab_manager_orphan_test.go
+++ b/internal/bridge/tab_manager_orphan_test.go
@@ -1,0 +1,64 @@
+package bridge
+
+import (
+	"testing"
+
+	"github.com/chromedp/cdproto/target"
+)
+
+func pageTarget(id string) *target.Info {
+	return &target.Info{TargetID: target.ID(id), Type: TargetTypePage}
+}
+
+// The production failure: Chrome held 158 page targets on an instance
+// configured with maxTabs: 8, because the cap only ever counted the
+// in-process managed map. Untracked targets must be selectable for reaping.
+func TestSelectOrphanTargets_PicksUntrackedOldestFirst(t *testing.T) {
+	tracked := map[string]bool{"t-managed": true}
+	// GetTargets returns newest-first.
+	pages := []*target.Info{pageTarget("t-new"), pageTarget("t-managed"), pageTarget("t-old")}
+
+	got := selectOrphanTargets(tracked, pages, 0)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 orphans, got %d (%v)", len(got), got)
+	}
+	if got[0] != target.ID("t-old") {
+		t.Fatalf("expected oldest orphan first, got %v", got)
+	}
+	for _, id := range got {
+		if id == target.ID("t-managed") {
+			t.Fatal("a tracked target must never be reaped as an orphan")
+		}
+	}
+}
+
+func TestSelectOrphanTargets_RespectsLimit(t *testing.T) {
+	pages := []*target.Info{pageTarget("a"), pageTarget("b"), pageTarget("c")}
+	got := selectOrphanTargets(map[string]bool{}, pages, 2)
+	if len(got) != 2 {
+		t.Fatalf("expected limit of 2, got %d", len(got))
+	}
+}
+
+func TestSelectOrphanTargets_IgnoresNonPageTargets(t *testing.T) {
+	pages := []*target.Info{
+		{TargetID: target.ID("worker"), Type: "service_worker"},
+		nil,
+		pageTarget("page"),
+	}
+	got := selectOrphanTargets(map[string]bool{}, pages, 0)
+	if len(got) != 1 || got[0] != target.ID("page") {
+		t.Fatalf("expected only the page target, got %v", got)
+	}
+}
+
+func TestTrackedCDPIDs(t *testing.T) {
+	tm := &TabManager{tabs: map[string]*TabEntry{
+		"tab_1": {CDPID: "raw1"},
+		"tab_2": {CDPID: ""},
+	}}
+	got := tm.trackedCDPIDs()
+	if !got["raw1"] || len(got) != 1 {
+		t.Fatalf("unexpected tracked set: %v", got)
+	}
+}

--- a/internal/bridge/text_echo.go
+++ b/internal/bridge/text_echo.go
@@ -1,0 +1,157 @@
+package bridge
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/chromedp/chromedp"
+	"github.com/pinchtab/pinchtab/internal/engine"
+)
+
+// Text echoes: /action, /actions and /macro used to return the literal string
+// that was typed or filled ({"typed": "<secret>"}). When the target is a
+// password or otherwise sensitive field, that plaintext lands in the caller's
+// transcript and in every log sink downstream. See SMI-3579.
+//
+// The helpers here replace the literal with a redacted descriptor
+// ({"typed_len": N, "redacted": true}) whenever the target field looks
+// sensitive, and keep the plaintext echo otherwise so existing callers on
+// ordinary form fields are unaffected.
+
+const (
+	echoKeyTyped  = "typed"
+	echoKeyFilled = "filled"
+)
+
+// redactedEcho is the result map returned in place of a plaintext echo.
+func redactedEcho(key, text string, extra map[string]any) map[string]any {
+	out := map[string]any{
+		key + "_len": len([]rune(text)),
+		"redacted":   true,
+	}
+	for k, v := range extra {
+		out[k] = v
+	}
+	return out
+}
+
+// plainEcho keeps the historical shape for non-sensitive fields.
+func plainEcho(key, text string, extra map[string]any) map[string]any {
+	out := map[string]any{key: text}
+	for k, v := range extra {
+		out[k] = v
+	}
+	return out
+}
+
+// textEcho builds the result map for a text-entry action, redacting the echo
+// when the target element is sensitive. target selects how the element is
+// resolved: a CSS selector, a backend node id, or (when both are empty/zero)
+// the currently focused element — which is the correct target for the
+// keyboard-type paths that operate on focus.
+func textEcho(ctx context.Context, selector string, nodeID int64, key, text string, extra map[string]any) map[string]any {
+	if fieldIsSensitive(ctx, selector, nodeID) {
+		return redactedEcho(key, text, extra)
+	}
+	return plainEcho(key, text, extra)
+}
+
+// RedactedTextEcho is the redacted echo for callers outside this package
+// (the lite engine path in handlers). It never returns the plaintext.
+func RedactedTextEcho(text string) map[string]any {
+	return redactedEcho(echoKeyTyped, text, nil)
+}
+
+const sensitiveProbeJS = `function() {
+	var el = this;
+	if (!el) { return null; }
+	return {
+		type: el.getAttribute ? (el.getAttribute('type') || '') : '',
+		autocomplete: el.getAttribute ? (el.getAttribute('autocomplete') || '') : '',
+		name: el.getAttribute ? (el.getAttribute('name') || '') : '',
+		id: el.id || '',
+		ariaLabel: el.getAttribute ? (el.getAttribute('aria-label') || '') : ''
+	};
+}`
+
+type fieldAttrs struct {
+	Type         string `json:"type"`
+	Autocomplete string `json:"autocomplete"`
+	Name         string `json:"name"`
+	ID           string `json:"id"`
+	AriaLabel    string `json:"ariaLabel"`
+}
+
+// fieldIsSensitive probes the target element's attributes. On any resolution
+// failure it fails closed (treats the field as sensitive) so a probe error can
+// never turn into a plaintext leak.
+func fieldIsSensitive(ctx context.Context, selector string, nodeID int64) bool {
+	attrs, err := readFieldAttrs(ctx, selector, nodeID)
+	if err != nil || attrs == nil {
+		return true
+	}
+	return engine.IsSensitiveFieldAttrs(attrs.Type, attrs.Autocomplete, attrs.Name, attrs.ID, attrs.AriaLabel)
+}
+
+func readFieldAttrs(ctx context.Context, selector string, nodeID int64) (*fieldAttrs, error) {
+	if nodeID > 0 {
+		return readFieldAttrsByNodeID(ctx, nodeID)
+	}
+	expr := "(function(){var el = document.activeElement;"
+	if selector != "" {
+		sel, err := json.Marshal(selector)
+		if err != nil {
+			return nil, err
+		}
+		expr = "(function(){var el = document.querySelector(" + string(sel) + ") || document.activeElement;"
+	}
+	expr += "if(!el){return null;} return (" + sensitiveProbeJS + ").call(el);})()"
+
+	var attrs *fieldAttrs
+	if err := chromedp.Run(ctx, chromedp.Evaluate(expr, &attrs)); err != nil {
+		return nil, err
+	}
+	return attrs, nil
+}
+
+func readFieldAttrsByNodeID(ctx context.Context, nodeID int64) (*fieldAttrs, error) {
+	var attrs *fieldAttrs
+	err := chromedp.Run(ctx, chromedp.ActionFunc(func(ctx context.Context) error {
+		var resolvedRaw json.RawMessage
+		if err := chromedp.FromContext(ctx).Target.Execute(ctx, "DOM.resolveNode", map[string]any{
+			"backendNodeId": nodeID,
+		}, &resolvedRaw); err != nil {
+			return err
+		}
+		var resolved struct {
+			Object struct {
+				ObjectID string `json:"objectId"`
+			} `json:"object"`
+		}
+		if err := json.Unmarshal(resolvedRaw, &resolved); err != nil {
+			return err
+		}
+		var callRaw json.RawMessage
+		if err := chromedp.FromContext(ctx).Target.Execute(ctx, "Runtime.callFunctionOn", map[string]any{
+			"functionDeclaration": sensitiveProbeJS,
+			"objectId":            resolved.Object.ObjectID,
+			"returnByValue":       true,
+		}, &callRaw); err != nil {
+			return err
+		}
+		var cr struct {
+			Result struct {
+				Value *fieldAttrs `json:"value"`
+			} `json:"result"`
+		}
+		if err := json.Unmarshal(callRaw, &cr); err != nil {
+			return err
+		}
+		attrs = cr.Result.Value
+		return nil
+	}))
+	if err != nil {
+		return nil, err
+	}
+	return attrs, nil
+}

--- a/internal/bridge/text_echo_test.go
+++ b/internal/bridge/text_echo_test.go
@@ -1,0 +1,45 @@
+package bridge
+
+import "testing"
+
+func TestRedactedEchoHasNoPlaintext(t *testing.T) {
+	secret := "hunter2-hunter2"
+	out := redactedEcho(echoKeyTyped, secret, map[string]any{"human": true})
+	if _, ok := out[echoKeyTyped]; ok {
+		t.Fatalf("redactedEcho leaked plaintext key: %v", out)
+	}
+	if out["typed_len"] != len([]rune(secret)) {
+		t.Fatalf("typed_len = %v, want %d", out["typed_len"], len([]rune(secret)))
+	}
+	if out["redacted"] != true {
+		t.Fatalf("redacted flag missing: %v", out)
+	}
+	if out["human"] != true {
+		t.Fatalf("extra keys dropped: %v", out)
+	}
+	for _, v := range out {
+		if s, ok := v.(string); ok && s == secret {
+			t.Fatalf("secret present in echo: %v", out)
+		}
+	}
+}
+
+func TestRedactedTextEchoAlwaysRedacts(t *testing.T) {
+	out := RedactedTextEcho("s3cret")
+	if _, ok := out["typed"]; ok {
+		t.Fatalf("lite echo leaked plaintext: %v", out)
+	}
+	if out["redacted"] != true || out["typed_len"] != 6 {
+		t.Fatalf("unexpected lite echo: %v", out)
+	}
+}
+
+func TestPlainEchoKeepsLegacyShape(t *testing.T) {
+	out := plainEcho(echoKeyFilled, "cape town", nil)
+	if out[echoKeyFilled] != "cape town" {
+		t.Fatalf("plainEcho changed shape: %v", out)
+	}
+	if _, ok := out["redacted"]; ok {
+		t.Fatalf("plainEcho should not set redacted: %v", out)
+	}
+}

--- a/internal/config/chrome_env.go
+++ b/internal/config/chrome_env.go
@@ -1,0 +1,10 @@
+package config
+
+// chromeNoSandboxEnvVar is the environment variable that forces Chrome's
+// --no-sandbox runtime-compatibility flag. It is read by the bridge and must
+// be re-forwarded to per-instance child processes by the orchestrator, which
+// otherwise strips every PINCHTAB_-prefixed var from the child environment.
+const chromeNoSandboxEnvVar = "PINCHTAB_CHROME_NO_SANDBOX"
+
+// ChromeNoSandboxEnvVar returns the no-sandbox compatibility env var name.
+func ChromeNoSandboxEnvVar() string { return chromeNoSandboxEnvVar }

--- a/internal/config/config_file.go
+++ b/internal/config/config_file.go
@@ -210,6 +210,7 @@ func DefaultFileConfig() FileConfig {
 				WrapContent:    true,
 				ScanTimeoutSec: 5,
 			},
+			TransactionPolicy: TransactionPolicyConfig{Enabled: false, Hosts: []string{}, DenyRules: []TransactionPolicyRule{}, AllowRules: []TransactionPolicyRule{}},
 		},
 		Profiles: ProfilesConfig{
 			BaseDir:        filepath.Join(userConfigDir(), "profiles"),

--- a/internal/config/config_file_json.go
+++ b/internal/config/config_file_json.go
@@ -79,9 +79,10 @@ type securityConfigJSON struct {
 	MaxRedirects           *int           `json:"maxRedirects"`
 	TrustedProxyCIDRs      []string       `json:"trustedProxyCIDRs"`
 	TrustedResolveCIDRs    []string       `json:"trustedResolveCIDRs"`
-	TrustLoopbackProxy     *bool          `json:"trustLoopbackProxy"`
-	Attach                 attachJSON     `json:"attach"`
-	IDPI                   idpiConfigJSON `json:"idpi"`
+	TrustLoopbackProxy     *bool                   `json:"trustLoopbackProxy"`
+	Attach                 attachJSON              `json:"attach"`
+	IDPI                   idpiConfigJSON          `json:"idpi"`
+	TransactionPolicy      TransactionPolicyConfig `json:"transactionPolicy"`
 }
 
 type attachJSON struct {

--- a/internal/config/config_file_json.go
+++ b/internal/config/config_file_json.go
@@ -58,27 +58,27 @@ type profilesConfigJSON struct {
 }
 
 type securityConfigJSON struct {
-	AllowEvaluate          *bool          `json:"allowEvaluate"`
-	AllowMacro             *bool          `json:"allowMacro"`
-	AllowScreencast        *bool          `json:"allowScreencast"`
-	AllowDownload          *bool          `json:"allowDownload"`
-	AllowCookies           *bool          `json:"allowCookies"`
-	AllowNetworkIntercept  *bool          `json:"allowNetworkIntercept"`
-	AllowedDomains         []string       `json:"allowedDomains"`
-	DownloadAllowedDomains []string       `json:"downloadAllowedDomains"`
-	DownloadMaxBytes       *int           `json:"downloadMaxBytes"`
-	AllowUpload            *bool          `json:"allowUpload"`
-	AllowClipboard         *bool          `json:"allowClipboard"`
-	AllowStateExport       *bool          `json:"allowStateExport"`
-	StateEncryptionKey     *string        `json:"stateEncryptionKey"`
-	EnableActionGuards     *bool          `json:"enableActionGuards"`
-	UploadMaxRequestBytes  *int           `json:"uploadMaxRequestBytes"`
-	UploadMaxFiles         *int           `json:"uploadMaxFiles"`
-	UploadMaxFileBytes     *int           `json:"uploadMaxFileBytes"`
-	UploadMaxTotalBytes    *int           `json:"uploadMaxTotalBytes"`
-	MaxRedirects           *int           `json:"maxRedirects"`
-	TrustedProxyCIDRs      []string       `json:"trustedProxyCIDRs"`
-	TrustedResolveCIDRs    []string       `json:"trustedResolveCIDRs"`
+	AllowEvaluate          *bool                   `json:"allowEvaluate"`
+	AllowMacro             *bool                   `json:"allowMacro"`
+	AllowScreencast        *bool                   `json:"allowScreencast"`
+	AllowDownload          *bool                   `json:"allowDownload"`
+	AllowCookies           *bool                   `json:"allowCookies"`
+	AllowNetworkIntercept  *bool                   `json:"allowNetworkIntercept"`
+	AllowedDomains         []string                `json:"allowedDomains"`
+	DownloadAllowedDomains []string                `json:"downloadAllowedDomains"`
+	DownloadMaxBytes       *int                    `json:"downloadMaxBytes"`
+	AllowUpload            *bool                   `json:"allowUpload"`
+	AllowClipboard         *bool                   `json:"allowClipboard"`
+	AllowStateExport       *bool                   `json:"allowStateExport"`
+	StateEncryptionKey     *string                 `json:"stateEncryptionKey"`
+	EnableActionGuards     *bool                   `json:"enableActionGuards"`
+	UploadMaxRequestBytes  *int                    `json:"uploadMaxRequestBytes"`
+	UploadMaxFiles         *int                    `json:"uploadMaxFiles"`
+	UploadMaxFileBytes     *int                    `json:"uploadMaxFileBytes"`
+	UploadMaxTotalBytes    *int                    `json:"uploadMaxTotalBytes"`
+	MaxRedirects           *int                    `json:"maxRedirects"`
+	TrustedProxyCIDRs      []string                `json:"trustedProxyCIDRs"`
+	TrustedResolveCIDRs    []string                `json:"trustedResolveCIDRs"`
 	TrustLoopbackProxy     *bool                   `json:"trustLoopbackProxy"`
 	Attach                 attachJSON              `json:"attach"`
 	IDPI                   idpiConfigJSON          `json:"idpi"`

--- a/internal/config/config_file_marshal.go
+++ b/internal/config/config_file_marshal.go
@@ -126,6 +126,7 @@ func (fc FileConfig) MarshalJSON() ([]byte, error) {
 				ScanTimeoutSec:  fc.Security.IDPI.ScanTimeoutSec,
 				ShieldThreshold: fc.Security.IDPI.ShieldThreshold,
 			},
+			TransactionPolicy: fc.Security.TransactionPolicy,
 		},
 		Profiles: profilesConfigJSON{
 			BaseDir:        fc.Profiles.BaseDir,
@@ -372,7 +373,8 @@ func FileConfigFromRuntime(cfg *RuntimeConfig) FileConfig {
 				AllowHosts:   append([]string(nil), cfg.AttachAllowHosts...),
 				AllowSchemes: append([]string(nil), cfg.AttachAllowSchemes...),
 			},
-			IDPI: cfg.IDPI,
+			IDPI:              cfg.IDPI,
+			TransactionPolicy: cfg.TransactionPolicy,
 		},
 		Profiles: ProfilesConfig{
 			BaseDir:        cfg.ProfilesBaseDir,

--- a/internal/config/config_load.go
+++ b/internal/config/config_load.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 )
@@ -214,6 +215,16 @@ func Load() *RuntimeConfig {
 	if errs := ValidateFileConfig(fc); len(errs) > 0 {
 		for _, e := range errs {
 			slog.Warn("config validation error", "path", configPath, "error", e)
+		}
+		// An enabled-but-invalid transaction policy must never load: a
+		// half-configured deny policy silently permits the traffic it was
+		// meant to block. Fail startup instead.
+		if fc.Security.TransactionPolicy.Enabled {
+			for _, e := range errs {
+				if strings.HasPrefix(e.Error(), "security.transactionPolicy") {
+					panic(fmt.Sprintf("invalid enabled security.transactionPolicy in %s: %v", configPath, errs))
+				}
+			}
 		}
 	}
 
@@ -644,6 +655,10 @@ func ApplyFileConfigToRuntime(cfg *RuntimeConfig, fc *FileConfig) {
 		return
 	}
 
+	// The transaction policy is startup-only: a live reload must not be able
+	// to enable or disable supplier transaction guards under a running bridge.
+	policy := cfg.TransactionPolicy
 	applyFileConfig(cfg, fc)
+	cfg.TransactionPolicy = policy
 	finalizeProfileConfig(cfg)
 }

--- a/internal/config/config_load.go
+++ b/internal/config/config_load.go
@@ -122,6 +122,9 @@ func Load() *RuntimeConfig {
 			ScanTimeoutSec: 5,
 		},
 
+		// TransactionPolicy defaults (disabled by default)
+		TransactionPolicy: TransactionPolicyConfig{},
+
 		// Engine default (set via config.json only)
 		Engine: "chrome",
 
@@ -340,6 +343,8 @@ func applyFileConfig(cfg *RuntimeConfig, fc *FileConfig) {
 	}
 	// IDPI – copy the whole struct; individual fields have safe zero-value defaults.
 	cfg.IDPI = fc.Security.IDPI
+	// TransactionPolicy – copy the whole struct; disabled by default.
+	cfg.TransactionPolicy = fc.Security.TransactionPolicy
 	cfg.AllowedDomains = effectiveSecurityAllowedDomains(fc.Security)
 	if fc.Observability.Activity.Enabled != nil {
 		cfg.Observability.Activity.Enabled = *fc.Observability.Activity.Enabled

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -355,27 +355,27 @@ type ProfilesConfig struct {
 }
 
 type SecurityConfig struct {
-	AllowEvaluate          *bool        `json:"allowEvaluate,omitempty"`
-	AllowMacro             *bool        `json:"allowMacro,omitempty"`
-	AllowScreencast        *bool        `json:"allowScreencast,omitempty"`
-	AllowDownload          *bool        `json:"allowDownload,omitempty"`
-	AllowCookies           *bool        `json:"allowCookies,omitempty"`
-	AllowNetworkIntercept  *bool        `json:"allowNetworkIntercept,omitempty"`
-	AllowedDomains         []string     `json:"allowedDomains,omitempty"`
-	DownloadAllowedDomains []string     `json:"downloadAllowedDomains,omitempty"`
-	DownloadMaxBytes       *int         `json:"downloadMaxBytes,omitempty"`
-	AllowUpload            *bool        `json:"allowUpload,omitempty"`
-	AllowClipboard         *bool        `json:"allowClipboard,omitempty"`
-	AllowStateExport       *bool        `json:"allowStateExport,omitempty"`
-	StateEncryptionKey     *string      `json:"stateEncryptionKey,omitempty"`
-	EnableActionGuards     *bool        `json:"enableActionGuards,omitempty"`
-	UploadMaxRequestBytes  *int         `json:"uploadMaxRequestBytes,omitempty"`
-	UploadMaxFiles         *int         `json:"uploadMaxFiles,omitempty"`
-	UploadMaxFileBytes     *int         `json:"uploadMaxFileBytes,omitempty"`
-	UploadMaxTotalBytes    *int         `json:"uploadMaxTotalBytes,omitempty"`
-	MaxRedirects           *int         `json:"maxRedirects,omitempty"`
-	TrustedProxyCIDRs      []string     `json:"trustedProxyCIDRs,omitempty"`
-	TrustedResolveCIDRs    []string     `json:"trustedResolveCIDRs,omitempty"`
+	AllowEvaluate          *bool                   `json:"allowEvaluate,omitempty"`
+	AllowMacro             *bool                   `json:"allowMacro,omitempty"`
+	AllowScreencast        *bool                   `json:"allowScreencast,omitempty"`
+	AllowDownload          *bool                   `json:"allowDownload,omitempty"`
+	AllowCookies           *bool                   `json:"allowCookies,omitempty"`
+	AllowNetworkIntercept  *bool                   `json:"allowNetworkIntercept,omitempty"`
+	AllowedDomains         []string                `json:"allowedDomains,omitempty"`
+	DownloadAllowedDomains []string                `json:"downloadAllowedDomains,omitempty"`
+	DownloadMaxBytes       *int                    `json:"downloadMaxBytes,omitempty"`
+	AllowUpload            *bool                   `json:"allowUpload,omitempty"`
+	AllowClipboard         *bool                   `json:"allowClipboard,omitempty"`
+	AllowStateExport       *bool                   `json:"allowStateExport,omitempty"`
+	StateEncryptionKey     *string                 `json:"stateEncryptionKey,omitempty"`
+	EnableActionGuards     *bool                   `json:"enableActionGuards,omitempty"`
+	UploadMaxRequestBytes  *int                    `json:"uploadMaxRequestBytes,omitempty"`
+	UploadMaxFiles         *int                    `json:"uploadMaxFiles,omitempty"`
+	UploadMaxFileBytes     *int                    `json:"uploadMaxFileBytes,omitempty"`
+	UploadMaxTotalBytes    *int                    `json:"uploadMaxTotalBytes,omitempty"`
+	MaxRedirects           *int                    `json:"maxRedirects,omitempty"`
+	TrustedProxyCIDRs      []string                `json:"trustedProxyCIDRs,omitempty"`
+	TrustedResolveCIDRs    []string                `json:"trustedResolveCIDRs,omitempty"`
 	TrustLoopbackProxy     *bool                   `json:"trustLoopbackProxy,omitempty"`
 	Attach                 AttachConfig            `json:"attach,omitempty"`
 	IDPI                   IDPIConfig              `json:"idpi,omitempty"`

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -44,6 +44,7 @@ type RuntimeConfig struct {
 	TrustedProxyCIDRs      []string // CIDRs/IPs whose RemoteIPAddress is trusted in navigation responses (e.g. internal proxy)
 	TrustedResolveCIDRs    []string // CIDRs/IPs allowed when a navigation target resolves to non-public addresses
 	TrustLoopbackProxy     bool     // when true, navigation responses with a loopback RemoteIPAddress (e.g. system HTTP/SOCKS proxy on 127.0.0.1) are not blocked; default false
+	TransactionPolicy      TransactionPolicyConfig
 
 	// Browser/instance settings
 	Headless            bool
@@ -146,6 +147,26 @@ type DashboardSessionRuntimeConfig struct {
 	ElevationWindow               time.Duration `json:"elevationWindow,omitempty"`
 	PersistElevationAcrossRestart bool          `json:"persistElevationAcrossRestart,omitempty"`
 	RequireElevation              bool          `json:"requireElevation,omitempty"`
+}
+
+// TransactionPolicyConfig controls MV3 network blocking for configured supplier hosts.
+// It is compiled for managed browser launch only; changes take effect on restart.
+type TransactionPolicyConfig struct {
+	Enabled    bool                    `json:"enabled,omitempty"`
+	Hosts      []string                `json:"hosts,omitempty"`
+	DenyRules  []TransactionPolicyRule `json:"denyRules,omitempty"`
+	AllowRules []TransactionPolicyRule `json:"allowRules,omitempty"`
+}
+
+// TransactionPolicyRule matches an HTTP method and a DNR-safe URL path prefix.
+// PathSegment optionally requires one exact unescaped path segment. QueryParam
+// and QueryValue optionally narrow the match to one exact unescaped query pair.
+type TransactionPolicyRule struct {
+	Method      string `json:"method,omitempty"`
+	PathPrefix  string `json:"pathPrefix,omitempty"`
+	PathSegment string `json:"pathSegment,omitempty"`
+	QueryParam  string `json:"queryParam,omitempty"`
+	QueryValue  string `json:"queryValue,omitempty"`
 }
 
 // IDPIConfig holds the configuration for the Indirect Prompt Injection (IDPI)
@@ -355,9 +376,10 @@ type SecurityConfig struct {
 	MaxRedirects           *int         `json:"maxRedirects,omitempty"`
 	TrustedProxyCIDRs      []string     `json:"trustedProxyCIDRs,omitempty"`
 	TrustedResolveCIDRs    []string     `json:"trustedResolveCIDRs,omitempty"`
-	TrustLoopbackProxy     *bool        `json:"trustLoopbackProxy,omitempty"`
-	Attach                 AttachConfig `json:"attach,omitempty"`
-	IDPI                   IDPIConfig   `json:"idpi,omitempty"`
+	TrustLoopbackProxy     *bool                   `json:"trustLoopbackProxy,omitempty"`
+	Attach                 AttachConfig            `json:"attach,omitempty"`
+	IDPI                   IDPIConfig              `json:"idpi,omitempty"`
+	TransactionPolicy      TransactionPolicyConfig `json:"transactionPolicy,omitempty"`
 }
 
 type MultiInstanceConfig struct {

--- a/internal/config/transaction_policy_test.go
+++ b/internal/config/transaction_policy_test.go
@@ -1,0 +1,98 @@
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestValidateTransactionPolicy(t *testing.T) {
+	valid := TransactionPolicyConfig{Enabled: true, Hosts: []string{"supplier.example"}, DenyRules: []TransactionPolicyRule{{Method: "POST", PathPrefix: "/checkout"}}}
+	if errs := ValidateFileConfig(&FileConfig{Security: SecurityConfig{TransactionPolicy: valid}}); len(errs) != 0 {
+		t.Fatalf("valid policy errors: %v", errs)
+	}
+	invalid := []TransactionPolicyConfig{
+		{Enabled: true},
+		{Enabled: true, Hosts: []string{"https://supplier.example"}, DenyRules: []TransactionPolicyRule{{Method: "POST", PathPrefix: "/checkout"}}},
+		{Enabled: true, Hosts: []string{"supplier.example:443"}, DenyRules: []TransactionPolicyRule{{Method: "POST", PathPrefix: "/checkout"}}},
+		{Enabled: true, Hosts: []string{"*.supplier.example"}, DenyRules: []TransactionPolicyRule{{Method: "POST", PathPrefix: "/checkout"}}},
+		{Enabled: true, Hosts: []string{"supplier..example"}, DenyRules: []TransactionPolicyRule{{Method: "POST", PathPrefix: "/checkout"}}},
+		{Enabled: true, Hosts: []string{"supplier.example"}, DenyRules: []TransactionPolicyRule{{Method: "CONNECT", PathPrefix: "checkout?x=1"}}},
+		{Enabled: true, Hosts: []string{"supplier.example"}, DenyRules: []TransactionPolicyRule{{Method: "POST", PathPrefix: "/checkout", QueryParam: "wc-ajax"}}},
+		{Enabled: true, Hosts: []string{"supplier.example"}, DenyRules: []TransactionPolicyRule{{Method: "POST", PathPrefix: "/checkout", QueryParam: "wc ajax", QueryValue: "checkout"}}},
+		{Enabled: true, Hosts: []string{"supplier.example"}, DenyRules: []TransactionPolicyRule{{Method: "POST", PathPrefix: "/", PathSegment: "orders/cancel"}}},
+	}
+	for _, policy := range invalid {
+		if errs := ValidateFileConfig(&FileConfig{Security: SecurityConfig{TransactionPolicy: policy}}); len(errs) == 0 {
+			t.Fatalf("invalid policy %+v unexpectedly passed", policy)
+		}
+	}
+	if errs := ValidateFileConfig(&FileConfig{Security: SecurityConfig{TransactionPolicy: TransactionPolicyConfig{Enabled: false, Hosts: []string{"https://not-a-host"}}}}); len(errs) != 0 {
+		t.Fatalf("disabled policy should be a no-op: %v", errs)
+	}
+	withExtension := FileConfig{Browser: BrowserConfig{ExtensionPaths: []string{"/operator-extension"}}, Security: SecurityConfig{TransactionPolicy: valid}}
+	if errs := ValidateFileConfig(&withExtension); len(errs) == 0 {
+		t.Fatal("enabled policy accepted operator extension paths")
+	}
+}
+
+func TestLoadRejectsInvalidEnabledTransactionPolicy(t *testing.T) {
+	clearConfigEnvVars(t)
+	path := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(path, []byte(`{"security":{"transactionPolicy":{"enabled":true,"hosts":[],"denyRules":[]}}}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PINCHTAB_CONFIG", path)
+	defer func() {
+		if recover() == nil {
+			t.Fatal("Load did not reject invalid enabled transaction policy")
+		}
+	}()
+	Load()
+}
+
+func TestLoadDoesNotPanicForUnrelatedValidationError(t *testing.T) {
+	clearConfigEnvVars(t)
+	path := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(path, []byte(`{"server":{"port":"invalid"},"security":{"transactionPolicy":{"enabled":true,"hosts":["supplier.example"],"denyRules":[{"method":"POST","pathPrefix":"/checkout"}]}}}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PINCHTAB_CONFIG", path)
+	Load()
+}
+
+func TestApplyFileConfigToRuntimeDoesNotToggleTransactionPolicy(t *testing.T) {
+	cfg := &RuntimeConfig{TransactionPolicy: TransactionPolicyConfig{Enabled: true}}
+	fc := DefaultFileConfig()
+	fc.Security.TransactionPolicy.Enabled = false
+	ApplyFileConfigToRuntime(cfg, &fc)
+	if !cfg.TransactionPolicy.Enabled {
+		t.Fatal("runtime transaction policy changed without a restart")
+	}
+}
+
+func TestTransactionPolicyConfigRoundTrip(t *testing.T) {
+	fc := DefaultFileConfig()
+	fc.Security.TransactionPolicy = TransactionPolicyConfig{Enabled: true, Hosts: []string{"supplier.example"}, DenyRules: []TransactionPolicyRule{{Method: "POST", PathPrefix: "/checkout"}}, AllowRules: []TransactionPolicyRule{{Method: "POST", PathPrefix: "/cart"}}}
+	cfg := &RuntimeConfig{}
+	applyFileConfig(cfg, &fc) // Load uses this startup-only path.
+	if !cfg.TransactionPolicy.Enabled || len(cfg.TransactionPolicy.AllowRules) != 1 {
+		t.Fatalf("runtime policy = %+v", cfg.TransactionPolicy)
+	}
+	roundTripped := FileConfigFromRuntime(cfg)
+	if got := roundTripped.Security.TransactionPolicy; !got.Enabled || len(got.DenyRules) != 1 {
+		t.Fatalf("round-trip policy = %+v", got)
+	}
+	data, err := json.Marshal(roundTripped)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var parsed FileConfig
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatal(err)
+	}
+	if !parsed.Security.TransactionPolicy.Enabled || len(parsed.Security.TransactionPolicy.AllowRules) != 1 {
+		t.Fatalf("JSON round-trip policy = %+v", parsed.Security.TransactionPolicy)
+	}
+}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -585,7 +585,7 @@ func validTransactionHost(host string) bool {
 			return false
 		}
 		for _, r := range label {
-			if !((r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-') {
+			if (r < 'a' || r > 'z') && (r < 'A' || r > 'Z') && (r < '0' || r > '9') && r != '-' {
 				return false
 			}
 		}
@@ -613,7 +613,7 @@ func validTransactionToken(value string) bool {
 		return false
 	}
 	for _, r := range value {
-		if !((r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || strings.ContainsRune("-._~", r)) {
+		if (r < 'a' || r > 'z') && (r < 'A' || r > 'Z') && (r < '0' || r > '9') && !strings.ContainsRune("-._~", r) {
 			return false
 		}
 	}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -186,6 +186,10 @@ func ValidateFileConfig(fc *FileConfig) []error {
 
 	// IDPI validation
 	errs = append(errs, validateIDPIConfig(fc.Security.IDPI, effectiveSecurityAllowedDomains(fc.Security))...)
+	errs = append(errs, validateTransactionPolicyConfig(fc.Security.TransactionPolicy)...)
+	if fc.Security.TransactionPolicy.Enabled && len(fc.Browser.ExtensionPaths) != 0 {
+		errs = append(errs, ValidationError{Field: "browser.extensionPaths", Message: "must be empty when security.transactionPolicy is enabled"})
+	}
 	errs = append(errs, validateAllowedDomainList("security.downloadAllowedDomains", fc.Security.DownloadAllowedDomains)...)
 	errs = append(errs, validateTrustedCIDRList("security.trustedProxyCIDRs", fc.Security.TrustedProxyCIDRs)...)
 	errs = append(errs, validateTrustedCIDRList("security.trustedResolveCIDRs", fc.Security.TrustedResolveCIDRs)...)
@@ -522,4 +526,114 @@ func ValidAllocationPolicies() []string {
 // ValidAttachSchemes returns all valid attach URL schemes.
 func ValidAttachSchemes() []string {
 	return []string{"ws", "wss", "http", "https"}
+}
+
+// validateTransactionPolicyConfig validates the request guard only when enabled.
+func validateTransactionPolicyConfig(cfg TransactionPolicyConfig) []error {
+	if !cfg.Enabled {
+		return nil
+	}
+	var errs []error
+	if len(cfg.Hosts) == 0 {
+		errs = append(errs, ValidationError{Field: "security.transactionPolicy.hosts", Message: "must contain at least one host when enabled"})
+	}
+	if len(cfg.DenyRules) == 0 {
+		errs = append(errs, ValidationError{Field: "security.transactionPolicy.denyRules", Message: "must contain at least one rule when enabled"})
+	}
+	for _, host := range cfg.Hosts {
+		host = strings.TrimSpace(host)
+		if !validTransactionHost(host) {
+			errs = append(errs, ValidationError{Field: "security.transactionPolicy.hosts", Message: "host must be an exact DNS hostname or IPv4 address without a scheme, port, wildcard, trailing dot, path, or whitespace"})
+		}
+	}
+	for _, group := range []struct {
+		field string
+		rules []TransactionPolicyRule
+		allow bool
+	}{{"security.transactionPolicy.denyRules", cfg.DenyRules, false}, {"security.transactionPolicy.allowRules", cfg.AllowRules, true}} {
+		for _, rule := range group.rules {
+			method := strings.ToUpper(strings.TrimSpace(rule.Method))
+			if !isValidTransactionMethod(method) {
+				errs = append(errs, ValidationError{Field: group.field, Message: fmt.Sprintf("invalid method %q", rule.Method)})
+			}
+			if !validTransactionPathPrefix(rule.PathPrefix) {
+				errs = append(errs, ValidationError{Field: group.field, Message: fmt.Sprintf("pathPrefix %q must be an unescaped absolute path made of unreserved ASCII characters", rule.PathPrefix)})
+			}
+			if rule.PathSegment != "" && !validTransactionToken(rule.PathSegment) {
+				errs = append(errs, ValidationError{Field: group.field, Message: "pathSegment must be one unescaped unreserved path segment"})
+			}
+			if (rule.QueryParam == "") != (rule.QueryValue == "") {
+				errs = append(errs, ValidationError{Field: group.field, Message: "queryParam and queryValue must be set together"})
+			}
+			if (rule.QueryParam != "" && !validTransactionToken(rule.QueryParam)) || (rule.QueryValue != "" && !validTransactionToken(rule.QueryValue)) {
+				errs = append(errs, ValidationError{Field: group.field, Message: "queryParam/queryValue must be unescaped unreserved ASCII"})
+			}
+			if group.allow && isUnsafeTransactionMethod(method) && strings.Trim(strings.TrimSpace(rule.PathPrefix), "/") == "" && rule.QueryParam == "" {
+				errs = append(errs, ValidationError{Field: group.field, Message: "unsafe root-wide allow requires an exact query condition"})
+			}
+		}
+	}
+	return errs
+}
+
+func validTransactionHost(host string) bool {
+	if host == "" || len(host) > 253 || strings.HasSuffix(host, ".") {
+		return false
+	}
+	for _, label := range strings.Split(host, ".") {
+		if label == "" || len(label) > 63 || label[0] == '-' || label[len(label)-1] == '-' {
+			return false
+		}
+		for _, r := range label {
+			if !((r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-') {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func validTransactionPathPrefix(value string) bool {
+	if !strings.HasPrefix(value, "/") || strings.Contains(value, "//") {
+		return false
+	}
+	for _, segment := range strings.Split(strings.Trim(value, "/"), "/") {
+		if segment == "" {
+			continue
+		}
+		if segment == "." || segment == ".." || !validTransactionToken(segment) {
+			return false
+		}
+	}
+	return true
+}
+
+func validTransactionToken(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, r := range value {
+		if !((r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || strings.ContainsRune("-._~", r)) {
+			return false
+		}
+	}
+	return true
+}
+
+func isUnsafeTransactionMethod(method string) bool {
+	switch method {
+	case "GET", "HEAD", "OPTIONS":
+		return false
+	default:
+		return true
+	}
+}
+
+func isValidTransactionMethod(method string) bool {
+	switch method {
+	case "*", "GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS":
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/dashboard/config_api.go
+++ b/internal/dashboard/config_api.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -385,6 +386,9 @@ func (c *ConfigAPI) restartReasonsFor(next config.FileConfig) []string {
 	}
 	if c.boot.InstanceDefaults.StealthLevel != next.InstanceDefaults.StealthLevel {
 		reasons = append(reasons, "Stealth level")
+	}
+	if !reflect.DeepEqual(c.boot.Security.TransactionPolicy, next.Security.TransactionPolicy) {
+		reasons = append(reasons, "Transaction policy")
 	}
 	if !sameIntPtr(c.boot.MultiInstance.Restart.MaxRestarts, next.MultiInstance.Restart.MaxRestarts) ||
 		!sameIntPtr(c.boot.MultiInstance.Restart.InitBackoffSec, next.MultiInstance.Restart.InitBackoffSec) ||

--- a/internal/dashboard/transaction_policy_test.go
+++ b/internal/dashboard/transaction_policy_test.go
@@ -1,0 +1,19 @@
+package dashboard
+
+import (
+	"testing"
+
+	"github.com/pinchtab/pinchtab/internal/config"
+)
+
+func TestRestartReasonsIncludesTransactionPolicy(t *testing.T) {
+	api := &ConfigAPI{boot: config.DefaultFileConfig()}
+	next := config.DefaultFileConfig()
+	next.Security.TransactionPolicy = config.TransactionPolicyConfig{Enabled: true, Hosts: []string{"supplier.example"}}
+	for _, reason := range api.restartReasonsFor(next) {
+		if reason == "Transaction policy" {
+			return
+		}
+	}
+	t.Fatal("transaction policy change did not require restart")
+}

--- a/internal/engine/lite.go
+++ b/internal/engine/lite.go
@@ -519,3 +519,26 @@ func normalizeWhitespace(s string) string {
 	}
 	return strings.TrimSpace(b.String())
 }
+
+// FieldSensitive reports whether the element behind ref is a credential-bearing
+// field (password type, sensitive autocomplete, or a secret-looking name/id).
+// Used to decide whether an action response may echo the typed text back.
+// Fails closed: an unresolvable ref is treated as sensitive.
+func (l *LiteEngine) FieldSensitive(tabID, ref string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	tab, err := l.resolveTab(tabID)
+	if err != nil {
+		return true
+	}
+	el, ok := tab.refMap[ref]
+	if !ok {
+		return true
+	}
+	attr := func(name string) string {
+		v, _ := el.GetAttribute(name)
+		return v
+	}
+	return IsSensitiveFieldAttrs(attr("type"), attr("autocomplete"), attr("name"), attr("id"), attr("aria-label"))
+}

--- a/internal/engine/sensitive_fields.go
+++ b/internal/engine/sensitive_fields.go
@@ -1,0 +1,33 @@
+package engine
+
+import "strings"
+
+// sensitiveNameHints are substrings of an element's name/id/autocomplete that
+// mark it credential-bearing even when its input type is not "password".
+var sensitiveNameHints = []string{
+	"password", "passwd", "pwd", "passphrase",
+	"secret", "token", "apikey", "api-key", "api_key",
+	"otp", "totp", "mfa", "2fa", "one-time-code", "onetimecode",
+	"cvv", "cvc", "cardnumber", "card-number", "card_number",
+	"security-code", "securitycode",
+	"private-key", "privatekey", "credential",
+}
+
+// IsSensitiveFieldAttrs decides sensitivity from element attributes.
+func IsSensitiveFieldAttrs(inputType, autocomplete, name, id, ariaLabel string) bool {
+	if strings.EqualFold(strings.TrimSpace(inputType), "password") {
+		return true
+	}
+	switch strings.ToLower(strings.TrimSpace(autocomplete)) {
+	case "current-password", "new-password", "one-time-code", "cc-number", "cc-csc":
+		return true
+	}
+	haystack := strings.ToLower(strings.Join([]string{autocomplete, name, id, ariaLabel}, " "))
+	haystack = strings.ReplaceAll(haystack, " ", "")
+	for _, hint := range sensitiveNameHints {
+		if strings.Contains(haystack, hint) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/engine/sensitive_fields_extra_test.go
+++ b/internal/engine/sensitive_fields_extra_test.go
@@ -1,0 +1,31 @@
+package engine
+
+import "testing"
+
+func TestIsSensitiveFieldAttrsMatrix(t *testing.T) {
+	cases := []struct {
+		name                                 string
+		typ, autocomplete, nm, id, ariaLabel string
+		want                                 bool
+	}{
+		{name: "password input", typ: "password", want: true},
+		{name: "password uppercase", typ: "PASSWORD", want: true},
+		{name: "current-password", typ: "text", autocomplete: "current-password", want: true},
+		{name: "one-time-code", typ: "text", autocomplete: "one-time-code", want: true},
+		{name: "cc-number", typ: "text", autocomplete: "cc-number", want: true},
+		{name: "totp name hint", typ: "text", nm: "totp_code", want: true},
+		{name: "apiKey id hint", typ: "text", id: "apiKey", want: true},
+		{name: "aria-label secret", typ: "text", ariaLabel: "Secret token", want: true},
+		{name: "revealed password", typ: "text", nm: "user_pwd", want: true},
+		{name: "plain email", typ: "email", nm: "email", id: "login-email", want: false},
+		{name: "search box", typ: "text", nm: "q", ariaLabel: "Search", want: false},
+		{name: "empty", want: false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := IsSensitiveFieldAttrs(c.typ, c.autocomplete, c.nm, c.id, c.ariaLabel); got != c.want {
+				t.Fatalf("got %v want %v", got, c.want)
+			}
+		})
+	}
+}

--- a/internal/handlers/action_execution.go
+++ b/internal/handlers/action_execution.go
@@ -110,6 +110,17 @@ func (h *Handlers) executeLiteAction(ctx context.Context, req bridge.ActionReque
 		if err := h.Router.Lite().Type(ctx, req.TabID, req.Ref, text); err != nil {
 			return nil, "lite", err
 		}
+		// Never echo the plaintext back for credential fields (SMI-3579).
+		// Fails closed when the engine cannot report sensitivity.
+		sensitive := true
+		if probe, ok := h.Router.Lite().(interface {
+			FieldSensitive(tabID, ref string) bool
+		}); ok {
+			sensitive = probe.FieldSensitive(req.TabID, req.Ref)
+		}
+		if sensitive {
+			return bridge.RedactedTextEcho(text), "lite", nil
+		}
 		return map[string]any{"typed": text}, "lite", nil
 	default:
 		return nil, "lite", fmt.Errorf("%w: %s", engine.ErrLiteNotSupported, req.Kind)

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -355,6 +355,12 @@ func (o *Orchestrator) Launch(name, port string, headless bool, extensionPaths [
 }
 
 func (o *Orchestrator) LaunchWithOptions(name, port string, headless bool, opts LaunchOptions) (*bridge.Instance, error) {
+	o.mu.RLock()
+	policyEnabled := o.runtimeCfg != nil && o.runtimeCfg.TransactionPolicy.Enabled
+	o.mu.RUnlock()
+	if policyEnabled && len(opts.ExtensionPaths) > 0 {
+		return nil, fmt.Errorf("request-supplied extensionPaths are not allowed while transaction policy is enabled")
+	}
 	// Validate profile name to prevent path traversal attacks
 	if err := profiles.ValidateProfileName(name); err != nil {
 		return nil, err
@@ -458,6 +464,16 @@ func (o *Orchestrator) LaunchWithOptions(name, port string, headless bool, opts 
 	}
 	if o.internalToken != "" {
 		envOverrides["PINCHTAB_INTERNAL_TOKEN"] = o.internalToken
+	}
+	// filterEnvWithPrefixes strips ALL PINCHTAB_-prefixed vars from the parent
+	// environment before spawning the per-instance child process, so runtime
+	// container-compatibility overrides (e.g. the no-sandbox flag needed under
+	// containerd/CRI-O, which lack a Docker-only /.dockerenv marker) must be
+	// explicitly re-forwarded here or every profile-managed instance silently
+	// loses them, even though the top-level always-on bridge process (which
+	// inherits the full container env directly) keeps working fine.
+	if v := os.Getenv(config.ChromeNoSandboxEnvVar()); v != "" {
+		envOverrides[config.ChromeNoSandboxEnvVar()] = v
 	}
 	env := mergeEnvWithOverrides(filterEnvWithPrefixes(os.Environ(), "PINCHTAB_"), envOverrides)
 
@@ -629,6 +645,10 @@ func intPtr(v int) *int {
 // bridge in place (upsert). Non-bridge duplicates still return an error.
 func (o *Orchestrator) attachExternalInstance(name string, inst bridge.Instance, authToken string) (*bridge.Instance, bool, error) {
 	o.mu.Lock()
+	if o.runtimeCfg != nil && o.runtimeCfg.TransactionPolicy.Enabled {
+		o.mu.Unlock()
+		return nil, false, fmt.Errorf("transaction policy requires a PinchTab-managed browser launch; attached browsers are not protected")
+	}
 	for _, existing := range o.instances {
 		if existing.ProfileName == name && instanceIsActive(existing) {
 			if existing.Attached && inst.AttachType == "bridge" && existing.AttachType == "bridge" {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -434,13 +434,33 @@ func (o *Orchestrator) LaunchWithOptions(name, port string, headless bool, opts 
 	reservedPorts = append(reservedPorts, cdpPort)
 
 	profilePath := filepath.Join(o.baseDir, name)
+	resolved := false
 	if o.profiles != nil {
 		if resolvedPath, err := o.profiles.ProfilePath(name); err == nil {
 			profilePath = resolvedPath
+			resolved = true
 		}
+	}
+	if !resolved {
+		// The named profile is not in the profile store. We still start — that
+		// is the documented "profile dirs are created on demand" behaviour —
+		// but it means the caller gets a BLANK browser: no cookies, no
+		// remembered-device token, no logged-in session. For a bank profile
+		// that silently turns "reuse my session" into "full re-auth", so say
+		// so loudly instead of leaving it to be inferred from a failed login.
+		slog.Warn("profile not found in store; starting instance on a fresh empty profile dir",
+			"profile", name, "path", profilePath)
 	}
 	if err := os.MkdirAll(filepath.Join(profilePath, "Default"), 0755); err != nil {
 		return nil, fmt.Errorf("create profile dir: %w", err)
+	}
+	// Mark the directory as a real Chromium user-data-dir immediately; see
+	// profiles.seedChromiumPreferences for why an unmarked dir is dangerous.
+	prefsPath := filepath.Join(profilePath, "Default", "Preferences")
+	if _, err := os.Stat(prefsPath); os.IsNotExist(err) {
+		if werr := os.WriteFile(prefsPath, []byte("{}"), 0600); werr != nil {
+			slog.Warn("failed to seed Chromium Preferences", "path", prefsPath, "err", werr)
+		}
 	}
 	instanceStateDir := filepath.Join(profilePath, ".pinchtab-state")
 	if err := os.MkdirAll(instanceStateDir, 0700); err != nil {

--- a/internal/orchestrator/process_test.go
+++ b/internal/orchestrator/process_test.go
@@ -70,6 +70,32 @@ func TestLaunch_Mocked(t *testing.T) {
 	}
 }
 
+func TestLaunch_ForwardsChromeNoSandboxCompatEnvVar(t *testing.T) {
+	old := portAvailableFunc
+	portAvailableFunc = func(int) bool { return true }
+	defer func() { portAvailableFunc = old }()
+
+	t.Setenv("PINCHTAB_CHROME_NO_SANDBOX", "1")
+
+	runner := &mockRunner{portAvail: true}
+	o := NewOrchestratorWithRunner(t.TempDir(), runner)
+
+	if _, err := o.Launch("test-prof", "9999", true, nil); err != nil {
+		t.Fatalf("Launch failed: %v", err)
+	}
+
+	found := false
+	for _, kv := range runner.env {
+		if kv == "PINCHTAB_CHROME_NO_SANDBOX=1" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected child env to include PINCHTAB_CHROME_NO_SANDBOX=1, got %v", runner.env)
+	}
+}
+
 func TestLaunch_PortConflict(t *testing.T) {
 	old := portAvailableFunc
 	portAvailableFunc = func(int) bool { return true }

--- a/internal/orchestrator/transaction_policy_test.go
+++ b/internal/orchestrator/transaction_policy_test.go
@@ -1,0 +1,20 @@
+package orchestrator
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/pinchtab/pinchtab/internal/config"
+)
+
+func TestLaunchRejectsRequestExtensionPathsWhenTransactionPolicyEnabled(t *testing.T) {
+	o := NewOrchestratorWithRunner(t.TempDir(), &mockRunner{portAvail: true})
+	o.ApplyRuntimeConfig(&config.RuntimeConfig{TransactionPolicy: config.TransactionPolicyConfig{Enabled: true}})
+	_, err := o.Launch("profile", "9868", true, []string{"/request-extension"})
+	if err == nil || !strings.Contains(err.Error(), "request-supplied extensionPaths") {
+		t.Fatalf("Launch error = %v", err)
+	}
+	if _, err := o.Attach("external", "ws://127.0.0.1:9222/devtools/browser/x"); err == nil || !strings.Contains(err.Error(), "managed browser launch") {
+		t.Fatalf("Attach error = %v", err)
+	}
+}

--- a/internal/profiles/profiles_crud.go
+++ b/internal/profiles/profiles_crud.go
@@ -89,10 +89,36 @@ func (pm *ProfileManager) Create(name string) error {
 	if err := os.MkdirAll(filepath.Join(dest, "Default"), 0755); err != nil {
 		return err
 	}
+	if err := seedChromiumPreferences(dest); err != nil {
+		return err
+	}
 	return writeProfileMeta(dest, ProfileMeta{
 		ID:   profileID(name),
 		Name: name,
 	})
+}
+
+// seedChromiumPreferences writes a minimal Default/Preferences file if none
+// exists yet.
+//
+// A freshly created profile is structurally indistinguishable from a corrupt
+// one until Chromium first launches into it and writes Preferences itself —
+// and Chromium writes that file atomically (temp + rename), so a hard kill
+// (pod eviction, OOM, SIGKILL on scale-to-zero) can also leave the directory
+// without one. External profile-volume janitors reasonably treat "no
+// Preferences" as "broken, safe to delete"; on 2026-08-17 that heuristic
+// destroyed the `stdbank-luke` and `bobgo-luke` bank profiles on the
+// production PinchTab volume, along with their remembered-device tokens.
+//
+// Seeding an empty-but-valid Preferences file at create time makes a managed
+// profile self-identifying from the filesystem alone. Chromium overwrites it
+// on first run.
+func seedChromiumPreferences(dest string) error {
+	prefs := filepath.Join(dest, "Default", "Preferences")
+	if _, err := os.Stat(prefs); err == nil {
+		return nil
+	}
+	return os.WriteFile(prefs, []byte("{}"), 0600)
 }
 
 func (pm *ProfileManager) CreateWithMeta(name string, meta ProfileMeta) error {

--- a/internal/profiles/profiles_test.go
+++ b/internal/profiles/profiles_test.go
@@ -902,3 +902,46 @@ func TestProfileRenameRejectsDuplicate(t *testing.T) {
 		t.Errorf("expected 'already exists' error, got: %v", err)
 	}
 }
+
+// A freshly created profile must look like a real Chromium user-data-dir on
+// disk. External profile-volume janitors delete "no Preferences" directories
+// as corrupt; on 2026-08-17 that destroyed two live bank profiles.
+func TestCreateSeedsChromiumPreferences(t *testing.T) {
+	dir := t.TempDir()
+	pm := NewProfileManager(dir)
+
+	if err := pm.Create("stdbank-luke"); err != nil {
+		t.Fatal(err)
+	}
+
+	prefs := filepath.Join(dir, profileID("stdbank-luke"), "Default", "Preferences")
+	data, err := os.ReadFile(prefs)
+	if err != nil {
+		t.Fatalf("Preferences not seeded at %s: %v", prefs, err)
+	}
+	if len(data) == 0 {
+		t.Fatal("seeded Preferences must not be empty")
+	}
+}
+
+// Seeding must never clobber a real Chromium Preferences file (import path).
+func TestSeedChromiumPreferencesPreservesExisting(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "Default"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	prefs := filepath.Join(dir, "Default", "Preferences")
+	if err := os.WriteFile(prefs, []byte(`{"real":"prefs"}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := seedChromiumPreferences(dir); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(prefs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != `{"real":"prefs"}` {
+		t.Fatalf("existing Preferences was overwritten: %s", data)
+	}
+}


### PR DESCRIPTION
Clean re-cut of #629 onto current main — that branch had six commits from other lanes sitting under mine, so this PR carries **only** the 5 files for this fix.

## 1. The tab cap was not enforced
`maxTabs` was checked against TabManager's in-process map, so every target it had stopped tracking (bridge restart, dead tab context, Chromium session restore) was **invisible to the cap** and accumulated without bound.

In production a `maxTabs: 8` instance was holding **158 live page targets** and had become too slow to answer its own readiness probe — that is what took the Standard Bank login down for a banking day (SMI-3785).

`liveTabCount()` now counts Chrome's real page targets, and orphans are reaped **oldest-first, before** any managed tab is considered for eviction.

> The previous comment here deliberately counted only the managed map, to avoid premature eviction caused by unmanaged targets like the initial `about:blank` tab. That concern is real and is now *better* served: the stray target gets closed instead of causing a live, caller-driven tab to be evicted.

## 2. A new profile looked identical to a corrupt one
`profiles.Create()` now seeds a minimal `Default/Preferences`, and the orchestrator seeds it and WARNs when it auto-creates an unknown profile dir.

Until Chromium first ran, a new profile had no `Preferences` — and Chromium writes that file atomically, so a hard kill leaves a *live* profile without one either. An external volume janitor treating "no Preferences" as "safe to delete" destroyed the `stdbank-luke` and `bobgo-luke` bank profiles on exactly that basis. Seeding it makes a managed profile self-identifying from the filesystem alone.

## Verification
`go build`, `go vet`, `go test ./internal/{bridge,profiles,orchestrator}/...` all clean against current main. New `tab_manager_orphan_test.go` covers oldest-first orphan selection and tracked-target exclusion.

Supersedes #629. Infra counterpart: valkyriweb/lue-kube#1438 (merged).