### PR TITLE
build: pin LF line endings so a Windows clone is not born broken

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,43 @@
+# Git's Windows default is core.autocrlf=true, which rewrites every text file to
+# CRLF on checkout. Nothing in this repository wants CRLF, and several things
+# break on it, so pin the working-tree ending rather than leaving it to whatever
+# each contributor's Git is configured to do.
+#
+# What breaks without this, all of it only on Windows and none of it visible to
+# Linux CI:
+#
+#   - Shell scripts. bash reads the trailing CR as part of the last token, so a
+#     CRLF script misparses. scripts/ci/detect-e2e-suites.sh reads
+#     e2e-escalation.map line by line and rejected every blank line in it,
+#     failing four tests in internal/devtools.
+#   - Golden files. internal/audit/report compares rendered output to a fixture
+#     byte for byte; CRLF adds one byte per line and every comparison fails.
+#   - The extensionless entry points below — ./dev is what DEFINITION_OF_DONE.md
+#     tells contributors to run.
+#
+# The repository's own content is already LF throughout, so this changes no
+# committed bytes; it stops checkout from changing them.
+
+# Detect text vs binary automatically, and give every text file LF in the
+# working tree on every platform.
+* text=auto eol=lf
+
+# Spelled out for the cases that break loudest, so a future `* -text` or a
+# contributor's local override cannot quietly take them with it.
+*.sh        text eol=lf
+dev         text eol=lf
+scripts/pre-commit text eol=lf
+npm/bin/pinchtab   text eol=lf
+*.map       text eol=lf
+
+# Binary formats: never convert, never diff as text.
+*.png       binary
+*.jpg       binary
+*.jpeg      binary
+*.gif       binary
+*.ico       binary
+*.pdf       binary
+*.zip       binary
+*.gz        binary
+*.woff      binary
+*.woff2     binary


### PR DESCRIPTION
## What

The repository has no `.gitattributes`. Git's Windows default is `core.autocrlf=true`, so every text file is rewritten to CRLF on checkout — and a contributor cloning on Windows gets a tree that **fails its own test suite before they have changed anything.**

Six failing tests across two packages, none visible to Linux CI, all of them one checkout rule.

## The two things that break

**Shell scripts.** `bash` takes the trailing CR as part of the last token on each line, so a CRLF script misparses. `scripts/ci/detect-e2e-suites.sh` reads `scripts/ci/e2e-escalation.map` line by line; its blank-line skip matches `''`, and a CRLF blank line is `"\r"`, so every blank line fell through to the `rule names no suite` error. That failed four tests in `internal/devtools` — and because the diagnostic ends by printing the offending line, which is a lone carriage return, the error message erased itself:

```
detect-e2e-suites: rule names no suite:
```

**Golden files.** `internal/audit/report` compares rendered output to a fixture byte for byte. CRLF adds one byte per line, so `report.golden.md` was 2247 bytes against 2172 rendered — both golden tests failed on size alone.

## Why this shape

Nothing in the tree wants CRLF — there is no `.bat`, `.cmd` or `.ps1` anywhere — so `* text=auto eol=lf` is safe and covers files added later, which a list of extensions would not.

The extensionless entry points (`dev`, `scripts/pre-commit`, `npm/bin/pinchtab`) are spelled out individually because no extension pattern can reach them, and `./dev` is what `DEFINITION_OF_DONE.md` tells contributors to run.

## This changes no committed bytes

The stored content is already LF throughout — verified with `git grep -I -l $'\r$' HEAD`, which matches nothing. What changes is that checkout stops converting it. Existing clones see no diff.

## Verification

On windows/amd64: deleting the affected files and checking them out fresh now restores them with LF (`file` reports no `CRLF line terminators`), and `go test ./internal/audit/report/ ./internal/devtools/` is green where both packages had been failing.

`git check-attr` confirms the intended classification, including that binaries are excluded:

```
scripts/ci/detect-e2e-suites.sh: text: set     eol: lf
dev:                             text: set     eol: lf
report.golden.md:                text: auto    eol: lf
assets/pinchtab-headless.png:    text: unset
```

## Definition of Done
- [x] Tests passing — two previously-failing packages now green
- [x] No production behaviour changed
- [x] No committed content changed
- [ ] README/docs updated — no user-facing surface
- [ ] npm install works — npm wrapper untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)
