### PR TITLE
fix: match wait url pattern in Go instead of a browser-evaluated boolean

### DIFF
--- a/internal/handlers/wait.go
+++ b/internal/handlers/wait.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"regexp"
+	"strings"
 	"time"
 
 	"github.com/pinchtab/pinchtab/internal/activity"
@@ -198,7 +200,6 @@ func (h *Handlers) handleWaitCore(w http.ResponseWriter, r *http.Request, req wa
 		js = fmt.Sprintf(`!document.body || !document.body.innerText.includes(%s)`, jsonStr(req.NotText))
 		matchLabel = "!" + req.NotText
 	case "url":
-		js = buildURLMatchJS(req.URL)
 		matchLabel = req.URL
 	case "load":
 		canonical, ok := canonicalLoadState(req.Load)
@@ -222,6 +223,13 @@ func (h *Handlers) handleWaitCore(w http.ResponseWriter, r *http.Request, req wa
 	}
 
 	err = pollUntil(tCtx, pollInterval, func() (bool, error) {
+		if mode == "url" {
+			var href string
+			if evalErr := h.Bridge.Evaluate(tCtx, "window.location.href", &href, bridge.EvalOpts{}); evalErr != nil {
+				return false, nil
+			}
+			return matchURLPattern(req.URL, href), nil
+		}
 		var result bool
 		evalErr := h.Bridge.Evaluate(tCtx, js, &result, bridge.EvalOpts{})
 		return evalErr == nil && result, nil
@@ -340,20 +348,32 @@ func buildSelectorJS(sel, state string) (string, string) {
 	return js, sel
 }
 
-// buildURLMatchJS builds a JS expression that checks if the current URL matches a glob pattern.
-func buildURLMatchJS(pattern string) string {
-	// Convert glob to regex: ** → .*, * → [^/]*, ? → .
-	return fmt.Sprintf(`(function(){
-		var p = %s;
-		var u = window.location.href;
-		// Convert glob to regex
-		var re = p.replace(/[.+^${}()|[\\]\\\\]/g, '\\\\$&')
-		           .replace(/\\*\\*/g, '<<<DOUBLESTAR>>>')
-		           .replace(/\\*/g, '[^/]*')
-		           .replace(/<<<DOUBLESTAR>>>/g, '.*')
-		           .replace(/\\?/g, '.');
-		return new RegExp(re).test(u);
-	})()`, jsonStr(pattern))
+func matchURLPattern(pattern, url string) bool {
+	var b strings.Builder
+	for i := 0; i < len(pattern); i++ {
+		c := pattern[i]
+		switch c {
+		case '*':
+			if i+1 < len(pattern) && pattern[i+1] == '*' {
+				b.WriteString(".*")
+				i++
+				continue
+			}
+			b.WriteString("[^/]*")
+		case '?':
+			b.WriteByte('.')
+		case '.', '+', '^', '$', '{', '}', '(', ')', '|', '[', ']', '\\':
+			b.WriteByte('\\')
+			b.WriteByte(c)
+		default:
+			b.WriteByte(c)
+		}
+	}
+	re, err := regexp.Compile(b.String())
+	if err != nil {
+		return false
+	}
+	return re.MatchString(url)
 }
 
 func jsonStr(s string) string {

--- a/internal/handlers/wait_test.go
+++ b/internal/handlers/wait_test.go
@@ -451,10 +451,23 @@ func TestBuildSelectorJS_HiddenText(t *testing.T) {
 	}
 }
 
-func TestBuildURLMatchJS(t *testing.T) {
-	js := buildURLMatchJS("**/dashboard")
-	if js == "" {
-		t.Error("expected non-empty JS for URL match")
+func TestMatchURLPattern(t *testing.T) {
+	cases := []struct {
+		pattern string
+		url     string
+		want    bool
+	}{
+		{"http://127.0.0.1:8998/page2.html", "http://127.0.0.1:8998/page2.html", true},
+		{"*page2.html", "http://127.0.0.1:8998/page2.html", true},
+		{"*.html", "http://127.0.0.1:8998/page2.html", true},
+		{"**/dashboard", "http://app.example.com/x/dashboard", true},
+		{"http://127.0.0.1:8998/page2.html", "http://127.0.0.1:8998/page1.html", false},
+		{"*page2.html", "http://127.0.0.1:8998/page3.html", false},
+	}
+	for _, c := range cases {
+		if got := matchURLPattern(c.pattern, c.url); got != c.want {
+			t.Errorf("matchURLPattern(%q, %q) = %v, want %v", c.pattern, c.url, got, c.want)
+		}
 	}
 }
 

--- a/tests/e2e/scenarios/api/wait-url-basic.sh
+++ b/tests/e2e/scenarios/api/wait-url-basic.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+GROUP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${GROUP_DIR}/../../helpers/api.sh"
+
+start_test "wait url returns immediately when the current URL already matches (#634)"
+
+pt_post /navigate -d "{\"url\":\"${FIXTURES_URL}/form.html\"}"
+assert_ok "navigate to form fixture"
+
+pt_post /evaluate -d "{\"expression\":\"window.location.href\"}"
+assert_ok "read current url"
+CURRENT_URL=$(echo "$RESULT" | jq -r '.result')
+
+WAIT_BODY=$(jq -nc --arg u "$CURRENT_URL" '{url:$u,timeout:3000}')
+pt_post /wait -d "$WAIT_BODY"
+assert_ok "exact url wait request"
+assert_result_eq '.waited' 'true' 'exact URL wait matches the current URL'
+
+pt_post /wait -d '{"url":"*form.html","timeout":3000}'
+assert_ok "glob url wait request"
+assert_result_eq '.waited' 'true' 'glob URL wait matches the current URL'
+
+end_test

--- a/tests/e2e/scenarios/manifest.json
+++ b/tests/e2e/scenarios/manifest.json
@@ -1,5 +1,12 @@
 {
   "scenarios": {
+    "api/wait-url-basic.sh": {
+      "tags": [
+        "wait",
+        "waiturl",
+        "pr"
+      ]
+    },
     "api/keyboard-focus-basic.sh": {
       "tags": [
         "keyboard",


### PR DESCRIPTION
Closes #634.

## Summary
- Move `/wait` URL matching out of a browser-evaluated boolean expression and into Go-side polling against `window.location.href`.
- Preserve the existing glob semantics for URL waits (`**`, `*`, `?`).
- Add unit coverage for URL pattern matching and an API E2E scenario covering the already-matching-URL case.

## Why
- Issue #634 reports that `pinchtab wait --url ...` and MCP `pinchtab_wait_for_url` time out even when the current tab URL already matches the requested exact URL or wildcard pattern.
- The fix keeps the current URL retrieval in the browser, but performs the pattern match in Go during each poll so the handler can evaluate the actual current URL reliably.

## Verification
- `go test ./internal/handlers`
