### PR TITLE
fix(ci): remove reusable dashboard ref input

### DIFF
--- a/.github/workflows/ci-dashboard.yml
+++ b/.github/workflows/ci-dashboard.yml
@@ -26,5 +26,3 @@ jobs:
   dashboard:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     uses: ./.github/workflows/reusable-dashboard.yml
-    with:
-      ref: ${{ github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,8 +43,6 @@ jobs:
   dashboard-checks:
     needs: validate
     uses: ./.github/workflows/reusable-dashboard.yml
-    with:
-      ref: ${{ needs.validate.outputs.sha }}
 
   docs-checks:
     needs: validate

--- a/.github/workflows/reusable-dashboard.yml
+++ b/.github/workflows/reusable-dashboard.yml
@@ -2,11 +2,6 @@ name: Reusable / Dashboard
 
 on:
   workflow_call:
-    inputs:
-      ref:
-        required: true
-        type: string
-
 
 permissions:
   contents: read
@@ -21,8 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-        with:
-          ref: ${{ inputs.ref }}
 
       - name: Setup Go
         uses: actions/setup-go@v7
@@ -64,8 +57,6 @@ jobs:
     needs: check
     steps:
       - uses: actions/checkout@v7
-        with:
-          ref: ${{ inputs.ref }}
 
       - name: Setup Go
         uses: actions/setup-go@v7


### PR DESCRIPTION
Fixes code scanning alert #107 (actions/cache-poisoning/poisonable-step, high severity).

CodeQL flags `reusable-dashboard.yml` because it checks out `inputs.ref` and then executes package scripts (`bun run build`) in workflows reachable from `workflow_dispatch` (`ci-dashboard.yml`, `release.yml`), which can write to the default-branch cache scope.

Same fix as #107's plugin-workflow sibling (55f0aa96): drop the `ref` input and use the default checkout. This is behavior-preserving — both callers pass values identical to the default checkout sha: `ci-dashboard.yml` passes `github.sha`, and `release.yml` passes `validate.outputs.sha`, which is `git rev-parse HEAD` of a checkout of `github.sha`. Since `github.sha` is frozen for the entire workflow run, the release jobs stay pinned to the same validated commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuKLjn1VE1XGwKrFeCMFB8