### PR TITLE
fix: preserve daemon ownership during CLI auto-start

### DIFF
--- a/cmd/pinchtab/cmd_server.go
+++ b/cmd/pinchtab/cmd_server.go
@@ -32,7 +32,7 @@ var serverCmd = &cobra.Command{
 
 		bind, _ := cmd.Flags().GetString("bind")
 		port, _ := cmd.Flags().GetString("port")
-		applyServerAddressFlags(cfg, bind, port)
+		addressChanged := detachedAddressChanged(cfg, bind, port)
 
 		yolo, _ := cmd.Flags().GetBool("yolo")
 		if yolo {
@@ -79,7 +79,7 @@ var serverCmd = &cobra.Command{
 				Browser:    browserName,
 				Bind:       bind,
 				Port:       port,
-			}); err != nil {
+			}, addressChanged); err != nil {
 				fmt.Fprintln(os.Stderr, cli.StyleStderr(cli.ErrorStyle, err.Error()))
 				os.Exit(1)
 			}
@@ -99,6 +99,12 @@ func applyServerAddressFlags(cfg *config.RuntimeConfig, bind, port string) {
 	if v := strings.TrimSpace(port); v != "" {
 		cfg.Port = v
 	}
+}
+
+func detachedAddressChanged(cfg *config.RuntimeConfig, bind, port string) bool {
+	daemonBind, daemonPort := cfg.Bind, cfg.Port
+	applyServerAddressFlags(cfg, bind, port)
+	return cfg.Bind != daemonBind || cfg.Port != daemonPort
 }
 
 // resolveLogLevel settles a run's threshold from the only inputs that carry it, in

--- a/cmd/pinchtab/cmd_server_background.go
+++ b/cmd/pinchtab/cmd_server_background.go
@@ -82,12 +82,8 @@ func detachedDaemonOwnership() (bool, error) {
 	return installed, nil
 }
 
-func (o serverBackgroundOptions) addressOverridden() bool {
-	return strings.TrimSpace(o.Bind) != "" || strings.TrimSpace(o.Port) != ""
-}
-
-func requireDetachedServerOwnership(action string, addressOverridden bool) error {
-	if addressOverridden {
+func requireDetachedServerOwnership(action string, addressChanged bool) error {
+	if addressChanged {
 		return nil
 	}
 	installed, err := detachedDaemonOwnership()
@@ -95,7 +91,7 @@ func requireDetachedServerOwnership(action string, addressOverridden bool) error
 		return fmt.Errorf("cannot determine background-service ownership; refusing %s: %w", action, err)
 	}
 	if installed {
-		return fmt.Errorf("background service is installed; use `pinchtab daemon start` so one service manager owns the server, or pass --bind/--port to run a separate detached server")
+		return fmt.Errorf("background service is installed; use `pinchtab daemon start` so one service manager owns the server, or pass --bind/--port with a different address to run a separate detached server")
 	}
 	return nil
 }
@@ -115,7 +111,7 @@ func runServerRestart(cfg *config.RuntimeConfig) error {
 		}
 	}
 	fmt.Println("Starting server...")
-	return runServerBackground(cfg, serverBackgroundOptions{})
+	return runServerBackground(cfg, serverBackgroundOptions{}, false)
 }
 
 func stateDirForConfig(cfg *config.RuntimeConfig) string {
@@ -167,8 +163,8 @@ func spawnDetachedChild(binary string, args []string, out *os.File) (int, error)
 	return pid, nil
 }
 
