### PR TITLE
fix: reap orphan tab targets at browser launch, not on the create path

### DIFF
--- a/internal/bridge/tab_budget.go
+++ b/internal/bridge/tab_budget.go
@@ -1,0 +1,99 @@
+package bridge
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	cdp "github.com/chromedp/cdproto/cdp"
+	"github.com/chromedp/cdproto/target"
+	"github.com/chromedp/chromedp"
+)
+
+func (tm *TabManager) trackedCDPIDs() map[string]bool {
+	tm.mu.RLock()
+	defer tm.mu.RUnlock()
+	out := make(map[string]bool, len(tm.tabs))
+	for _, entry := range tm.tabs {
+		if entry != nil && entry.CDPID != "" {
+			out[entry.CDPID] = true
+		}
+	}
+	return out
+}
+
+func selectOrphanTargets(tracked map[string]bool, pages []*target.Info, limit int) []target.ID {
+	orphans := make([]target.ID, 0)
+	for i := len(pages) - 1; i >= 0; i-- {
+		t := pages[i]
+		if t == nil || t.Type != TargetTypePage {
+			continue
+		}
+		if tracked[string(t.TargetID)] {
+			continue
+		}
+		orphans = append(orphans, t.TargetID)
+		if limit > 0 && len(orphans) >= limit {
+			break
+		}
+	}
+	return orphans
+}
+
+func (tm *TabManager) closeTarget(id target.ID) bool {
+	closeCtx, cancel := context.WithTimeout(tm.browserCtx, 5*time.Second)
+	defer cancel()
+	c := chromedp.FromContext(closeCtx)
+	if c == nil || c.Browser == nil {
+		return false
+	}
+	if err := target.CloseTarget(id).Do(cdp.WithExecutor(closeCtx, c.Browser)); err != nil {
+		slog.Debug("tab budget: orphan close failed", "targetId", id, "err", err)
+		return false
+	}
+	return true
+}
+
+func (tm *TabManager) reconcileTabBudget() {
+	if tm == nil || tm.config == nil || tm.config.MaxTabs <= 0 || tm.browserCtx == nil {
+		return
+	}
+
+	pages, err := tm.ListTargets()
+	if err != nil {
+		slog.Debug("tab budget: launch reconcile skipped", "err", err)
+		return
+	}
+	if len(pages) <= tm.config.MaxTabs {
+		return
+	}
+
+	orphans := selectOrphanTargets(tm.trackedCDPIDs(), pages, len(pages)-tm.config.MaxTabs)
+	closed := 0
+	for _, id := range orphans {
+		if !tm.closeTarget(id) {
+			continue
+		}
+		closed++
+	}
+	if closed == 0 {
+		return
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	live := len(pages)
+	for {
+		remaining, err := tm.ListTargets()
+		if err != nil {
+			break
+		}
+		live = len(remaining)
+		if live <= tm.config.MaxTabs || time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+
+	slog.Info("tab budget: reaped untracked targets on browser launch",
+		"closed", closed, "live", live, "maxTabs", tm.config.MaxTabs)
+}

--- a/internal/bridge/tab_budget_integration_test.go
+++ b/internal/bridge/tab_budget_integration_test.go
@@ -1,0 +1,91 @@
+package bridge
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/chromedp/cdproto/target"
+	"github.com/chromedp/chromedp"
+	"github.com/pinchtab/pinchtab/internal/config"
+	"github.com/pinchtab/pinchtab/internal/testbrowser"
+)
+
+func TestReconcileTabBudgetBoundsUntrackedTargets(t *testing.T) {
+	chromePath := testbrowser.Path(t)
+	profile := testbrowser.ProfileDir(t)
+	alloc, cancelAlloc := chromedp.NewExecAllocator(context.Background(), append(
+		chromedp.DefaultExecAllocatorOptions[:],
+		chromedp.ExecPath(chromePath),
+		chromedp.UserDataDir(profile),
+		chromedp.Flag("headless", true),
+		chromedp.Flag("no-sandbox", true),
+	)...)
+	ctx, cancel := chromedp.NewContext(alloc)
+	ctx, cancelTimeout := context.WithTimeout(ctx, 30*time.Second)
+	t.Cleanup(func() {
+		cancelTimeout()
+		cancel()
+		cancelAlloc()
+		_ = os.RemoveAll(profile)
+	})
+
+	if err := chromedp.Run(ctx, chromedp.Navigate("about:blank")); err != nil {
+		t.Fatalf("start browser: %v", err)
+	}
+
+	const maxTabs = 3
+	tm := NewTabManager(ctx, &config.RuntimeConfig{
+		MaxTabs:           maxTabs,
+		TabEvictionPolicy: "close_lru",
+	}, nil, nil, nil)
+
+	exec, err := browserExecutorContext(ctx)
+	if err != nil {
+		t.Fatalf("browser executor: %v", err)
+	}
+
+	var firstCreated target.ID
+	for i := 0; i < 6; i++ {
+		id, err := target.CreateTarget("about:blank").Do(exec)
+		if err != nil {
+			t.Fatalf("create untracked target %d: %v", i, err)
+		}
+		if i == 0 {
+			firstCreated = id
+		}
+	}
+
+	tm.mu.Lock()
+	tm.tabs["managed"] = &TabEntry{CDPID: string(firstCreated)}
+	tm.mu.Unlock()
+
+	before, err := tm.ListTargets()
+	if err != nil {
+		t.Fatalf("list targets: %v", err)
+	}
+	if len(before) <= maxTabs {
+		t.Fatalf("precondition: expected more than %d page targets before reconcile, got %d", maxTabs, len(before))
+	}
+
+	tm.reconcileTabBudget()
+
+	after, err := tm.ListTargets()
+	if err != nil {
+		t.Fatalf("list targets after reconcile: %v", err)
+	}
+	if len(after) > maxTabs {
+		t.Fatalf("reconcile did not bound live page targets to MaxTabs: got %d, want <= %d", len(after), maxTabs)
+	}
+
+	survived := false
+	for _, tg := range after {
+		if tg.TargetID == firstCreated {
+			survived = true
+		}
+	}
+	if !survived {
+		t.Fatalf("reconcile reaped the tracked/managed target %s", firstCreated)
+	}
+}

--- a/internal/bridge/tab_budget_test.go
+++ b/internal/bridge/tab_budget_test.go
@@ -1,0 +1,73 @@
+package bridge
+
+import (
+	"testing"
+
+	"github.com/chromedp/cdproto/target"
+)
+
+func pageTarget(id string) *target.Info {
+	return &target.Info{TargetID: target.ID(id), Type: TargetTypePage}
+}
+
+func TestSelectOrphanTargets_PicksUntrackedOldestFirst(t *testing.T) {
+	tracked := map[string]bool{"t-managed": true}
+	pages := []*target.Info{pageTarget("t-new"), pageTarget("t-managed"), pageTarget("t-old")}
+
+	got := selectOrphanTargets(tracked, pages, 0)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 orphans, got %d (%v)", len(got), got)
+	}
+	if got[0] != target.ID("t-old") {
+		t.Fatalf("expected oldest orphan first, got %v", got)
+	}
+	for _, id := range got {
+		if id == target.ID("t-managed") {
+			t.Fatal("a tracked target must never be reaped as an orphan")
+		}
+	}
+}
+
+func TestSelectOrphanTargets_RespectsLimit(t *testing.T) {
+	pages := []*target.Info{pageTarget("a"), pageTarget("b"), pageTarget("c")}
+	got := selectOrphanTargets(map[string]bool{}, pages, 2)
+	if len(got) != 2 {
+		t.Fatalf("expected limit of 2, got %d", len(got))
+	}
+}
+
+func TestSelectOrphanTargets_LimitSparesNewest(t *testing.T) {
+	pages := []*target.Info{pageTarget("in-flight"), pageTarget("mid"), pageTarget("oldest")}
+	got := selectOrphanTargets(map[string]bool{}, pages, 1)
+	if len(got) != 1 || got[0] != target.ID("oldest") {
+		t.Fatalf("expected only the oldest target, got %v", got)
+	}
+	for _, id := range got {
+		if id == target.ID("in-flight") {
+			t.Fatal("a bounded reconcile must not reap the newest (in-flight) target")
+		}
+	}
+}
+
+func TestSelectOrphanTargets_IgnoresNonPageTargets(t *testing.T) {
+	pages := []*target.Info{
+		{TargetID: target.ID("worker"), Type: "service_worker"},
+		nil,
+		pageTarget("page"),
+	}
+	got := selectOrphanTargets(map[string]bool{}, pages, 0)
+	if len(got) != 1 || got[0] != target.ID("page") {
+		t.Fatalf("expected only the page target, got %v", got)
+	}
+}
+
+func TestTrackedCDPIDs(t *testing.T) {
+	tm := &TabManager{tabs: map[string]*TabEntry{
+		"tab_1": {CDPID: "raw1"},
+		"tab_2": {CDPID: ""},
+	}}
+	got := tm.trackedCDPIDs()
+	if !got["raw1"] || len(got) != 1 {
+		t.Fatalf("unexpected tracked set: %v", got)
+	}
+}

