### PR TITLE
test: three Windows expectations that asserted the platform, not the behaviour

### DIFF
--- a/internal/bridge/runtime/exesuffix_test.go
+++ b/internal/bridge/runtime/exesuffix_test.go
@@ -1,0 +1,13 @@
+package runtime
+
+import "runtime"
+
+// exeSuffix is what this platform requires on the end of an executable's name.
+// Windows decides executability by extension, so a stub without one is not a
+// browser as far as discovery is concerned.
+var exeSuffix = func() string {
+	if runtime.GOOS == "windows" {
+		return ".exe"
+	}
+	return ""
+}()

--- a/internal/bridge/runtime/init_target_test.go
+++ b/internal/bridge/runtime/init_target_test.go
@@ -62,7 +62,11 @@ func TestEffectiveLaunchTargetPrefersTargetBinaryOverDiscovery(t *testing.T) {
 func TestEffectiveLaunchTargetFallsBackToDiscoveryWithoutTargets(t *testing.T) {
 	withoutBrowserDiscovery(t)
 	dir := t.TempDir()
-	discovered := filepath.Join(dir, "cloakbrowser")
+	// The stub has to be something the host agrees is executable, or discovery
+	// correctly refuses it and there is nothing left to fall back to. On Windows
+	// that means an extension PATHEXT names: exec.LookPath will not return a bare
+	// "cloakbrowser" there, and the mode bits below carry no meaning.
+	discovered := filepath.Join(dir, "cloakbrowser"+exeSuffix)
 	if err := os.WriteFile(discovered, []byte("#!/bin/sh\n"), 0o755); err != nil {
 		t.Fatalf("WriteFile() error = %v", err)
 	}

--- a/internal/config/config_load_test.go
+++ b/internal/config/config_load_test.go
@@ -793,15 +793,20 @@ func TestApplyFileConfigToRuntime_CloakBrowserSettings(t *testing.T) {
 	if cfg.BrowserBinary != "/opt/cloakbrowser/chrome" {
 		t.Fatalf("BrowserBinary = %q, want configured binary", cfg.BrowserBinary)
 	}
+	// The loader stores fontsDir cleaned, and filepath.Clean is separator-aware:
+	// "/opt/fonts" comes back as `\opt\fonts` on Windows. Comparing against the
+	// literal asserted the separator of whoever ran the test rather than the
+	// behaviour, so it failed there while the loader was doing exactly its job.
+	wantFontsDir := filepath.Clean("/opt/fonts")
 	if cfg.Cloak.FingerprintSeed != "42069" ||
 		cfg.Cloak.Platform != "windows" ||
 		cfg.Cloak.Locale != "en-GB" ||
 		cfg.Cloak.Timezone != "Europe/London" ||
 		cfg.Cloak.WebRTCIP != "auto" ||
-		cfg.Cloak.FontsDir != "/opt/fonts" ||
+		cfg.Cloak.FontsDir != wantFontsDir ||
 		cfg.Cloak.StorageQuotaMB != quota ||
 		cfg.Cloak.DisableDefaultStealthArgs {
-		t.Fatalf("Cloak settings not applied: %+v", cfg.Cloak)
+		t.Fatalf("Cloak settings not applied: %+v (wanted fontsDir %q)", cfg.Cloak, wantFontsDir)
 	}
 
 	defaultCfg := &RuntimeConfig{}

--- a/internal/testbrowser/profile_test.go
+++ b/internal/testbrowser/profile_test.go
@@ -13,10 +13,11 @@ import (
 
 // The property the fix delivers, proven deterministically rather than sampled by
 // re-running a suite: a browser profile whose removal FAILS must not fail the test.
-// The subtest's own recorder stands in for a real Chrome still flushing its cache —
-// on this platform a directory is unremovable while it is a mount point or read-only
-// parent, so the honest simulation is to fail the removal by making the PARENT
-// unwritable, which is exactly the class of error RemoveAll reports mid-flush.
+// The subtest's own recorder stands in for a real Chrome still flushing its cache.
+//
+// How a removal is made to fail is per-platform, so makeRemovalFail owns it: unix
+// clears the parent's write bit, Windows holds a handle open inside the profile.
+// Both produce the class of error RemoveAll reports mid-flush.
 func TestProfileDirCleanupToleratesAFailedRemoval(t *testing.T) {
 	parent := t.TempDir()
 	dir := filepath.Join(parent, "profile")
@@ -26,10 +27,7 @@ func TestProfileDirCleanupToleratesAFailedRemoval(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "Default", "Cache", "Cache_Data", "index"), []byte("x"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Chmod(parent, 0o500); err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = os.Chmod(parent, 0o700) })
+	makeRemovalFail(t, parent, dir)
 
 	recorder := &cleanupRecorder{TB: t}
 	removeProfileDir(recorder, dir)

--- a/internal/testbrowser/removal_fail_other_test.go
+++ b/internal/testbrowser/removal_fail_other_test.go
@@ -1,0 +1,21 @@
+//go:build !windows
+
+package testbrowser
+
+import (
+	"os"
+	"testing"
+)
+
+// makeRemovalFail arranges for os.RemoveAll(dir) to fail, standing in for a
+// browser still writing into its profile.
+//
+// On unix it is the parent's write bit that governs whether an entry can be
+// unlinked, so clearing it is enough and the directory below is untouched.
+func makeRemovalFail(t *testing.T, parent, _ string) {
+	t.Helper()
+	if err := os.Chmod(parent, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(parent, 0o700) })
+}

--- a/internal/testbrowser/removal_fail_windows_test.go
+++ b/internal/testbrowser/removal_fail_windows_test.go
@@ -1,0 +1,32 @@
+//go:build windows
+
+package testbrowser
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// makeRemovalFail arranges for os.RemoveAll(dir) to fail, standing in for a
+// browser still writing into its profile.
+//
+// The unix approach — clearing the parent's write bit — arranges nothing here.
+// os.Chmod on Windows only toggles the read-only attribute, and RemoveAll
+// clears that on its way through, so the directory came away cleanly and the
+// test found itself asserting against a successful removal: it reported that
+// "the unremovable dir vanished", which was exactly right.
+//
+// What Windows does enforce is sharing. A file held open cannot be unlinked,
+// and its directory cannot be removed while it is there, which surfaces as
+// "The process cannot access the file because it is being used by another
+// process." That is also the closer analogue of the case this guards — a real
+// Chrome still flushing its cache is holding handles, not permissions.
+func makeRemovalFail(t *testing.T, _, dir string) {
+	t.Helper()
+	held, err := os.Open(filepath.Join(dir, "Default", "Cache", "Cache_Data", "index"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = held.Close() })
+}


### PR DESCRIPTION
## What

Three independent test-only fixes, each a case where the assertion encoded the host platform rather than the property under test. No production code changes.

### 1. `internal/testbrowser` — the failed removal never failed

`TestProfileDirCleanupToleratesAFailedRemoval` needs `os.RemoveAll` to fail, so it can check that a failed profile cleanup is *logged* rather than failing the test. It arranged that by clearing the parent directory's write bit.

That arranges nothing on Windows. `os.Chmod` there only toggles the read-only attribute, and `RemoveAll` clears it on the way through — so the directory came away cleanly and the test found itself asserting against a **successful** removal. It said so accurately:

```
the unremovable dir vanished, so this test did not exercise a failed removal
```

Which is the right complaint about the wrong thing: the simulation was broken, not the code under test.

`makeRemovalFail` now owns this per-platform. Unix keeps the parent write bit. Windows holds a handle open inside the profile, because sharing is what Windows enforces — a file held open cannot be unlinked, surfacing as *"The process cannot access the file because it is being used by another process."*

That is also the closer analogue of what the test guards. The thing that makes a real profile removal fail is a Chrome still flushing its cache, and it is holding handles, not permissions.

### 2. `internal/bridge/runtime` — a stub Windows cannot execute

`TestEffectiveLaunchTargetFallsBackToDiscoveryWithoutTargets` writes a stub named `cloakbrowser` onto `PATH` and expects discovery to find it. On Windows nothing can: executability is decided by extension, `exec.LookPath` will not return a bare `cloakbrowser`, and the `0o755` it is written with carries no meaning. Discovery correctly found nothing, and the test read that as a failed fallback.

The stub now carries the host's executable suffix. The assertion is unchanged — the fallback still has to return exactly the file that was planted.

### 3. `internal/config` — comparing a path against a separator

The loader stores `cloak.fontsDir` through `filepath.Clean`, which is separator-aware: `/opt/fonts` comes back as `\opt\fonts` on Windows. The test compared against the literal, so it asserted the separator of whoever ran it rather than the behaviour, and failed on Windows while the loader was doing exactly its job.

It now compares against `filepath.Clean` of the same input — the property the loader actually promises — and reports the expected value on failure.

## Verification

All three packages green on windows/amd64 where each had been failing. `go vet` clean for linux and darwin.

`internal/config` retains one unrelated failure, `TestReaderDecodesAFileConfigShadowSoTheWalkChecksTheRightKeys`, which searches source for `"\n}\n"` and cannot match under CRLF. That is fixed by #665 and passes in a clean LF clone.

## Scope

No overlap with #586 — it touches none of these three files.

## Definition of Done
- [x] Tests passing
- [x] No production behaviour changed
- [x] Commits atomic — one per package
- [x] No redundant comments
- [ ] README/docs updated — test-only change
- [ ] npm install works — npm wrapper untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)
