### PR TITLE
fix: keyboard-type humanize types into the focused element

### DIFF
--- a/internal/bridge/action_text.go
+++ b/internal/bridge/action_text.go
@@ -156,11 +156,13 @@ func (b *Bridge) actionHumanizedType(ctx context.Context, req ActionRequest) (ma
 		return nil, NewInvalidActionRequestError("need selector, ref, or nodeId")
 	}
 
-	actions := Type(req.Text, req.Fast)
-	if err := chromedp.Run(ctx, actions...); err != nil {
+	return b.humanizedTypeFocused(ctx, req)
+}
+
+func (b *Bridge) humanizedTypeFocused(ctx context.Context, req ActionRequest) (map[string]any, error) {
+	if err := chromedp.Run(ctx, Type(req.Text, req.Fast)...); err != nil {
 		return nil, err
 	}
-
 	result := textEntryResult("typed", req.Text)
 	result["human"] = true
 	return result, nil
@@ -177,6 +179,9 @@ func (b *Bridge) actionKeyboardType(ctx context.Context, req ActionRequest) (map
 	}
 
 	if b.effectiveHumanize(req) {
+		if req.Selector == "" && req.NodeID <= 0 {
+			return b.humanizedTypeFocused(ctx, req)
+		}
 		return b.actionHumanizedType(ctx, req)
 	}
 

--- a/tests/e2e/scenarios/api/keyboard-focus-basic.sh
+++ b/tests/e2e/scenarios/api/keyboard-focus-basic.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+GROUP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${GROUP_DIR}/../../helpers/api.sh"
+
+start_test "keyboard-type humanize types into the focused element (#633)"
+
+pt_post /navigate -d "{\"url\":\"${FIXTURES_URL}/form.html\"}"
+assert_ok "navigate to form fixture"
+
+pt_post /action -d '{"kind":"click","selector":"#username"}'
+assert_ok "focus the username input"
+
+pt_post /action -d '{"kind":"keyboard-type","text":"hello633","humanize":true}'
+assert_ok "humanized keyboard-type into the focused element (no selector)"
+
+pt_post /evaluate -d "{\"expression\":\"document.querySelector('#username').value\"}"
+assert_ok "read the focused input value"
+assert_result_eq '.result' 'hello633' 'humanized keyboard-type value persisted in the focused input'
+
+end_test

--- a/tests/e2e/scenarios/manifest.json
+++ b/tests/e2e/scenarios/manifest.json
@@ -1,5 +1,12 @@
 {
   "scenarios": {
+    "api/keyboard-focus-basic.sh": {
+      "tags": [
+        "keyboard",
+        "kbfocus",
+        "pr"
+      ]
+    },
     "api/tab-budget-basic.sh": {
       "tags": [
         "tabs",


### PR DESCRIPTION
Closes #633.

## Summary
- Restore the focused-element contract for `keyboard-type` when `humanize=true` and no selector/ref/nodeId is supplied.
- Reuse the already-focused typing path instead of forcing selector validation for this targetless keyboard case.
- Add a targeted API E2E scenario covering humanized `keyboard-type` into a focused input.

## Why
- Issue #633 reports that `pinchtab keyboard type <text>` and MCP `pinchtab_keyboard_type` started rejecting the focused-element flow with `need selector, ref, or nodeId`.
- `keyboard-type` is supposed to type into the currently focused element without requiring selector resolution.
- This change restores that behavior without widening the selector/node-targeted humanized type paths.

## Verification
- `go test ./internal/bridge`
