### PR TITLE
fix(doctor): binary_starts opened a browser window and called it a version

### DIFF
--- a/internal/doctor/checks_binary.go
+++ b/internal/doctor/checks_binary.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"strings"
-	"time"
 
 	"github.com/pinchtab/pinchtab/internal/browserprobe"
 	"github.com/pinchtab/pinchtab/internal/config"
@@ -77,21 +75,33 @@ func checkBinaryStarts(ctx context.Context, cfg *config.RuntimeConfig) CheckResu
 	if bin == "" {
 		return CheckResult{Status: StatusSkip, Detail: "browser.binary not set; relying on provider discovery"}
 	}
-	cctx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-
-	cmd := exec.CommandContext(cctx, bin, "--version") // #nosec G204 -- bin is a browser path from config/discovery, not user input
-	out, err := cmd.CombinedOutput()
+	// This used to run `bin --version` itself, a second copy of a probe
+	// browserprobe already owns — and the copy still had the Windows defect the
+	// original was fixed for. There `--version` prints no version: the process
+	// forwards its arguments to the running browser and prints "Opening in
+	// existing browser session.", so `pinchtab doctor` opened a window on the
+	// user's desktop and then reported that sentence as the browser's version
+	// (issue #649). browserprobe.RunVersion reads the install layout on Windows
+	// and starts nothing.
+	version, err := browserprobe.RunVersion(ctx, bin)
 	if err != nil {
 		return CheckResult{
 			Status: StatusFail,
-			Detail: fmt.Sprintf("--version failed: %v", err),
+			Detail: fmt.Sprintf("version probe failed: %v", err),
 			Err:    err,
 		}
 	}
-	version := parseVersionLine(string(out))
-	if version == "" {
-		version = strings.TrimSpace(string(out))
+	if parsed := parseVersionLine(version); parsed != "" {
+		version = parsed
+	}
+	// A probe that answers something with no version in it has not identified the
+	// browser, whatever its exit code was. Reporting Pass on that is how the
+	// "Opening in existing browser session." sentence reached users as a version.
+	if extractVersionToken(version) == "" {
+		return CheckResult{
+			Status: StatusWarn,
+			Detail: fmt.Sprintf("%s: probe returned no version (%q)", bin, version),
+		}
 	}
 	return CheckResult{
 		Status: StatusPass,

--- a/internal/doctor/runner_test.go
+++ b/internal/doctor/runner_test.go
@@ -284,3 +284,58 @@ func TestCheckResultMarshalsDurationInMilliseconds(t *testing.T) {
 		t.Fatalf("expected durationMs in milliseconds, got %s", data)
 	}
 }
+
+// TestBinaryStarts_DoesNotRunTheBrowserOnWindows is the regression for the
+// binary_starts half of issue #649. The check ran `bin --version` itself, a
+// second copy of a probe browserprobe owns. On Windows that switch prints no
+// version — the process forwards its arguments to the running browser — so
+// `pinchtab doctor` opened a window and reported "Opening in existing browser
+// session." as the version.
+//
+// The stub here is not a runnable image. If the check execs it the probe fails,
+// which is the point: the version has to come from the install layout beside it.
+func TestBinaryStarts_DoesNotRunTheBrowserOnWindows(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("install-layout version reading is windows-only")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "fake-chrome.exe")
+	if err := os.WriteFile(path, []byte("not a PE image"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(dir, "151.0.7922.175"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.RuntimeConfig{BrowserBinary: path}
+	r := checkBinaryStarts(context.Background(), cfg)
+	if r.Status != StatusPass {
+		t.Fatalf("status = %v, want pass; detail=%q err=%v", r.Status, r.Detail, r.Err)
+	}
+	if !strings.Contains(r.Detail, "151.0.7922.175") {
+		t.Errorf("detail = %q, want the version from the install layout", r.Detail)
+	}
+}
+
+// A probe that comes back without a version in it has not identified the
+// browser, whatever the exit code was. Passing on that is how the sentence
+// "Opening in existing browser session." reached users as a version string.
+func TestBinaryStarts_DoesNotPassWithoutAVersion(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fake binary requires unix")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "fake-chrome-chatty")
+	script := "#!/bin/sh\necho 'Opening in existing browser session.'\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.RuntimeConfig{BrowserBinary: path}
+	r := checkBinaryStarts(context.Background(), cfg)
+	if r.Status == StatusPass {
+		t.Fatalf("status = pass for a probe with no version in it; detail=%q", r.Detail)
+	}
+	if !strings.Contains(r.Detail, "no version") {
+		t.Errorf("detail = %q, want it to say no version was returned", r.Detail)
+	}
+}


### PR DESCRIPTION
## What

`pinchtab doctor` with `browser.binary` pointed at Edge or Brave on Windows reported:

```
OK   binary_starts   Opening in existing browser session.   (197ms)
```

That sentence is not a version, and getting it cost the user a browser window on their desktop. It is what a Chromium build prints on Windows when handed `--version`: the switch is not implemented there, so the process forwards its arguments to the already-running browser and exits 0. `binary_starts` ran that command, could not parse the output, fell through to its raw-output branch, and reported the sentence as a successful result.

Reported in #649, whose author saw exactly this line.

## Why it survived dbce448e

`browserprobe.RunVersion` already solves this — dbce448e taught it to read the versioned directory Chrome's installer places beside the executable, and to start no process on Windows. `binary_starts` never used it. It carried its own `exec.CommandContext(bin, "--version")`, a second copy of a probe that has an owner, and the copy kept the defect the original had been fixed for. It now calls `RunVersion` like every other caller.

The raw-output fallback goes with it. A probe that answers with no version in it has not identified the browser, whatever its exit code was, and `Pass` is the wrong verdict — it is precisely what let the sentence through. It reports `Warn` and quotes what it actually got.

## Verification

On windows/amd64, against both browsers named in #649:

| | before | after |
|---|---|---|
| Brave | `OK binary_starts Opening in existing browser session. (197ms)` + a browser window opens | `OK binary_starts 152.1.94.117 (0ms)` |
| Edge | `OK binary_starts Opening in existing browser session.` | `OK binary_starts 152.0.4191.53 (0ms)` |

Two regression tests. The Windows one points `browser.binary` at a stub that is *not* a runnable image, with a versioned directory beside it — if the check execs the stub the probe fails, which is the point. The unix one feeds a stub that prints the sentence and pins that the result is not `Pass`.

`go test ./internal/doctor/` green on windows/amd64; `go vet` clean for linux and darwin.

## Scope

This is the `doctor` half of #649. The launch half — Brave spawning but never completing the CDP handshake (`chrome failed to start:` with an empty reason), and Edge handing off to the user's running session — is untouched here and still open.

## Definition of Done
- [x] Unit tests added & passing
- [x] Error handling explicit (wrapped with `%w` where wrapping applies; `Err` carried on the result)
- [x] No regressions in stealth/perf/persistence — check is diagnostic-only, and it now starts fewer processes
- [x] No redundant comments
- [ ] README/docs updated — not user-facing beyond the check's own output
- [ ] npm install works — npm wrapper untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)
