### PR TITLE
test(report): stop the security-defaults test rewriting the real config

### DIFF
--- a/internal/cli/report/security_test.go
+++ b/internal/cli/report/security_test.go
@@ -375,6 +375,22 @@ func TestRestoreSecurityDefaults_RefusesToProvisionIntoAnOperatorConfig(t *testi
 	}
 }
 
+func pathWithinDir(dir, path string) bool {
+	rel, err := filepath.Rel(dir, path)
+	return err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && !filepath.IsAbs(rel)
+}
+
+func TestPathWithinDirRejectsSiblingWithSharedPrefix(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "config")
+
+	if !pathWithinDir(dir, filepath.Join(dir, "config.json")) {
+		t.Fatal("path inside directory was rejected")
+	}
+	if pathWithinDir(dir, filepath.Join(dir+"-escaped", "config.json")) {
+		t.Fatal("sibling path sharing directory prefix was accepted")
+	}
+}
+
 func TestRestoreSecurityDefaults_TokenOnlyChangeOnTheDefaultPathIsSaved(t *testing.T) {
 	tmpHome := t.TempDir()
 	// This test clears PINCHTAB_CONFIG on purpose, so restoreSecurityDefaults
@@ -397,7 +413,7 @@ func TestRestoreSecurityDefaults_TokenOnlyChangeOnTheDefaultPathIsSaved(t *testi
 	// rewrites what it finds there. Fail loudly rather than proceed: before this
 	// guard the escape was silent and the test still PASSED, because the token it
 	// asserts on was already present in the file it should never have opened.
-	if !strings.HasPrefix(configPath, tmpHome) {
+	if !pathWithinDir(tmpHome, configPath) {
 		t.Fatalf("default config path %q escaped the test's temp dir %q; this test would be rewriting the real config", configPath, tmpHome)
 	}
 	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {

--- a/internal/cli/report/security_test.go
+++ b/internal/cli/report/security_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/pinchtab/pinchtab/internal/config"
@@ -376,9 +377,29 @@ func TestRestoreSecurityDefaults_RefusesToProvisionIntoAnOperatorConfig(t *testi
 
 func TestRestoreSecurityDefaults_TokenOnlyChangeOnTheDefaultPathIsSaved(t *testing.T) {
 	tmpHome := t.TempDir()
+	// This test clears PINCHTAB_CONFIG on purpose, so restoreSecurityDefaults
+	// resolves the real default path. Redirecting that default therefore has to
+	// work on every platform: HOME only moves it on darwin and linux, because
+	// config.userConfigDir falls through to os.UserConfigDir elsewhere, which
+	// reads %AppData% and never consults HOME. Both spellings are set because
+	// os.Getenv is case-sensitive even where Windows is not.
+	configHome := filepath.Join(tmpHome, "AppData", "Roaming")
 	t.Setenv("HOME", tmpHome)
+	t.Setenv("AppData", configHome)
+	t.Setenv("APPDATA", configHome)
 	t.Setenv("PINCHTAB_CONFIG", "")
-	configPath := filepath.Join(tmpHome, ".pinchtab", "config.json")
+
+	// Ask for the default path rather than assuming its shape. The hardcoded
+	// unix layout was the defect: on Windows the fixture landed in
+	// tmpHome\.pinchtab while restoreSecurityDefaults edited %AppData%.
+	configPath := config.DefaultConfigPath()
+	// A default that escaped tmpHome is the operator's own config, and this test
+	// rewrites what it finds there. Fail loudly rather than proceed: before this
+	// guard the escape was silent and the test still PASSED, because the token it
+	// asserts on was already present in the file it should never have opened.
+	if !strings.HasPrefix(configPath, tmpHome) {
+		t.Fatalf("default config path %q escaped the test's temp dir %q; this test would be rewriting the real config", configPath, tmpHome)
+	}
 	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## What

`TestRestoreSecurityDefaults_TokenOnlyChangeOnTheDefaultPathIsSaved` clears `PINCHTAB_CONFIG` deliberately, because the behaviour it covers is what happens on the **default** config path. It then redirected that default with `HOME`, and wrote its fixture to a hardcoded `filepath.Join(tmpHome, ".pinchtab", "config.json")`.

Both of those are unix-shaped. `config.userConfigDir` returns `$HOME/.pinchtab` only on darwin and linux; elsewhere it falls through to `os.UserConfigDir`, which reads `%AppData%` and never consults `HOME`.

So on Windows the fixture went to one place and `restoreSecurityDefaults` went to another — the developer's own `%AppData%\pinchtab\config.json`.

## It did not fail. That is the problem.

It restored security defaults into that file, saved it, then asserted a token was present — which it was — and **passed**.

Measured on windows/amd64 by pointing `%AppData%` at a scratch directory holding an operator config, then running `go test ./internal/cli/report/`:

| setting | before | after |
|---|---|---|
| `allowEvaluate` | `true` | `false` |
| `allowedDomains` | `["my-private-host.internal"]` | `["127.0.0.1","localhost","::1"]` |

Running the project's own test suite reset a real allowlist, silently, with a green result. The failing-assertion case in #667 was the same root cause but the mild version of it — that one at least told you something was wrong.

## Fix

The default is redirected on every platform, with both spellings of the AppData variable set because `os.Getenv` is case-sensitive where Windows is not, and the path now comes from `config.DefaultConfigPath()` rather than an assumed layout.

**The guard is the durable half.** A default that resolves outside the test's `TempDir` means this test is about to rewrite the operator's file, so it now fails saying exactly that:

```
default config path "C:\...\002\AppData\Roaming\pinchtab\config.json" escaped the
test's temp dir "C:\...\001"; this test would be rewriting the real config
```

Verified by reintroducing the escape — the test fails with the path it escaped to, where before it passed in silence.

## Scope

Same class as #667, found by auditing the remaining `t.Setenv("HOME", ...)` sites as I offered there. The rest of those resolve through `os.UserHomeDir` for cloak discovery, which has no Windows install layout, so they do not escape. `internal/cli/report` and `cmd/pinchtab` were the only two packages clearing `PINCHTAB_CONFIG` to drive the default path.

No production code changes. `go test ./internal/cli/report/` green on windows/amd64; `go vet` clean for linux and darwin.

## Definition of Done
- [x] Tests passing
- [x] No production behaviour changed
- [x] No redundant comments
- [ ] README/docs updated — test-only change
- [ ] npm install works — npm wrapper untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)
