### PR TITLE
test: fix two platform assumptions that fail the suite on Windows

### DIFF
--- a/internal/autosolver/autosolver_test.go
+++ b/internal/autosolver/autosolver_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -64,6 +65,16 @@ type mockSolver struct {
 	solved     bool
 	err        error
 	solveCalls int
+
+	// waitForClockTick makes Solve occupy at least one tick of the clock the
+	// autosolver times attempts with, for the tests that assert a recorded
+	// duration is non-zero. A solver that returns immediately can be timed as
+	// exactly 0 — time.Since only reports what the clock resolves, and the
+	// Windows clock advances about every 15.6ms, so an instant return is
+	// genuinely 0ms there. Waiting for the tick asserts what the tests mean
+	// (the duration was measured, not left unset) without assuming any
+	// particular clock resolution.
+	waitForClockTick bool
 }
 
 func (m *mockSolver) Name() string  { return m.name }
@@ -73,10 +84,23 @@ func (m *mockSolver) CanHandle(_ context.Context, _ Page) (bool, error) {
 }
 func (m *mockSolver) Solve(_ context.Context, _ Page, _ ActionExecutor) (*Result, error) {
 	m.solveCalls++
+	if m.waitForClockTick {
+		waitForClockTick()
+	}
 	if m.err != nil {
 		return &Result{Error: m.err.Error()}, m.err
 	}
 	return &Result{Solved: m.solved, SolverUsed: m.name}, nil
+}
+
+// waitForClockTick blocks until the monotonic clock has advanced at least once,
+// which is the smallest non-zero duration this machine can report. It returns
+// as soon as that happens, so it costs nothing on a fine-grained clock.
+func waitForClockTick() {
+	start := time.Now()
+	for time.Since(start) <= 0 {
+		runtime.Gosched()
+	}
 }
 
 type mockSemantic struct {
@@ -531,15 +555,17 @@ func solverHistory(history []AttemptEntry) []AttemptEntry {
 
 func twoFailingSolvers() (*mockSolver, *mockSolver) {
 	return &mockSolver{
-			name:      "alpha",
-			priority:  10,
-			canHandle: true,
-			err:       fmt.Errorf("alpha exploded"),
+			name:             "alpha",
+			priority:         10,
+			canHandle:        true,
+			err:              fmt.Errorf("alpha exploded"),
+			waitForClockTick: true,
 		}, &mockSolver{
-			name:      "beta",
-			priority:  20,
-			canHandle: true,
-			err:       fmt.Errorf("beta exploded"),
+			name:             "beta",
+			priority:         20,
+			canHandle:        true,
+			err:              fmt.Errorf("beta exploded"),
+			waitForClockTick: true,
 		}
 }
 

--- a/internal/cdptk/screenshot_rule_test.go
+++ b/internal/cdptk/screenshot_rule_test.go
@@ -1,0 +1,50 @@
+package cdptk
+
+import (
+	"testing"
+
+	"github.com/chromedp/cdproto/page"
+)
+
+// The fromSurface rule is platform-dependent: Windows always composites a fresh
+// surface, because the read-the-view fast path returns a blank image there
+// (issue #619). The exported CaptureFromSurface reads runtime.GOOS, so a table
+// driven through it can only ever assert the rule for the machine running the
+// test — and it asserted the non-Windows answers, which is why it failed on
+// Windows while leaving the Windows clause untested everywhere else.
+//
+// captureFromSurface takes goos precisely so the whole rule can be checked from
+// any host. This is that table.
+func TestCaptureFromSurfaceRulePerGOOS(t *testing.T) {
+	clip := &page.Viewport{Width: 120, Height: 60, Scale: 1}
+
+	for _, tc := range []struct {
+		name           string
+		goos           string
+		beyondViewport bool
+		clip           *page.Viewport
+		want           bool
+	}{
+		{name: "linux plain capture keeps the fast read", goos: "linux", want: false},
+		{name: "darwin plain capture keeps the fast read", goos: "darwin", want: false},
+		{name: "windows always composites a surface", goos: "windows", want: true},
+
+		{name: "linux any clip needs the surface", goos: "linux", clip: clip, want: true},
+		{name: "darwin any clip needs the surface", goos: "darwin", clip: clip, want: true},
+		{name: "windows with a clip still needs it", goos: "windows", clip: clip, want: true},
+
+		{name: "linux beyond viewport needs it with no clip", goos: "linux", beyondViewport: true, want: true},
+		{name: "darwin beyond viewport needs it with no clip", goos: "darwin", beyondViewport: true, want: true},
+		{name: "windows beyond viewport needs it too", goos: "windows", beyondViewport: true, want: true},
+
+		{name: "linux both", goos: "linux", beyondViewport: true, clip: clip, want: true},
+		{name: "windows both", goos: "windows", beyondViewport: true, clip: clip, want: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := captureFromSurface(tc.goos, tc.beyondViewport, tc.clip); got != tc.want {
+				t.Errorf("captureFromSurface(%q, %v, %+v) = %v, want %v",
+					tc.goos, tc.beyondViewport, tc.clip, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/cdptk/screenshot_test.go
+++ b/internal/cdptk/screenshot_test.go
@@ -8,6 +8,7 @@ import (
 	"go/token"
 	"path"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -291,23 +292,34 @@ func TestAnnotationRectForNodeAppliesFrameOffset(t *testing.T) {
 }
 
 // The fromSurface rule had two implementations in packages that cannot import each other,
-// and they had already drifted once. This is the table that now stands for both.
+// and they had already drifted once. The rule itself is now tabled per-GOOS in the
+// in-package TestCaptureFromSurfaceRulePerGOOS, which is the only place it can be checked
+// whole: this exported wrapper reads runtime.GOOS, so from out here only the host's own
+// answers are knowable. This covers what is left — that the wrapper asks the rule about
+// the machine it is running on, rather than deciding anything itself.
+//
+// It used to assert want:false for a plain capture unconditionally, which is the
+// non-Windows answer. Windows always composites a surface (issue #619), so the row was
+// wrong on the one platform whose clause it was accidentally exercising.
 func TestCaptureFromSurface(t *testing.T) {
+	clip := &page.Viewport{Width: 120, Height: 60, Scale: 1}
+	hostAlwaysComposites := runtime.GOOS == "windows"
+
 	for _, tc := range []struct {
 		name           string
 		beyondViewport bool
 		clip           *page.Viewport
 		want           bool
 	}{
-		{name: "plain capture keeps the fast read", beyondViewport: false, clip: nil, want: false},
-		{name: "any clip needs the surface", beyondViewport: false, clip: &page.Viewport{Width: 120, Height: 60, Scale: 1}, want: true},
-		{name: "a native-scale clip still needs it", beyondViewport: false, clip: &page.Viewport{Width: 120, Height: 60, Scale: 1}, want: true},
-		{name: "beyond viewport needs it with no clip", beyondViewport: true, clip: nil, want: true},
-		{name: "both", beyondViewport: true, clip: &page.Viewport{Width: 10, Height: 10, Scale: 1}, want: true},
+		{name: "plain capture keeps the fast read where the host allows it", want: hostAlwaysComposites},
+		{name: "any clip needs the surface", clip: clip, want: true},
+		{name: "beyond viewport needs it with no clip", beyondViewport: true, want: true},
+		{name: "both", beyondViewport: true, clip: clip, want: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := cdptk.CaptureFromSurface(tc.beyondViewport, tc.clip); got != tc.want {
-				t.Errorf("cdptk.CaptureFromSurface(%v, %+v) = %v, want %v", tc.beyondViewport, tc.clip, got, tc.want)
+				t.Errorf("cdptk.CaptureFromSurface(%v, %+v) = %v, want %v (GOOS=%s)",
+					tc.beyondViewport, tc.clip, got, tc.want, runtime.GOOS)
 			}
 		})
 	}


### PR DESCRIPTION
## What

Two independent test-only fixes, each a platform assumption baked into an assertion. Neither changes production code.

### 1. `cdptk` — the `fromSurface` rule was only ever half-checked

`TestCaptureFromSurface` drove its table through the exported `CaptureFromSurface`, which reads `runtime.GOOS`. That makes the table assert the rule for whichever machine runs it, and the row it hardcoded — *"plain capture keeps the fast read"*, `want: false` — is the non-Windows answer. Windows always composites a fresh surface, because the read-the-view fast path returns a blank image there (#619).

So the table failed on Windows, and off Windows it never exercised the Windows clause at all: **the one branch with a bug behind it was the one branch nothing covered.**

`captureFromSurface` already takes `goos` precisely so the rule can be checked whole from any host, but nothing used that seam. An in-package table now walks every combination across linux, darwin and windows, so Linux CI covers the Windows clause too. The exported wrapper keeps a test for what remains knowable from outside the package — that it asks the rule about its own host rather than deciding anything itself.

This one is a coverage gain, not just a red-to-green fix.

### 2. `autosolver` — an instant return really is 0ms on a coarse clock

`TestSolve_HistoryRecordsEverySolverAttempt` asserts each history entry carries a non-zero `Duration`. Its stub solvers return immediately, so the assertion holds only where the clock resolves an instant return as more than nothing. On Windows it does not — the clock advances about every 15.6ms, so `time.Since` reports exactly `0`.

Nothing is wrong with the production timing here; a solver that fails instantly did take 0ms as far as that machine can tell.

The assertion is still worth keeping: a `Duration` left unset and one measured as zero are the same value, and this test is what would catch the former. So rather than weakening it to `>= 0`, the stubs now occupy at least one tick before returning. `waitForClockTick` returns the moment the clock moves — effectively free where resolution is already fine, one tick where it is not — and it is opt-in per solver, used only by the two stubs whose durations are asserted.

## Verification

On windows/amd64 both packages go from failing to green. `go vet` clean for linux and darwin.

Found while running the suite on Windows, where `upstream/main` currently fails in several packages Linux CI does not surface.

## Scope

No overlap with #586 — that PR touches neither package.

## Definition of Done
- [x] Tests passing
- [x] No production behaviour changed
- [x] No redundant comments
- [ ] README/docs updated — test-only change
- [ ] npm install works — npm wrapper untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)
