### PR TITLE
fix(handlers): current-tab LRU evicted at random inside one clock tick

### DIFF
--- a/internal/handlers/current_tab.go
+++ b/internal/handlers/current_tab.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/pinchtab/pinchtab/internal/activity"
 	"github.com/pinchtab/pinchtab/internal/session"
@@ -42,12 +41,21 @@ func (s currentTabScope) Description() string {
 // keeps that bounded.
 const defaultCurrentTabCap = 5000
 
-// currentTabEntry holds a tab id plus a per-entry timestamp used as the
-// LRU recency signal. lastTouched is updated on Get, Set, and any access
-// that proves the entry is still in active use.
+// currentTabEntry holds a tab id plus a per-entry tick used as the LRU
+// recency signal. touchedAt is updated on Get, Set, and any access that
+// proves the entry is still in active use.
+//
+// It counts touches rather than reading a clock. Wall time cannot order two
+// touches that land inside the same clock tick, and the tick is coarse on
+// Windows — ~15.6ms, long enough to cover a burst of current-tab traffic.
+// Entries touched within one tick all compared equal, no entry was Before any
+// other, and eviction fell through to Go's randomized map iteration order:
+// the store stopped being an LRU and dropped an arbitrary agent's pointer
+// while a genuinely older one survived. A counter is exactly ordered by
+// construction and needs no clock at all.
 type currentTabEntry struct {
-	tabID       string
-	lastTouched time.Time
+	tabID     string
+	touchedAt uint64
 }
 
 // CurrentTabStore tracks server-side current-tab pointers for identified
@@ -57,14 +65,13 @@ type CurrentTabStore struct {
 	mu      sync.RWMutex
 	entries map[string]currentTabEntry
 	cap     int
-	now     func() time.Time
+	touches uint64
 }
 
 func NewCurrentTabStore() *CurrentTabStore {
 	return &CurrentTabStore{
 		entries: make(map[string]currentTabEntry),
 		cap:     defaultCurrentTabCap,
-		now:     time.Now,
 	}
 }
 
@@ -90,7 +97,7 @@ func (s *CurrentTabStore) Get(scope currentTabScope) (string, bool) {
 		s.mu.Unlock()
 		return "", false
 	}
-	entry.lastTouched = s.now()
+	entry.touchedAt = s.nextTouchLocked()
 	s.entries[scope.key] = entry
 	s.mu.Unlock()
 	return entry.tabID, true
@@ -105,7 +112,7 @@ func (s *CurrentTabStore) Set(scope currentTabScope, tabID string) {
 		return
 	}
 	s.mu.Lock()
-	s.entries[scope.key] = currentTabEntry{tabID: tabID, lastTouched: s.now()}
+	s.entries[scope.key] = currentTabEntry{tabID: tabID, touchedAt: s.nextTouchLocked()}
 	s.evictExcessLocked()
 	s.mu.Unlock()
 }
