### PR TITLE
fix(server): the port-in-use remedy never printed on Windows

### DIFF
--- a/internal/server/addrinuse_other.go
+++ b/internal/server/addrinuse_other.go
@@ -1,0 +1,14 @@
+//go:build !windows
+
+package server
+
+import (
+	"errors"
+	"syscall"
+)
+
+// isAddrInUse reports whether err is the kernel refusing a bind because
+// something already holds the address.
+func isAddrInUse(err error) bool {
+	return errors.Is(err, syscall.EADDRINUSE)
+}

--- a/internal/server/addrinuse_test.go
+++ b/internal/server/addrinuse_test.go
@@ -1,0 +1,72 @@
+package server
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"syscall"
+	"testing"
+)
+
+// TestIsAddrInUseRecognizesARealBindConflict pins the platform's own answer
+// rather than a constant this test picked.
+//
+// The check used to be errors.Is(err, syscall.EADDRINUSE) inline. That is
+// correct on unix and always false on Windows, where a taken address comes back
+// as winsock's WSAEADDRINUSE (10048) and syscall.EADDRINUSE names an
+// APPLICATION_ERROR placeholder (536870914) that nothing returns. The call
+// compiled and ran on both platforms and answered "no" on one of them, so
+// `pinchtab server` printed the raw winsock sentence with none of the guidance
+// that explains it — on what is the most ordinary startup failure there is,
+// starting a server while the daemon already holds the port.
+func TestIsAddrInUseRecognizesARealBindConflict(t *testing.T) {
+	held, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("could not take a port to hold: %v", err)
+	}
+	defer func() { _ = held.Close() }()
+
+	_, err = net.Listen("tcp", held.Addr().String())
+	if err == nil {
+		t.Fatal("second listen on a held address succeeded; no conflict to classify")
+	}
+	if !isAddrInUse(err) {
+		var errno syscall.Errno
+		errors.As(err, &errno)
+		t.Fatalf("isAddrInUse did not recognize a real bind conflict: %v (errno %d)", err, uintptr(errno))
+	}
+}
+
+// Unrelated failures must not collect the port-in-use advice, which would send
+// the reader looking for a process that is not there.
+func TestIsAddrInUseIgnoresOtherErrors(t *testing.T) {
+	for _, err := range []error{
+		fmt.Errorf("some other failure"),
+		syscall.ENOENT,
+		fmt.Errorf("wrapped: %w", syscall.EACCES),
+	} {
+		if isAddrInUse(err) {
+			t.Errorf("isAddrInUse(%v) = true, want false", err)
+		}
+	}
+}
+
+// TestStartupFatalHintsFireForARealBindConflict is the positive half that was
+// missing. TestStartupFatalHintsOnlyForAddressInUse already pins that an
+// unrelated error produces nothing — which stayed true on Windows for the worst
+// possible reason, because the classifier said "not in use" to everything.
+func TestStartupFatalHintsFireForARealBindConflict(t *testing.T) {
+	held, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("could not take a port to hold: %v", err)
+	}
+	defer func() { _ = held.Close() }()
+	_, bindErr := net.Listen("tcp", held.Addr().String())
+	if bindErr == nil {
+		t.Fatal("second listen on a held address succeeded")
+	}
+
+	if got := startupFatalHints(bindErr); len(got) == 0 {
+		t.Error("a real bind conflict produced no hints")
+	}
+}