--- a/internal/bridge/tab_popup_guard.go
+++ b/internal/bridge/tab_popup_guard.go
@@ -50,6 +50,8 @@ func (tm *TabManager) StartBrowserGuards() {
 		tm.mu.Lock()
 		tm.guardActive = true
 		tm.mu.Unlock()
+
+		tm.reconcileTabBudget()
 	})
 }
 

--- a/tests/e2e/scenarios/api/tab-budget-basic.sh
+++ b/tests/e2e/scenarios/api/tab-budget-basic.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+GROUP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${GROUP_DIR}/../../helpers/api.sh"
+
+start_test "tab budget: tab creation stays fast under fingerprint-rotate churn"
+
+URL="${FIXTURES_URL}/index.html"
+BODY="$(mktemp)"
+timeouts=0
+slow=0
+total_navs=0
+
+nav_once() {
+  local started dur
+  started=$(get_time_ms)
+  e2e_curl -s -o "$BODY" -w '%{http_code}' \
+    -X POST "${E2E_SERVER}/navigate" -H 'Content-Type: application/json' \
+    -d "{\"url\":\"${URL}\"}" >/dev/null
+  dur=$(($(get_time_ms) - started))
+  total_navs=$((total_navs + 1))
+  if grep -q 'did not open a new tab' "$BODY" 2>/dev/null; then
+    timeouts=$((timeouts + 1))
+  elif [ "$dur" -ge 8000 ]; then
+    slow=$((slow + 1))
+  fi
+}
+
+nav_once
+
+for round in 1 2 3; do
+  pt_post /fingerprint/rotate '{"os":"windows"}' >/dev/null 2>&1 || true
+  for n in 1 2 3 4 5 6; do nav_once; done
+done
+
+rm -f "$BODY"
+echo -e "  ${MUTED}navigations=${total_navs} create-timeouts=${timeouts} slow(>=8s)=${slow}${NC}"
+
+if [ "$timeouts" -eq 0 ]; then
+  pass_assert "no create-tab timeouts across ${total_navs} navigations"
+else
+  fail_assert "${timeouts}/${total_navs} navigations hit the 10s create-tab timeout"
+fi
+
+if [ "$slow" -eq 0 ]; then
+  pass_assert "no navigation stalled >= 8s"
+else
+  fail_assert "${slow}/${total_navs} navigations stalled >= 8s"
+fi
+
+end_test