-func runServerBackground(cfg *config.RuntimeConfig, opts serverBackgroundOptions) error {
-	if err := requireDetachedServerOwnership("background start", opts.addressOverridden()); err != nil {
+func runServerBackground(cfg *config.RuntimeConfig, opts serverBackgroundOptions, addressChanged bool) error {
+	if err := requireDetachedServerOwnership("background start", addressChanged); err != nil {
 		return err
 	}
 

--- a/cmd/pinchtab/cmd_server_background.go
+++ b/cmd/pinchtab/cmd_server_background.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -70,24 +71,37 @@ var serverRestartCmd = &cobra.Command{
 	},
 }
 
-// requireDetachedServerOwnership prevents the detached server launch paths from
-// competing with an installed service manager for the same configured port and
-// state directory. An installed daemon is the canonical owner; it is also
-// KeepAlive-managed, so callers should ask that manager to start it instead of
-// creating an orphaned background child.
-func requireDetachedServerOwnership(action string) error {
+func detachedDaemonOwnership() (bool, error) {
 	installed, err := daemonInstallationStatus()
+	if err != nil {
+		if errors.Is(err, daemon.ErrUnsupportedOS) {
+			return false, nil
+		}
+		return false, err
+	}
+	return installed, nil
+}
+
+func (o serverBackgroundOptions) addressOverridden() bool {
+	return strings.TrimSpace(o.Bind) != "" || strings.TrimSpace(o.Port) != ""
+}
+
+func requireDetachedServerOwnership(action string, addressOverridden bool) error {
+	if addressOverridden {
+		return nil
+	}
+	installed, err := detachedDaemonOwnership()
 	if err != nil {
 		return fmt.Errorf("cannot determine background-service ownership; refusing %s: %w", action, err)
 	}
 	if installed {
-		return fmt.Errorf("background service is installed; use `pinchtab daemon start` so one service manager owns the server")
+		return fmt.Errorf("background service is installed; use `pinchtab daemon start` so one service manager owns the server, or pass --bind/--port to run a separate detached server")
 	}
 	return nil
 }
 
 func runServerRestart(cfg *config.RuntimeConfig) error {
-	installed, err := daemonInstallationStatus()
+	installed, err := detachedDaemonOwnership()
 	if err != nil {
 		return fmt.Errorf("cannot determine background-service ownership; refusing restart: %w", err)
 	}
@@ -154,7 +168,7 @@ func spawnDetachedChild(binary string, args []string, out *os.File) (int, error)
 }
 
 func runServerBackground(cfg *config.RuntimeConfig, opts serverBackgroundOptions) error {
-	if err := requireDetachedServerOwnership("background start"); err != nil {
+	if err := requireDetachedServerOwnership("background start", opts.addressOverridden()); err != nil {
 		return err
 	}
 

--- a/cmd/pinchtab/cmd_server_background.go
+++ b/cmd/pinchtab/cmd_server_background.go
@@ -70,6 +70,22 @@ var serverRestartCmd = &cobra.Command{
 	},
 }
 
+// requireDetachedServerOwnership prevents the detached server launch paths from
+// competing with an installed service manager for the same configured port and
+// state directory. An installed daemon is the canonical owner; it is also
+// KeepAlive-managed, so callers should ask that manager to start it instead of
+// creating an orphaned background child.
+func requireDetachedServerOwnership(action string) error {
+	installed, err := daemonInstallationStatus()
+	if err != nil {
+		return fmt.Errorf("cannot determine background-service ownership; refusing %s: %w", action, err)
+	}
+	if installed {
+		return fmt.Errorf("background service is installed; use `pinchtab daemon start` so one service manager owns the server")
+	}
+	return nil
+}
+
 func runServerRestart(cfg *config.RuntimeConfig) error {
 	installed, err := daemonInstallationStatus()
 	if err != nil {
@@ -138,6 +154,10 @@ func spawnDetachedChild(binary string, args []string, out *os.File) (int, error)
 }
 
 func runServerBackground(cfg *config.RuntimeConfig, opts serverBackgroundOptions) error {
+	if err := requireDetachedServerOwnership("background start"); err != nil {
+		return err
+	}
+
 	stateDir := stateDirForConfig(cfg)
 	if info, ok := readServerPID(stateDir); ok {
 		if processAlive(info.PID) {

--- a/cmd/pinchtab/cmd_server_background_test.go
+++ b/cmd/pinchtab/cmd_server_background_test.go
@@ -14,6 +14,44 @@ import (
 	"github.com/pinchtab/pinchtab/internal/server"
 )
 
+func TestDetachedServerStartsRefuseInstalledOrUnknownServiceOwnership(t *testing.T) {
+	original := daemonInstallationStatus
+	defer func() { daemonInstallationStatus = original }()
+
+	tests := []struct {
+		name      string
+		installed bool
+		err       error
+		start     func() error
+		want      string
+	}{
+		{
+			name: "background installed", installed: true,
+			start: func() error { return runServerBackground(&config.RuntimeConfig{}, serverBackgroundOptions{}) },
+			want:  "pinchtab daemon start",
+		},
+		{
+			name: "automatic installed", installed: true,
+			start: autoStartServer,
+			want:  "pinchtab daemon start",
+		},
+		{
+			name: "automatic unknown", err: errors.New("service path unreadable"),
+			start: autoStartServer,
+			want:  "refusing automatic start",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			daemonInstallationStatus = func() (bool, error) { return tt.installed, tt.err }
+			err := tt.start()
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("detached start error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
 func TestServerRestartRefusesInstalledOrUnknownServiceOwnership(t *testing.T) {
 	original := daemonInstallationStatus
 	defer func() { daemonInstallationStatus = original }()

--- a/cmd/pinchtab/cmd_server_background_test.go
+++ b/cmd/pinchtab/cmd_server_background_test.go
@@ -39,37 +39,42 @@ func TestDetachedDaemonOwnershipTreatsUnsupportedOSAsNotInstalled(t *testing.T) 
 	}
 }
 
-func TestServerBackgroundOptionsAddressOverridden(t *testing.T) {
+func TestDetachedAddressChanged(t *testing.T) {
 	cases := []struct {
-		name string
-		opts serverBackgroundOptions
-		want bool
+		name       string
+		bind, port string
+		flagBind   string
+		flagPort   string
+		want       bool
 	}{
-		{"default", serverBackgroundOptions{}, false},
-		{"port", serverBackgroundOptions{Port: "9880"}, true},
-		{"bind", serverBackgroundOptions{Bind: "0.0.0.0"}, true},
-		{"blank", serverBackgroundOptions{Bind: "  ", Port: "  "}, false},
+		{"no flags", "127.0.0.1", "9867", "", "", false},
+		{"port equals default", "127.0.0.1", "9867", "", "9867", false},
+		{"bind equals default", "127.0.0.1", "9867", "127.0.0.1", "", false},
+		{"blank flags", "127.0.0.1", "9867", "  ", "  ", false},
+		{"port differs", "127.0.0.1", "9867", "", "5000", true},
+		{"bind differs", "127.0.0.1", "9867", "0.0.0.0", "", true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := tc.opts.addressOverridden(); got != tc.want {
-				t.Fatalf("addressOverridden() = %v, want %v", got, tc.want)
+			cfg := &config.RuntimeConfig{Bind: tc.bind, Port: tc.port}
+			if got := detachedAddressChanged(cfg, tc.flagBind, tc.flagPort); got != tc.want {
+				t.Fatalf("detachedAddressChanged() = %v, want %v", got, tc.want)
 			}
 		})
 	}
 }
 
-func TestRequireDetachedServerOwnershipAllowsAddressOverride(t *testing.T) {
+func TestRequireDetachedServerOwnershipAllowsChangedAddress(t *testing.T) {
 	original := daemonInstallationStatus
 	defer func() { daemonInstallationStatus = original }()
 	daemonInstallationStatus = func() (bool, error) { return true, nil }
 
 	if err := requireDetachedServerOwnership("background start", true); err != nil {
-		t.Fatalf("an explicit address override must bypass the ownership gate, got %v", err)
+		t.Fatalf("a genuinely different address must bypass the ownership gate, got %v", err)
 	}
 	err := requireDetachedServerOwnership("background start", false)
 	if err == nil || !strings.Contains(err.Error(), "pinchtab daemon start") {
-		t.Fatalf("default address must still defer to the installed daemon, got %v", err)
+		t.Fatalf("the daemon-owned address must still defer to the installed daemon, got %v", err)
 	}
 }
 
@@ -98,7 +103,7 @@ func TestDetachedServerStartsRefuseInstalledOrUnknownServiceOwnership(t *testing
 	}{
 		{
 			name: "background installed", installed: true,
-			start: func() error { return runServerBackground(&config.RuntimeConfig{}, serverBackgroundOptions{}) },
+			start: func() error { return runServerBackground(&config.RuntimeConfig{}, serverBackgroundOptions{}, false) },
 			want:  "pinchtab daemon start",
 		},
 		{

--- a/cmd/pinchtab/cmd_server_background_test.go
+++ b/cmd/pinchtab/cmd_server_background_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -11,8 +12,78 @@ import (
 	"testing"
 
 	"github.com/pinchtab/pinchtab/internal/config"
+	"github.com/pinchtab/pinchtab/internal/daemon"
 	"github.com/pinchtab/pinchtab/internal/server"
 )
+
+func TestDetachedDaemonOwnershipTreatsUnsupportedOSAsNotInstalled(t *testing.T) {
+	original := daemonInstallationStatus
+	defer func() { daemonInstallationStatus = original }()
+
+	daemonInstallationStatus = func() (bool, error) {
+		return false, fmt.Errorf("resolve manager: %w", daemon.ErrUnsupportedOS)
+	}
+	installed, err := detachedDaemonOwnership()
+	if err != nil {
+		t.Fatalf("unsupported OS must not be an ownership error, got %v", err)
+	}
+	if installed {
+		t.Fatal("a daemon cannot own the server on an OS that cannot host one")
+	}
+
+	daemonInstallationStatus = func() (bool, error) {
+		return false, errors.New("service path unreadable")
+	}
+	if _, err := detachedDaemonOwnership(); err == nil {
+		t.Fatal("a genuine ownership error must still propagate")
+	}
+}
+
+func TestServerBackgroundOptionsAddressOverridden(t *testing.T) {
+	cases := []struct {
+		name string
+		opts serverBackgroundOptions
+		want bool
+	}{
+		{"default", serverBackgroundOptions{}, false},
+		{"port", serverBackgroundOptions{Port: "9880"}, true},
+		{"bind", serverBackgroundOptions{Bind: "0.0.0.0"}, true},
+		{"blank", serverBackgroundOptions{Bind: "  ", Port: "  "}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.opts.addressOverridden(); got != tc.want {
+				t.Fatalf("addressOverridden() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRequireDetachedServerOwnershipAllowsAddressOverride(t *testing.T) {
+	original := daemonInstallationStatus
+	defer func() { daemonInstallationStatus = original }()
+	daemonInstallationStatus = func() (bool, error) { return true, nil }
+
+	if err := requireDetachedServerOwnership("background start", true); err != nil {
+		t.Fatalf("an explicit address override must bypass the ownership gate, got %v", err)
+	}
+	err := requireDetachedServerOwnership("background start", false)
+	if err == nil || !strings.Contains(err.Error(), "pinchtab daemon start") {
+		t.Fatalf("default address must still defer to the installed daemon, got %v", err)
+	}
+}
+
+func TestRequireDetachedServerOwnershipAllowsUnsupportedOS(t *testing.T) {
+	original := daemonInstallationStatus
+	defer func() { daemonInstallationStatus = original }()
+	daemonInstallationStatus = func() (bool, error) {
+		return false, fmt.Errorf("resolve manager: %w", daemon.ErrUnsupportedOS)
+	}
+
+	if err := requireDetachedServerOwnership("automatic start", false); err != nil {
+		t.Fatalf("auto-start on an OS without daemon support must be allowed, got %v", err)
+	}
+}
 
 func TestDetachedServerStartsRefuseInstalledOrUnknownServiceOwnership(t *testing.T) {
 	original := daemonInstallationStatus

--- a/cmd/pinchtab/cmd_server_ensure.go
+++ b/cmd/pinchtab/cmd_server_ensure.go
@@ -23,7 +23,7 @@ func ensureServerForCLI(cfg *config.RuntimeConfig, baseURL, token, command strin
 		baseURL, token, command,
 		canAutoStartServerForCLI(cfg, baseURL),
 		autoStartServer, probeServerHealth,
-		daemonInstallationStatus, startInstalledDaemon,
+		detachedDaemonOwnership, startInstalledDaemon,
 		ensureServerTimeout,
 	)
 }
@@ -140,7 +140,7 @@ func isServerHealthy(baseURL, token string) bool {
 }
 
 func autoStartServer() error {
-	if err := requireDetachedServerOwnership("automatic start"); err != nil {
+	if err := requireDetachedServerOwnership("automatic start", false); err != nil {
 		return err
 	}
 

--- a/cmd/pinchtab/cmd_server_ensure.go
+++ b/cmd/pinchtab/cmd_server_ensure.go
@@ -19,7 +19,64 @@ type serverHealthFunc func(baseURL, token string) bool
 type serverProbeFunc func(baseURL, token string) server.HealthProbe
 
 func ensureServerForCLI(cfg *config.RuntimeConfig, baseURL, token, command string) error {
-	return ensureServerWithAutoStart(baseURL, token, command, canAutoStartServerForCLI(cfg, baseURL), autoStartServer, probeServerHealth, ensureServerTimeout)
+	return ensureServerWithDaemonRecovery(
+		baseURL, token, command,
+		canAutoStartServerForCLI(cfg, baseURL),
+		autoStartServer, probeServerHealth,
+		daemonInstallationStatus, startInstalledDaemon,
+		ensureServerTimeout,
+	)
+}
+
+// startInstalledDaemon asks the installed service manager to recover the
+// daemon. It is intentionally separate from autoStartServer: only the service
+// manager may create a server when it owns the lifecycle.
+func startInstalledDaemon() (string, error) {
+	manager, err := daemonCurrentManager()
+	if err != nil {
+		return "", fmt.Errorf("access background service manager: %w", err)
+	}
+	return manager.Start()
+}
+
+// ensureServerWithDaemonRecovery preserves CLI cold-start ergonomics without
+// allowing a detached child to compete with an installed daemon. A healthy
+// daemon needs no action; an unreachable installed daemon is started through
+// its manager and given the normal bounded readiness wait. A reachable-but-
+// unhealthy listener is never restarted implicitly because it may be a rogue
+// child holding the daemon port.
+func ensureServerWithDaemonRecovery(baseURL, token, command string, allowAutoStart bool, startDetached serverStartFunc, probe serverProbeFunc, ownership func() (bool, error), startDaemon func() (string, error), timeout time.Duration) error {
+	initial := probe(baseURL, token)
+	if serverProbeHealthy(initial) {
+		return nil
+	}
+	if !allowAutoStart {
+		if initial.Reachable {
+			return fmt.Errorf("server at %s is running but unhealthy: %s", baseURL, unhealthyServerDetail(initial))
+		}
+		return fmt.Errorf("server at %s is not running; auto-start is only supported for the default local server", baseURL)
+	}
+
+	installed, err := ownership()
+	if err != nil {
+		return fmt.Errorf("cannot determine background-service ownership; refusing automatic start: %w", err)
+	}
+	if installed {
+		if initial.Reachable {
+			return fmt.Errorf("server at %s is running but unhealthy: %s; an installed PinchTab daemon owns lifecycle, so refusing detached auto-start. Check `pinchtab daemon status` and the port owner", baseURL, unhealthyServerDetail(initial))
+		}
+		message, err := startDaemon()
+		if err != nil {
+			return fmt.Errorf("installed PinchTab daemon owns lifecycle, but could not start it: %w; refusing detached auto-start", err)
+		}
+		ready := func(url, tok string) bool { return serverProbeHealthy(probe(url, tok)) }
+		if !waitForServerWith(baseURL, token, timeout, ready) {
+			return fmt.Errorf("installed PinchTab daemon was asked to start (%s), but server did not become healthy at %s within %s; a stale or rogue listener may own the port. Run `pinchtab daemon status` and inspect the port owner; refusing detached auto-start", message, baseURL, timeout)
+		}
+		return nil
+	}
+
+	return ensureServerWithAutoStart(baseURL, token, command, true, startDetached, probe, timeout)
 }
 
 func ensureServerWith(baseURL, token, command string, start serverStartFunc, probe serverProbeFunc, timeout time.Duration) error {
@@ -83,6 +140,10 @@ func isServerHealthy(baseURL, token string) bool {
 }
 
 func autoStartServer() error {
+	if err := requireDetachedServerOwnership("automatic start"); err != nil {
+		return err
+	}
+
 	stateDir := stateDirForConfig(loadConfig())
 	binary, marker, err := prepareServerSpawn()
 	if err != nil {

--- a/cmd/pinchtab/cmd_server_ensure_test.go
+++ b/cmd/pinchtab/cmd_server_ensure_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"net/http"
 	"strings"
 	"testing"
@@ -117,6 +118,96 @@ func TestEnsureServer_UnreachableStillAutoStarts(t *testing.T) {
 	if probes < 2 {
 		t.Errorf("health probes = %d, want the post-start readiness poll too", probes)
 	}
+}
+
+func TestEnsureServerWithDaemonRecoveryOwnsInstalledDaemonLifecycle(t *testing.T) {
+	t.Run("installed healthy", func(t *testing.T) {
+		ownershipCalled := false
+		daemonStarted := false
+		detachedStarted := false
+		err := ensureServerWithDaemonRecovery(
+			"http://127.0.0.1:9867", "", "nav", true,
+			func() error { detachedStarted = true; return nil },
+			func(string, string) server.HealthProbe {
+				return server.HealthProbe{Reachable: true, StatusCode: http.StatusOK}
+			},
+			func() (bool, error) { ownershipCalled = true; return true, nil },
+			func() (string, error) { daemonStarted = true; return "started", nil },
+			time.Second,
+		)
+		if err != nil {
+			t.Fatalf("ensureServerWithDaemonRecovery() error = %v", err)
+		}
+		if ownershipCalled || daemonStarted || detachedStarted {
+			t.Fatalf("healthy installed daemon should be left alone: ownership=%t daemon=%t detached=%t", ownershipCalled, daemonStarted, detachedStarted)
+		}
+	})
+
+	t.Run("installed unloaded starts through manager", func(t *testing.T) {
+		daemonStarted := false
+		detachedStarted := false
+		probes := 0
+		err := ensureServerWithDaemonRecovery(
+			"http://127.0.0.1:9867", "", "nav", true,
+			func() error { detachedStarted = true; return nil },
+			func(string, string) server.HealthProbe {
+				probes++
+				if daemonStarted {
+					return server.HealthProbe{Reachable: true, StatusCode: http.StatusOK}
+				}
+				return server.HealthProbe{}
+			},
+			func() (bool, error) { return true, nil },
+			func() (string, error) { daemonStarted = true; return "Pinchtab daemon started.", nil },
+			time.Second,
+		)
+		if err != nil {
+			t.Fatalf("ensureServerWithDaemonRecovery() error = %v", err)
+		}
+		if !daemonStarted || detachedStarted || probes < 2 {
+			t.Fatalf("expected bounded daemon recovery only: daemon=%t detached=%t probes=%d", daemonStarted, detachedStarted, probes)
+		}
+	})
+
+	t.Run("installed wedged listener refuses detached fallback", func(t *testing.T) {
+		daemonStarted := false
+		detachedStarted := false
+		err := ensureServerWithDaemonRecovery(
+			"http://127.0.0.1:9867", "", "nav", true,
+			func() error { detachedStarted = true; return nil },
+			func(string, string) server.HealthProbe {
+				return unhealthyProbe(`{"reason":"browser stuck","status":"error"}`)
+			},
+			func() (bool, error) { return true, nil },
+			func() (string, error) { daemonStarted = true; return "started", nil },
+			time.Second,
+		)
+		if err == nil || !strings.Contains(err.Error(), "installed PinchTab daemon owns lifecycle") || !strings.Contains(err.Error(), "port owner") {
+			t.Fatalf("wedged installed daemon error = %v", err)
+		}
+		if daemonStarted || detachedStarted {
+			t.Fatalf("wedged listener must not be restarted or replaced implicitly: daemon=%t detached=%t", daemonStarted, detachedStarted)
+		}
+	})
+
+	t.Run("unknown ownership refuses detached fallback", func(t *testing.T) {
+		daemonStarted := false
+		detachedStarted := false
+		err := ensureServerWithDaemonRecovery(
+			"http://127.0.0.1:9867", "", "nav", true,
+			func() error { detachedStarted = true; return nil },
+			func(string, string) server.HealthProbe { return server.HealthProbe{} },
+			func() (bool, error) { return false, errors.New("service path unreadable") },
+			func() (string, error) { daemonStarted = true; return "started", nil },
+			time.Second,
+		)
+		if err == nil || !strings.Contains(err.Error(), "cannot determine background-service ownership") {
+			t.Fatalf("unknown ownership error = %v", err)
+		}
+		if daemonStarted || detachedStarted {
+			t.Fatalf("unknown ownership must not start anything: daemon=%t detached=%t", daemonStarted, detachedStarted)
+		}
+	})
 }
 
 func TestEnsureServer_ReadinessWaitTreatsUnhealthyAsNotReadyYet(t *testing.T) {

--- a/cmd/pinchtab/cmd_server_ensure_test.go
+++ b/cmd/pinchtab/cmd_server_ensure_test.go
@@ -190,6 +190,30 @@ func TestEnsureServerWithDaemonRecoveryOwnsInstalledDaemonLifecycle(t *testing.T
 		}
 	})
 
+	t.Run("not installed auto-starts detached", func(t *testing.T) {
+		daemonStarted := false
+		detachedStarted := false
+		err := ensureServerWithDaemonRecovery(
+			"http://127.0.0.1:9867", "", "nav", true,
+			func() error { detachedStarted = true; return nil },
+			func(string, string) server.HealthProbe {
+				if detachedStarted {
+					return server.HealthProbe{Reachable: true, StatusCode: http.StatusOK}
+				}
+				return server.HealthProbe{}
+			},
+			func() (bool, error) { return false, nil },
+			func() (string, error) { daemonStarted = true; return "started", nil },
+			time.Second,
+		)
+		if err != nil {
+			t.Fatalf("ensureServerWithDaemonRecovery() error = %v", err)
+		}
+		if !detachedStarted || daemonStarted {
+			t.Fatalf("no installed daemon must cold-start a detached server: detached=%t daemon=%t", detachedStarted, daemonStarted)
+		}
+	})
+
 	t.Run("unknown ownership refuses detached fallback", func(t *testing.T) {
 		daemonStarted := false
 		detachedStarted := false

--- a/internal/daemon/manager.go
+++ b/internal/daemon/manager.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -14,6 +15,10 @@ const (
 	pinchtabDaemonUnitName = "pinchtab.service"
 	pinchtabLaunchdLabel   = "com.pinchtab.pinchtab"
 )
+
+var ErrUnsupportedOS = errors.New("pinchtab daemon is supported on macOS and Linux only")
+
+var runtimeGOOS = runtime.GOOS
 
 type Manager interface {
 	Preflight() error
@@ -111,7 +116,7 @@ func currentEnvironment() (environment, error) {
 	return environment{
 		execPath:      execPath,
 		homeDir:       homeDir,
-		osName:        runtime.GOOS,
+		osName:        runtimeGOOS,
 		userID:        currentUser.Uid,
 		xdgConfigHome: os.Getenv("XDG_CONFIG_HOME"),
 	}, nil
@@ -124,7 +129,7 @@ func newManager(env environment, runner commandRunner) (Manager, error) {
 	case "darwin":
 		return &launchdManager{env: env, runner: runner}, nil
 	default:
-		return nil, fmt.Errorf("pinchtab daemon is supported on macOS and Linux; current OS is %s", env.osName)
+		return nil, fmt.Errorf("%w; current OS is %s", ErrUnsupportedOS, env.osName)
 	}
 }
 

--- a/internal/daemon/manager_test.go
+++ b/internal/daemon/manager_test.go
@@ -1,11 +1,28 @@
 package daemon
 
-import "testing"
+import (
+	"errors"
+	"testing"
+)
 
 func TestNewManagerRejectsUnsupportedOS(t *testing.T) {
 	_, err := newManager(environment{osName: "windows"}, &fakeCommandRunner{})
-	if err == nil {
-		t.Fatal("expected unsupported OS error")
+	if !errors.Is(err, ErrUnsupportedOS) {
+		t.Fatalf("newManager on unsupported OS = %v, want ErrUnsupportedOS", err)
+	}
+}
+
+func TestInstallationStatusUnsupportedOSSurfacesErrUnsupportedOS(t *testing.T) {
+	original := runtimeGOOS
+	defer func() { runtimeGOOS = original }()
+	runtimeGOOS = "windows"
+
+	installed, err := InstallationStatus()
+	if !errors.Is(err, ErrUnsupportedOS) {
+		t.Fatalf("InstallationStatus on unsupported OS = %v, want ErrUnsupportedOS", err)
+	}
+	if installed {
+		t.Fatal("daemon cannot be installed on an unsupported OS")
 	}
 }
 


### PR DESCRIPTION
## Summary
- refuse detached server starts when a PinchTab daemon is installed or ownership cannot be verified
- recover an installed-but-unreachable daemon through its service manager, then use the existing bounded health wait
- return a precise no-detached-fallback error for reachable unhealthy/rogue listeners

## Verification
- `go test ./cmd/pinchtab -count=1`
- `go test ./internal/daemon ./internal/server ./internal/orchestrator -count=1`
- `go vet ./cmd/pinchtab ./internal/daemon ./internal/server ./internal/orchestrator`
- independent Codex review (clean; artifacts retained locally)

## Behavior matrix
- installed + healthy: no-op
- installed + unloaded: daemon-manager start + bounded readiness wait
- installed + reachable unhealthy/rogue listener: actionable error, never detached spawn
- ownership unknown: fail closed, never detached spawn

This PR does not modify deployment configuration or existing browser profiles.