--- a/internal/server/addrinuse_windows.go
+++ b/internal/server/addrinuse_windows.go
@@ -1,0 +1,30 @@
+//go:build windows
+
+package server
+
+import (
+	"errors"
+	"syscall"
+)
+
+// wsaAddrInUse is winsock's WSAEADDRINUSE, which is what Windows actually
+// returns for a taken address.
+//
+// It is not syscall.EADDRINUSE. Go's Windows errno table defines that name as a
+// placeholder in the APPLICATION_ERROR range — 536870914 — which no syscall
+// ever returns, so errors.Is(err, syscall.EADDRINUSE) is false for every real
+// bind conflict on this platform. A plain check against it therefore compiled,
+// ran, and silently answered "no" every time.
+//
+// Declared inline for the same reason internal/bridge/state_lock_windows.go
+// declares its ERROR_* codes: it keeps golang.org/x/sys/windows out of the
+// import graph for the sake of one constant.
+const wsaAddrInUse syscall.Errno = 10048
+
+func isAddrInUse(err error) bool {
+	if errors.Is(err, syscall.EADDRINUSE) {
+		return true
+	}
+	var errno syscall.Errno
+	return errors.As(err, &errno) && errno == wsaAddrInUse
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -49,7 +48,7 @@ func fatalStartup(stage string, err error) {
 }
 
 func startupFatalHints(err error) []string {
-	if !errors.Is(err, syscall.EADDRINUSE) {
+	if !isAddrInUse(err) {
 		return nil
 	}
 	return []string{


### PR DESCRIPTION
## What

Starting the server while something already holds the port is the most ordinary startup failure there is — running `pinchtab server` when the daemon is up does it. The intended output names the cause and the way out:

```
pinchtab: cannot listen on 127.0.0.1:9867: ...
         Another process is already listening on that address.
         Check for a running service with `pinchtab daemon`, or stop it with `pinchtab server stop`.
```

On Windows neither hint line ever appeared. The user got the raw winsock sentence and nothing to act on:

```
pinchtab: cannot listen on 127.0.0.1:9867: listen tcp 127.0.0.1:9867: bind: Only one usage of each socket address (protocol/network address/port) is normally permitted.
```

## Why

`startupFatalHints` classified with `errors.Is(err, syscall.EADDRINUSE)`. That is correct on unix and cannot be correct on Windows: a taken address comes back from winsock as `WSAEADDRINUSE`, errno **10048**, while Go's Windows errno table defines the name `EADDRINUSE` as an `APPLICATION_ERROR` placeholder — **536870914** — that no syscall returns.

So the comparison was between a real error and a constant nothing on the platform can produce. It compiled, it ran, and it answered "not in use" to every bind conflict.

Measured rather than assumed, by binding a held port on windows/amd64:

```
errno                       = 10048
syscall.EADDRINUSE          = 536870914
errors.Is(err, EADDRINUSE)  = false
```

## Fix

Classification moves behind `isAddrInUse`, split per-GOOS. The Windows build declares the winsock constant inline, for the same reason `internal/bridge/state_lock_windows.go` already declares its `ERROR_*` codes that way — it keeps `golang.org/x/sys/windows` out of the import graph for one constant. It keeps the `EADDRINUSE` check alongside, so nothing is lost if a future toolchain starts mapping it.

## Tests

`TestFatalStartupPortInUseNamesAddressAndRemedy` has been failing on windows/amd64 for exactly this reason, and passes now.

The new tests take a real port, bind it twice, and classify the **actual** error rather than a constant the test chose — a unit test asserting `errno == 10048` would have passed against the broken code and proved nothing.

`TestStartupFatalHintsOnlyForAddressInUse` already pinned that unrelated errors produce no hints. That assertion stayed true on Windows for the worst possible reason — the classifier said "not in use" to everything — so the missing positive half is what this adds.

## Verification

`go test ./internal/server/` green on windows/amd64. `go vet` clean for linux and darwin.

## Note on the other `internal/server` failure

`TestFatalStartupIsTheOnlyExitOneSite` also fails on a Windows checkout, but for an unrelated reason and not one this PR touches: it splits source on `"\n"`, so under CRLF every line keeps a trailing `\r` and `insideFatalStartup` stops recognising the legitimate call site. That is fixed by #665 (`.gitattributes`), and passes in a clean LF clone.

## Definition of Done
- [x] Unit tests added & passing
- [x] Error handling explicit — classification only, no new error paths
- [x] No regressions in stealth/perf/persistence — diagnostic output only
- [x] No redundant comments
- [ ] README/docs updated — no documented surface changes; the hint text is unchanged, it just reaches Windows now
- [ ] npm install works — npm wrapper untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)
