### PR TITLE
fix: enforce tab cap against Chrome reality; make new profiles self-identifying

### DIFF
--- a/internal/bridge/tab_manager.go
+++ b/internal/bridge/tab_manager.go
@@ -129,6 +129,98 @@ func browserExecutorContext(ctx context.Context) (context.Context, error) {
 	return cdp.WithExecutor(ctx, c.Browser), nil
 }
 
+// trackedCDPIDs returns the raw CDP target IDs this manager currently tracks.
+func (tm *TabManager) trackedCDPIDs() map[string]bool {
+	tm.mu.RLock()
+	defer tm.mu.RUnlock()
+	out := make(map[string]bool, len(tm.tabs))
+	for _, entry := range tm.tabs {
+		if entry != nil && entry.CDPID != "" {
+			out[entry.CDPID] = true
+		}
+	}
+	return out
+}
+
+// selectOrphanTargets returns page targets that exist in Chrome but are not
+// tracked by this TabManager, oldest-first (GetTargets returns newest first),
+// capped at `limit` entries. A negative or zero limit means "all orphans".
+//
+// Orphans accumulate whenever the bridge process is restarted, a tab context
+// dies, or Chromium restores a previous session: the Chrome target survives
+// but the managed entry does not. They are invisible to a managed-count-only
+// tab cap, which is how a `maxTabs: 8` instance ended up holding 158 live
+// page targets in production (SBSA lane, 2026-08-17) and starved every other
+// caller of that instance.
+func selectOrphanTargets(tracked map[string]bool, pages []*target.Info, limit int) []target.ID {
+	orphans := make([]target.ID, 0)
+	// GetTargets is newest-first; walk backwards so we reap the oldest first.
+	for i := len(pages) - 1; i >= 0; i-- {
+		t := pages[i]
+		if t == nil || t.Type != TargetTypePage {
+			continue
+		}
+		if tracked[string(t.TargetID)] {
+			continue
+		}
+		orphans = append(orphans, t.TargetID)
+		if limit > 0 && len(orphans) >= limit {
+			break
+		}
+	}
+	return orphans
+}
+
+// reapOrphanTargets closes untracked page targets so the configured tab cap
+// reflects Chrome reality rather than in-process bookkeeping. Returns the
+// number of targets actually closed.
+func (tm *TabManager) reapOrphanTargets(limit int) int {
+	pages, err := tm.ListTargets()
+	if err != nil {
+		slog.Warn("tab budget: cannot list chrome targets", "err", err)
+		return 0
+	}
+	orphans := selectOrphanTargets(tm.trackedCDPIDs(), pages, limit)
+	closed := 0
+	for _, id := range orphans {
+		closeCtx, cancel := context.WithTimeout(tm.browserCtx, 5*time.Second)
+		c := chromedp.FromContext(closeCtx)
+		if c == nil || c.Browser == nil {
+			cancel()
+			break
+		}
+		if err := target.CloseTarget(id).Do(cdp.WithExecutor(closeCtx, c.Browser)); err != nil {
+			slog.Debug("tab budget: orphan close failed", "targetId", id, "err", err)
+			cancel()
+			continue
+		}
+		cancel()
+		closed++
+	}
+	if closed > 0 {
+		slog.Info("tab budget: closed untracked chrome targets", "count", closed, "maxTabs", tm.config.MaxTabs)
+	}
+	return closed
+}
+
+// liveTabCount is the number of tabs the cap must be enforced against: every
+// open page target in Chrome, not just the ones this process happens to track.
+// Falls back to the managed count if Chrome cannot be queried.
+func (tm *TabManager) liveTabCount() int {
+	tm.mu.RLock()
+	managed := len(tm.tabs)
+	tm.mu.RUnlock()
+
+	pages, err := tm.ListTargets()
+	if err != nil {
+		return managed
+	}
+	if len(pages) > managed {
+		return len(pages)
+	}
+	return managed
+}
+
 func (tm *TabManager) CreateTab(url string) (string, context.Context, context.CancelFunc, error) {
 	return tm.createTab(url, "")
 }