--- a/tests/e2e/scenarios/manifest.json
+++ b/tests/e2e/scenarios/manifest.json
@@ -1,5 +1,12 @@
 {
   "scenarios": {
+    "api/tab-budget-basic.sh": {
+      "tags": [
+        "tabs",
+        "budget",
+        "pr"
+      ]
+    },
     "api/actions-basic.sh": {
       "tags": [
         "actions",


### PR DESCRIPTION
Supersedes #631.

## Summary
- Reap untracked orphan page targets once at browser launch instead of reconciling against Chrome on every `createTab` call.
- Keep the create-path tab budget focused on managed tabs, so normal tab creation stays fast.
- Add unit coverage, a bridge-level integration test, and a targeted API E2E scenario for tab creation under fingerprint-rotate churn.

## Why this approach instead of #631
- The real bug here is orphan page targets surviving across bridge/browser lifecycle boundaries and becoming invisible to the managed tab map.
- Solving that by querying and reconciling Chrome on the hot `createTab` path is too expensive: it serializes tab creation against `Target.getTargets` / `Target.closeTarget` exactly when the browser is under restart-style churn.
- This branch fixes the orphan leak at browser launch, where the bridge is freshly wired and reconciliation is cheap, instead of paying that price on every create.
- In practice that avoids the `create tab: browser did not open a new tab within 10s` failure mode that motivated the rethink.

## What changed
- Add `reconcileTabBudget()` to select the oldest untracked page targets and close only those.
- Run reconciliation once from `StartBrowserGuards()` after the browser connection is ready.
- Wait and re-list after close requests so the postcondition (`live <= maxTabs`) is actually true before the reconcile is considered done.
- Add unit tests for orphan selection, an integration test for the launch-time cap bound, and an API E2E scenario covering repeated navigate/fingerprint-rotate churn.

## Verification
- `go test ./internal/bridge -run TestReconcileTabBudgetBoundsUntrackedTargets -count=1`
- `go test ./internal/bridge`