@@ -121,18 +128,25 @@ func (s *CurrentTabStore) evictExcessLocked() {
 	for len(s.entries) > s.cap {
 		var (
 			oldestKey string
-			oldestAt  time.Time
+			oldestAt  uint64
 			first     = true
 		)
 		for k, e := range s.entries {
-			if first || e.lastTouched.Before(oldestAt) {
+			if first || e.touchedAt < oldestAt {
 				oldestKey = k
-				oldestAt = e.lastTouched
+				oldestAt = e.touchedAt
 				first = false
 			}
 		}
 		delete(s.entries, oldestKey)
 	}
+}
+
+// nextTouchLocked returns a strictly increasing recency tick. Caller must hold
+// s.mu (write).
+func (s *CurrentTabStore) nextTouchLocked() uint64 {
+	s.touches++
+	return s.touches
 }
 
 func (s *CurrentTabStore) Clear(scope currentTabScope) {

--- a/internal/handlers/current_tab_test.go
+++ b/internal/handlers/current_tab_test.go
@@ -304,3 +304,70 @@ func TestUntrustedSessionHeaderIgnored(t *testing.T) {
 		t.Fatalf("untrusted header must not resolve to %q", got)
 	}
 }
+
+// TestCurrentTabStore_EvictsInTouchOrderWithoutSleeping pins the invariant the
+// wall-clock recency signal could not hold: eviction order must follow the
+// order entries were touched, not how fast they were touched.
+//
+// The old signal was time.Now(). Every touch here lands inside a single clock
+// tick — ~15.6ms on Windows, wide enough for far more traffic than this — so
+// every entry compared equal, no entry was Before any other, and eviction fell
+// through to Go's randomized map iteration. Entries survived or died at random
+// while the store still claimed to be an LRU.
+//
+// No sleeps: a test that has to pause to let a clock advance is measuring the
+// clock, and the store must not need one.
+func TestCurrentTabStore_EvictsInTouchOrderWithoutSleeping(t *testing.T) {
+	const (
+		capacity = 10
+		total    = 50
+	)
+	store := NewCurrentTabStore()
+	store.SetCap(capacity)
+
+	scopes := make([]currentTabScope, total)
+	for i := range scopes {
+		scopes[i] = scopedCurrentTab(currentTabScopeAgent, fmt.Sprintf("agent-%02d", i))
+		store.Set(scopes[i], fmt.Sprintf("tab-%02d", i))
+	}
+
+	// Exactly the last `capacity` writes survive; everything older is gone.
+	for i := 0; i < total-capacity; i++ {
+		if _, ok := store.Get(scopes[i]); ok {
+			t.Fatalf("scope %d should have been evicted; only the newest %d survive", i, capacity)
+		}
+	}
+	for i := total - capacity; i < total; i++ {
+		if _, ok := store.Get(scopes[i]); !ok {
+			t.Fatalf("scope %d should have survived; only the oldest %d are evicted", i, total-capacity)
+		}
+	}
+}
+
+// Get is a touch, so reading an entry has to move it out of eviction's way even
+// when every read happens within one clock tick.
+func TestCurrentTabStore_GetBumpsRecencyWithoutSleeping(t *testing.T) {
+	const capacity = 4
+	store := NewCurrentTabStore()
+	store.SetCap(capacity)
+
+	scopes := make([]currentTabScope, capacity)
+	for i := range scopes {
+		scopes[i] = scopedCurrentTab(currentTabScopeAgent, fmt.Sprintf("agent-%d", i))
+		store.Set(scopes[i], fmt.Sprintf("tab-%d", i))
+	}
+
+	// Touch the oldest entry, then push the cap. The entry just read must
+	// outlive the one that has not been touched since it was written.
+	if _, ok := store.Get(scopes[0]); !ok {
+		t.Fatal("scope 0 should still be present before the bump")
+	}
+	store.Set(scopedCurrentTab(currentTabScopeAgent, "agent-new"), "tab-new")
+
+	if _, ok := store.Get(scopes[0]); !ok {
+		t.Error("the entry Get touched was evicted; Get did not bump recency")
+	}
+	if _, ok := store.Get(scopes[1]); ok {
+		t.Error("scope 1 was the least recently used and should have been evicted")
+	}
+}


### PR DESCRIPTION
## What

`CurrentTabStore` caps how many per-agent current-tab pointers it holds and evicts the least recently used on overflow. Its recency signal was `time.Now()`, compared with `lastTouched.Before(oldestAt)`.

Two touches inside the same clock tick carry the same timestamp, and neither is `Before` the other. Once that happens the eviction scan has no ordering left: every entry compares equal, `first` selects whichever key Go's randomized map iteration reaches first, and that is what gets dropped. The store keeps reporting itself as an LRU while discarding an arbitrary agent's pointer and retaining a genuinely older one — that agent's next request finds no current tab and has to re-establish it.

How wide the window is depends on the platform. Windows is the bad case: the system clock advances roughly every 15.6ms, comfortably wider than a burst of current-tab traffic, so every touch in the burst ties.

## Fix

Recency is a counter incremented per touch under the write lock. It is exactly ordered by construction on every platform and reads no clock. Ordering entries relative to each other never needed wall time — only a sequence.

```go
-	tabID       string
-	lastTouched time.Time
+	tabID     string
+	touchedAt uint64
```

## Tests

`TestCurrentTabStore_GetBumpsRecency` has been failing on windows/amd64 for exactly this reason: `Set(a)`, `Set(b)`, `Get(a)`, `Set(c)` all land in one tick, so its "b is the LRU" premise did not hold and the assertion was settled by map order.

Two new tests pin the invariant without sleeping — eviction follows touch order, and `Get` counts as a touch, both while every operation lands inside a single tick. A test that has to pause for a clock to advance is measuring the clock, and the store must not need one.

Both new tests fail against the previous implementation (verified by reverting the implementation and re-running).

## Verification

On windows/amd64, `go test ./internal/handlers/` goes from one failure to green (84s). `go vet` clean for linux and darwin.

Found while running the suite on Windows, where `upstream/main` currently has failures across several packages that Linux CI does not surface. This is one of them, and it turned out to be a production defect rather than a test artifact.

## Definition of Done
- [x] Unit tests added & passing
- [x] Error handling explicit — no new error paths
- [x] No regressions in stealth/perf/persistence — eviction is now cheaper (integer compare, no clock read)
- [x] No redundant comments
- [ ] README/docs updated — internal data structure, no user-facing surface
- [ ] npm install works — npm wrapper untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)
