### PR TITLE
test(cmd): isolate the default config path on Windows, not just HOME

### DIFF
--- a/cmd/pinchtab/token_guard_test.go
+++ b/cmd/pinchtab/token_guard_test.go
@@ -87,7 +87,19 @@ func TestAnEnvTokenStartsBothModesWithoutTouchingTheOperatorConfig(t *testing.T)
 
 func TestTheDefaultPathStillSelfProvisionsAndSaysSo(t *testing.T) {
 	tmpHome := t.TempDir()
+	// HOME alone does not redirect the default config path on Windows.
+	// config.userConfigDir returns $HOME/.pinchtab only on darwin and linux; on
+	// Windows it falls through to os.UserConfigDir, which reads %AppData% and
+	// never consults HOME. So this test used to run against the developer's real
+	// config: it read a token that was already there, self-provisioned nothing,
+	// printed nothing, and failed — and on a machine with no config yet it would
+	// have created one, writing a generated credential outside the test's
+	// TempDir. internal/config/config_utils_test.go already isolates this way,
+	// setting both spellings because os.Getenv is case-sensitive.
+	configHome := filepath.Join(tmpHome, "AppData", "Roaming")
 	t.Setenv("HOME", tmpHome)
+	t.Setenv("AppData", configHome)
+	t.Setenv("APPDATA", configHome)
 	t.Setenv("PINCHTAB_CONFIG", "")
 	t.Setenv("PINCHTAB_TOKEN", "")
 


### PR DESCRIPTION
## What

`TestTheDefaultPathStillSelfProvisionsAndSaysSo` exercises a first run on the **default** config path, so it cannot set `PINCHTAB_CONFIG`. It redirects the default instead, with `t.Setenv("HOME", t.TempDir())`.

That redirects nothing on Windows. `config.userConfigDir` returns `$HOME/.pinchtab` only on darwin and linux; on Windows it falls through to `os.UserConfigDir`, which reads `%AppData%` and never consults `HOME`.

Measured on windows/amd64 rather than assumed:

```
HOME only      -> C:\Users\<user>\AppData\Roaming\pinchtab\config.json
HOME + APPDATA -> <TempDir>\pinchtab\config.json
```

## The failure is the mild outcome

The test ran against the developer's real config. On my machine that config already had a token, so `ensureMandatoryToken` had nothing to provision and printed nothing — and the test failed on an empty stderr, reporting a silent credential write that had not happened, because no write happened at all.

**On a machine with no config yet, the same test takes the branch it is written for and creates one** — a generated `server.token` written into `%AppData%`, outside the test's `TempDir`, as a side effect of `go test ./...`.

A test suite should not provision credentials into the developer's real profile.

## Fix

`internal/config/config_utils_test.go` already isolates correctly, setting `HOME` alongside **both** spellings of the AppData variable — both, because `os.Getenv` is case-sensitive even where Windows itself is not. This adopts that existing pattern rather than inventing a second one.

## Verification

`go test ./cmd/pinchtab/` on windows/amd64 now leaves only `TestPrintDaemonOverviewIncludesStatusAndHints` failing, which is a separate Windows assumption already addressed by #586. `go vet` clean for linux and darwin.

## Worth an audit, deliberately not widened here

Ten other `t.Setenv("HOME", ...)` isolation sites remain, across seven files:

```
cmd/pinchtab/cmd_daemon_test.go
cmd/pinchtab/server_log_location_test.go
internal/bridge/runtime/init_target_test.go
internal/browsers/cloak/doctor_test.go
internal/cli/report/security_test.go
internal/config/config_utils_test.go   (already isolates correctly)
internal/doctor/checks_system_test.go
```

Not all resolve through `userConfigDir`, so not all escape — several target `~/.cloakbrowser` discovery, which has no Windows layout anyway. I have not swept them here because `cmd_daemon_test.go` is already touched by #586 and I would rather not create a conflict over it. Happy to follow up with the audit as a separate PR if you want it.

## Definition of Done
- [x] Tests passing
- [x] No production behaviour changed
- [x] No redundant comments
- [ ] README/docs updated — test-only change
- [ ] npm install works — npm wrapper untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)