@@ -148,13 +240,27 @@ func (tm *TabManager) createTab(url, browserContextID string) (string, context.C
 		return "", nil, nil, fmt.Errorf("no browser context available")
 	}
 
+	// Upstream deliberately counted only the managed map here, to avoid
+	// premature eviction from unmanaged targets such as the initial
+	// about:blank tab. That is still the right concern, but the fix is to reap
+	// the untracked targets rather than to ignore them: counting only the
+	// managed map let untracked targets (bridge restart, dead tab contexts,
+	// Chromium session restore) grow without bound, which is how a
+	// `maxTabs: 8` instance ended up holding 158 live page targets in
+	// production and starved every other caller of that instance
+	// (SBSA lane, 2026-08-17).
+	//
+	// Orphans are reaped oldest-first BEFORE any managed tab is considered for
+	// eviction, so the about:blank case now resolves by closing that stray
+	// target instead of evicting a tab a caller may still be driving.
 	if tm.config != nil && tm.config.MaxTabs > 0 {
-		// Count managed tabs for eviction decisions. Using Chrome's target list
-		// would include unmanaged targets (e.g. the initial about:blank tab),
-		// causing premature eviction of managed tabs.
-		tm.mu.RLock()
-		managedCount := len(tm.tabs)
-		tm.mu.RUnlock()
+		managedCount := tm.liveTabCount()
+
+		if managedCount >= tm.config.MaxTabs {
+			if closed := tm.reapOrphanTargets(managedCount - tm.config.MaxTabs + 1); closed > 0 {
+				managedCount = tm.liveTabCount()
+			}
+		}
 
 		if managedCount >= tm.config.MaxTabs {
 			switch tm.config.TabEvictionPolicy {

--- a/internal/bridge/tab_manager_orphan_test.go
+++ b/internal/bridge/tab_manager_orphan_test.go
@@ -1,0 +1,64 @@
+package bridge
+
+import (
+	"testing"
+
+	"github.com/chromedp/cdproto/target"
+)
+
+func pageTarget(id string) *target.Info {
+	return &target.Info{TargetID: target.ID(id), Type: TargetTypePage}
+}
+
+// The production failure: Chrome held 158 page targets on an instance
+// configured with maxTabs: 8, because the cap only ever counted the
+// in-process managed map. Untracked targets must be selectable for reaping.
+func TestSelectOrphanTargets_PicksUntrackedOldestFirst(t *testing.T) {
+	tracked := map[string]bool{"t-managed": true}
+	// GetTargets returns newest-first.
+	pages := []*target.Info{pageTarget("t-new"), pageTarget("t-managed"), pageTarget("t-old")}
+
+	got := selectOrphanTargets(tracked, pages, 0)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 orphans, got %d (%v)", len(got), got)
+	}
+	if got[0] != target.ID("t-old") {
+		t.Fatalf("expected oldest orphan first, got %v", got)
+	}
+	for _, id := range got {
+		if id == target.ID("t-managed") {
+			t.Fatal("a tracked target must never be reaped as an orphan")
+		}
+	}
+}
+
+func TestSelectOrphanTargets_RespectsLimit(t *testing.T) {
+	pages := []*target.Info{pageTarget("a"), pageTarget("b"), pageTarget("c")}
+	got := selectOrphanTargets(map[string]bool{}, pages, 2)
+	if len(got) != 2 {
+		t.Fatalf("expected limit of 2, got %d", len(got))
+	}
+}
+
+func TestSelectOrphanTargets_IgnoresNonPageTargets(t *testing.T) {
+	pages := []*target.Info{
+		{TargetID: target.ID("worker"), Type: "service_worker"},
+		nil,
+		pageTarget("page"),
+	}
+	got := selectOrphanTargets(map[string]bool{}, pages, 0)
+	if len(got) != 1 || got[0] != target.ID("page") {
+		t.Fatalf("expected only the page target, got %v", got)
+	}
+}
+
+func TestTrackedCDPIDs(t *testing.T) {
+	tm := &TabManager{tabs: map[string]*TabEntry{
+		"tab_1": {CDPID: "raw1"},
+		"tab_2": {CDPID: ""},
+	}}
+	got := tm.trackedCDPIDs()
+	if !got["raw1"] || len(got) != 1 {
+		t.Fatalf("unexpected tracked set: %v", got)
+	}
+}

--- a/internal/orchestrator/instance_launch.go
+++ b/internal/orchestrator/instance_launch.go
@@ -96,13 +96,33 @@ func (o *Orchestrator) LaunchWithOptions(name, port string, headless bool, opts 
 	reservedPorts = append(reservedPorts, cdpPort)
 
 	profilePath := filepath.Join(o.baseDir, name)
+	resolved := false
 	if o.profiles != nil {
 		if resolvedPath, err := o.profiles.ProfilePath(name); err == nil {
 			profilePath = resolvedPath
+			resolved = true
 		}
+	}
+	if !resolved {
+		// The named profile is not in the profile store. We still start — that
+		// is the documented "profile dirs are created on demand" behaviour —
+		// but it means the caller gets a BLANK browser: no cookies, no
+		// remembered-device token, no logged-in session. For a bank profile
+		// that silently turns "reuse my session" into "full re-auth", so say
+		// so loudly instead of leaving it to be inferred from a failed login.
+		slog.Warn("profile not found in store; starting instance on a fresh empty profile dir",
+			"profile", name, "path", profilePath)
 	}
 	if err := os.MkdirAll(filepath.Join(profilePath, "Default"), 0755); err != nil {
 		return nil, fmt.Errorf("create profile dir: %w", err)
+	}
+	// Mark the directory as a real Chromium user-data-dir immediately; see
+	// profiles.seedChromiumPreferences for why an unmarked dir is dangerous.
+	prefsPath := filepath.Join(profilePath, "Default", "Preferences")
+	if _, err := os.Stat(prefsPath); os.IsNotExist(err) {
+		if werr := os.WriteFile(prefsPath, []byte("{}"), 0600); werr != nil {
+			slog.Warn("failed to seed Chromium Preferences", "path", prefsPath, "err", werr)
+		}
 	}
 	instanceStateDir := filepath.Join(profilePath, ".pinchtab-state")
 	if err := os.MkdirAll(instanceStateDir, 0700); err != nil {

--- a/internal/profiles/profiles_crud.go
+++ b/internal/profiles/profiles_crud.go
@@ -128,10 +128,36 @@ func (pm *ProfileManager) Create(name string) error {
 	if err := os.MkdirAll(filepath.Join(dest, "Default"), 0755); err != nil {
 		return err
 	}
+	if err := seedChromiumPreferences(dest); err != nil {
+		return err
+	}
 	return writeProfileMeta(dest, ProfileMeta{
 		ID:   id,
 		Name: name,
 	})
+}
+
+// seedChromiumPreferences writes a minimal Default/Preferences file if none
+// exists yet.
+//
+// A freshly created profile is structurally indistinguishable from a corrupt
+// one until Chromium first launches into it and writes Preferences itself —
+// and Chromium writes that file atomically (temp + rename), so a hard kill
+// (pod eviction, OOM, SIGKILL on scale-to-zero) can also leave the directory
+// without one. External profile-volume janitors reasonably treat "no
+// Preferences" as "broken, safe to delete"; on 2026-08-17 that heuristic
+// destroyed the `stdbank-luke` and `bobgo-luke` bank profiles on the
+// production PinchTab volume, along with their remembered-device tokens.
+//
+// Seeding an empty-but-valid Preferences file at create time makes a managed
+// profile self-identifying from the filesystem alone. Chromium overwrites it
+// on first run.
+func seedChromiumPreferences(dest string) error {
+	prefs := filepath.Join(dest, "Default", "Preferences")
+	if _, err := os.Stat(prefs); err == nil {
+		return nil
+	}
+	return os.WriteFile(prefs, []byte("{}"), 0600)
 }
 
 func (pm *ProfileManager) CreateWithMeta(name string, meta ProfileMeta) error {

--- a/internal/profiles/profiles_test.go
+++ b/internal/profiles/profiles_test.go
@@ -1662,3 +1662,46 @@ func TestAStaleLockWithNoLiveHolderStillDeletes(t *testing.T) {
 			w.Code, w.Body.String())
 	}
 }
+
+// A freshly created profile must look like a real Chromium user-data-dir on
+// disk. External profile-volume janitors delete "no Preferences" directories
+// as corrupt; on 2026-08-17 that destroyed two live bank profiles.
+func TestCreateSeedsChromiumPreferences(t *testing.T) {
+	dir := t.TempDir()
+	pm := NewProfileManager(dir)
+
+	if err := pm.Create("stdbank-luke"); err != nil {
+		t.Fatal(err)
+	}
+
+	prefs := filepath.Join(dir, profileID("stdbank-luke"), "Default", "Preferences")
+	data, err := os.ReadFile(prefs)
+	if err != nil {
+		t.Fatalf("Preferences not seeded at %s: %v", prefs, err)
+	}
+	if len(data) == 0 {
+		t.Fatal("seeded Preferences must not be empty")
+	}
+}
+
+// Seeding must never clobber a real Chromium Preferences file (import path).
+func TestSeedChromiumPreferencesPreservesExisting(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "Default"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	prefs := filepath.Join(dir, "Default", "Preferences")
+	if err := os.WriteFile(prefs, []byte(`{"real":"prefs"}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := seedChromiumPreferences(dir); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(prefs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != `{"real":"prefs"}` {
+		t.Fatalf("existing Preferences was overwritten: %s", data)
+	}
+}


### PR DESCRIPTION
Replaces #629 and #630, both of which were cut from the `valkyriweb` fork's main — **636 commits behind upstream** — so both arrived conflicted. This is the same fix applied to current upstream layout (`Create()` now in `profiles_crud.go`, launch in `instance_launch.go`). 5 files.

## 1. The tab cap was not enforced
`maxTabs` was checked against TabManager's in-process map, so every target it had stopped tracking (bridge restart, dead tab context, Chromium session restore) was **invisible to the cap** and accumulated without bound.

In production a `maxTabs: 8` instance was holding **158 live page targets** and had become too slow to answer its own readiness probe — that is what took a Standard Bank login down for a banking day (SMI-3785).

`liveTabCount()` counts Chrome's real page targets, and orphans are reaped **oldest-first, before** any managed tab is considered for eviction.

> The previous comment there deliberately counted only the managed map, to avoid premature eviction from unmanaged targets like the initial `about:blank` tab. That concern is real and is now better served: the stray target gets closed instead of a live, caller-driven tab being evicted.

## 2. A new profile looked identical to a corrupt one
`profiles.Create()` seeds a minimal `Default/Preferences`, and instance launch seeds it and WARNs when starting on a profile that isn't in the store (that case silently hands the caller a blank browser — for a bank profile it turns "reuse my session" into "full re-auth").

Until Chromium first ran there was no `Preferences`, and Chromium writes it atomically, so a hard kill leaves a *live* profile without one too. An external volume janitor treating "no Preferences" as "safe to delete" destroyed two bank profiles on exactly that basis.

## Verification
`go build`, `go vet`, `gofmt` clean; `internal/profiles` and `internal/orchestrator` suites pass; new orphan-selection tests pass. The `internal/bridge` integration failures on my host are pre-existing (`chrome failed to start` — no browser available) and reproduce identically on a clean `upstream/main` checkout.

Infra counterparts: valkyriweb/lue-kube#1438 (merged), #1440 (open).